### PR TITLE
Update manila images

### DIFF
--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -1,3 +1,5 @@
 ---
 docker_yum_baseurl: "{{ stackhpc_repo_docker_url }}"
 docker_yum_gpgkey: "https://download.docker.com/linux/{% raw %}{{ ansible_distribution | lower }}{% endraw %}/gpg"
+
+manila_tag: wallaby-20211210T140839


### PR DESCRIPTION
New images include Ceph Pacific client libraries, fixing an issue with CephFS.

See https://github.com/stackhpc/kolla/pull/88.