### PR TITLE
Fix configuration dump

### DIFF
--- a/etc/kayobe/pulp.yml
+++ b/etc/kayobe/pulp.yml
@@ -22,8 +22,8 @@ stackhpc_release_pulp_password:
 
 # Client certificates used to access StackHPC Ark repositories.
 # They are trusted by the 'release' cert guard's CA.
-stackhpc_release_pulp_client_cert: "{{ lookup('file', 'certs/ark.stackhpc.com/client-cert.pem') | trim }}"
-stackhpc_release_pulp_client_key: "{{ lookup('file', 'certs/ark.stackhpc.com/client-key.pem') | trim }}"
+stackhpc_release_pulp_client_cert: "{{ lookup('file', kayobe_config_path ~ '/ansible/certs/ark.stackhpc.com/client-cert.pem') | trim }}"
+stackhpc_release_pulp_client_key: "{{ lookup('file', kayobe_config_path ~ '/ansible/certs/ark.stackhpc.com/client-key.pem') | trim }}"
 
 
 ###############################################################################


### PR DESCRIPTION
Currently, a kayobe configuration dump fails:

    $ kayobe configuration dump --var-name stackhpc_pulp_repository_rpm_repos --limit localhost
    [WARNING]: Unable to find 'certs/ark.stackhpc.com/client-cert.pem' in expected paths (use -vvvvv to see paths)
    could not locate file in lookup: certs/ark.stackhpc.com/client-cert.pem

This change fixes the issue by using an absolute path to the certificate
files.

Fixes: #35