### PR TITLE
Use ansible_facts to reference distribution fact in globals.yml

### DIFF
--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -1,6 +1,6 @@
 ---
 docker_yum_baseurl: "{{ stackhpc_repo_docker_url }}"
-docker_yum_gpgkey: "https://download.docker.com/linux/{% raw %}{{ ansible_distribution | lower }}{% endraw %}/gpg"
+docker_yum_gpgkey: "https://download.docker.com/linux/{% raw %}{{ ansible_facts.distribution | lower }}{% endraw %}/gpg"
 
 manila_tag: wallaby-20211210T140839
 neutron_tag: wallaby-20220104T102739


### PR DESCRIPTION
Using ansible_facts allows us to disable fact variable injection, which
can have a performance benefit for Ansible at scale.