### PR TITLE
Disable EPEL by default, get GPG key via URL

### DIFF
--- a/etc/kayobe/dnf.yml
+++ b/etc/kayobe/dnf.yml
@@ -57,15 +57,23 @@ dnf_custom_repos:
   epel:
     baseurl: "{{ stackhpc_repo_epel_url }}"
     description: "Extra Packages for Enterprise Linux $releasever - $basearch"
+    enabled: "{{ dnf_enable_epel | bool }}"
     file: epel
-    gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-8
+    gpgkey: "{{ dnf_epel_gpg_key_url }}"
     gpgcheck: yes
   epel-modular:
     baseurl: "{{ stackhpc_repo_epel_modular_url }}"
     description: "Extra Packages for Enterprise Linux Modular $releasever - $basearch"
+    enabled: "{{ dnf_enable_epel | bool }}"
     file: epel-modular
-    gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-8
+    gpgkey: "{{ dnf_epel_gpg_key_url }}"
     gpgcheck: yes
+
+# Whether to enable EPEL repositories. This affects RedHat-based systems only.
+dnf_enable_epel: "{{ dnf_install_epel | bool }}"
+
+# URL of EPEL GPG key.
+dnf_epel_gpg_key_url: "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8"
 
 # Whether to install the epel-release package. This affects RedHat-based
 # systems only. Default value is 'true'.


### PR DESCRIPTION
If an existing system has not been deployed with EPEL repositories, then
the EPEL GPG key will not be present on the system.  Enabling EPEL
repositories using a file-based GPG key would then fail, and break
subsequent DNF commands. Specify the EPEL GPG key via URL to avoid this
issue when EPEL is enabled. Allow the URL to be configured via
dnf_epel_gpg_key_url for air-gapped environments.

EPEL is no longer required for a default installation. Let's stop
installing epel-release by default by setting dnf_install_epel to false.

Also, add a new dnf_enable_epel variable that defaults to the value of
dnf_install_epel, and determines whether EPEL repositories will be
enabled on hosts.