### PR TITLE
Bump stackhpc.pulp collection to 0.3.0

### DIFF
--- a/etc/kayobe/ansible/requirements.yml
+++ b/etc/kayobe/ansible/requirements.yml
@@ -1,5 +1,5 @@
 collections:
   - name: stackhpc.pulp
-    version: 0.2.0
+    version: 0.3.0
   - name: pulp.squeezer
     version: 0.0.11


### PR DESCRIPTION
This release fixes an issue with distribution promotion.