### PR TITLE
Bump neutron server and metadata agent versions

### DIFF
--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -8,6 +8,7 @@ horizon_tag: wallaby-20220119T122428
 manila_tag: wallaby-20211210T140839
 neutron_tag: wallaby-20220104T102739
 neutron_server_tag: wallaby-20220211T160636
+neutron_ovn_metadata_agent_tag: wallaby-20220211T160636
 neutron_metadata_agent_tag: wallaby-20220211T160636
 neutron_sriov_agent_tag: wallaby-20220110T113538
 prometheus_jiralert_tag: wallaby-20220119T122428

--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -7,6 +7,8 @@ grafana_tag: wallaby-20220210T160332
 horizon_tag: wallaby-20220119T122428
 manila_tag: wallaby-20211210T140839
 neutron_tag: wallaby-20220104T102739
+neutron_server_tag: wallaby-20220211T160636
+neutron_metadata_agent_tag: wallaby-20220211T160636
 neutron_sriov_agent_tag: wallaby-20220110T113538
 prometheus_jiralert_tag: wallaby-20220119T122428
 prometheus_msteams_tag: wallaby-20220119T122428


### PR DESCRIPTION
Hoping to pull in this commit:

https://github.com/openstack/neutron/commit/7193059143ff5720da8fc466865130d2c0d62c2c

To fix errors with the signature:

```
Maintenance task: Failed to fix deleted resource dbb38cda-6c40-4c32-9e5d-1a02ec03009a (type: subnets): KeyError: 'uuid'
2022-02-09 17:46:55.961 49 ERROR neutron.plugins.ml2.drivers.ovn.mech_driver.ovsdb.maintenance Traceback (most recent call last):
2022-02-09 17:46:55.961 49 ERROR neutron.plugins.ml2.drivers.ovn.mech_driver.ovsdb.maintenance File "/var/lib/kolla/venv/lib/python3.6/site-packages/neutron/plugins/ml2/drivers/ovn/mech_driver/ovsdb/maintenance.py", line 386, in check_for_inconsistencies
2022-02-09 17:46:55.961 49 ERROR neutron.plugins.ml2.drivers.ovn.mech_driver.ovsdb.maintenance row.resource_uuid)
2022-02-09 17:46:55.961 49 ERROR neutron.plugins.ml2.drivers.ovn.mech_driver.ovsdb.maintenance File "/var/lib/kolla/venv/lib/python3.6/site-packages/neutron/plugins/ml2/drivers/ovn/mech_driver/ovsdb/ovn_client.py", line 2024, in delete_subnet
2022-02-09 17:46:55.961 49 ERROR neutron.plugins.ml2.drivers.ovn.mech_driver.ovsdb.maintenance self._remove_subnet_dhcp_options(subnet_id, txn)
2022-02-09 17:46:55.961 49 ERROR neutron.plugins.ml2.drivers.ovn.mech_driver.ovsdb.maintenance File "/var/lib/kolla/venv/lib/python3.6/site-packages/neutron/plugins/ml2/drivers/ovn/mech_driver/ovsdb/ovn_client.py", line 1892, in _remove_subnet_dhcp_options
2022-02-09 17:46:55.961 49 ERROR neutron.plugins.ml2.drivers.ovn.mech_driver.ovsdb.maintenance dhcp_options['subnet']['uuid']))
2022-02-09 17:46:55.961 49 ERROR neutron.plugins.ml2.drivers.ovn.mech_driver.ovsdb.maintenance KeyError: 'uuid'
2022-02-09 17:46:55.961 49 ERROR neutron.plugins.ml2.drivers.ovn.mech_driver.ovsdb.maintenance
```