### PR TITLE
Fix typo in container name

### DIFF
--- a/etc/kayobe/pulp.yml
+++ b/etc/kayobe/pulp.yml
@@ -267,7 +267,7 @@ stackhpc_pulp_images:
   - prometheus-cadvisor
   - prometheus-elasticsearch-exporter
   - prometheus-haproxy-exporter
-  - prometheus-jiraalert
+  - prometheus-jiralert
   # FIXME: Not built.
   # - prometheus-libvirt-exporter
   - prometheus-memcached-exporter


### PR DESCRIPTION
See: https://github.com/stackhpc/kolla/blob/1f737a1f2c51cc78dce35bbf6c9b90037b015253/docker/prometheus/prometheus-jiralert/Dockerfile.j2

Apologies: This has always been jira alert in my head!