### PR TITLE
Update OVN and OVS packages

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -205,7 +205,24 @@ kolla_build_blocks:
 # Hyphens in the image name must be replaced with underscores. The
 # customization is most commonly packages. The operation should be one of
 # override, append or remove. The value should be a list.
-#kolla_build_customizations:
+kolla_build_customizations:
+  ovn_base_packages_override:
+    - ovn-2021-21.06.0
+  ovn_controller_packages_override:
+    - ovn-2021-host-21.06.0
+  ovn_nb_db_server_packages_override:
+    - ovn-2021-central-21.06.0
+  ovn_northd_packages_override:
+    - ovn-2021-central-21.06.0
+  ovn_sb_db_server_packages_override:
+    - ovn-2021-central-21.06.0
+  openvswitch_base_packages_override:
+    - libibverbs
+    - openvswitch2.16
+    - openvswitch-selinux-extra-policy
+    - python3-netifaces
+    - python3-openvswitch2.16
+    - tcpdump
 
 ###############################################################################
 # Kolla-ansible inventory configuration.


### PR DESCRIPTION
overridden OVS and OVN packages to:

OVN 21.06 - https://www.ovn.org/en/releases/release_21.06.0/
OVS 2.16 - https://www.openvswitch.org/releases/NEWS-2.16.0.txt