### PR TITLE
ovs: Bump up python ovs bindings to OVS pkg version

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -211,7 +211,7 @@ kolla_build_blocks:
   prometheus_blackbox_exporter_repository_version: |
     ARG blackbox_exporter_version='0.19.0'
   openstack_base_footer: |
-    RUN sed -i s/^ovs===2.13.0/^ovs===2.16.0/ /requirements/upper-constraints.txt
+    RUN sed -i s/^ovs===2.13.0/ovs===2.16.0/ /requirements/upper-constraints.txt
 
 # Dict mapping image customization variable names to their values.
 # Each variable takes the form:

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -210,12 +210,8 @@ kolla_build_blocks:
     ARG mysqld_exporter_version='0.13.0'
   prometheus_blackbox_exporter_repository_version: |
     ARG blackbox_exporter_version='0.19.0'
-  neutron_base_footer:
-    RUN pip3 install -U ovs==2.16.*
-  nova_base_footer:
-    RUN pip3 install -U ovs==2.16.*
-  octavia_base_footer:
-    RUN pip3 install -U ovs==2.16.*
+  openstack_base_footer: |
+    RUN sed -i s/^ovs===2.13.0/^ovs===2.16.0/ /requirements/upper-constraints.txt
 
 # Dict mapping image customization variable names to their values.
 # Each variable takes the form:

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -210,6 +210,12 @@ kolla_build_blocks:
     ARG mysqld_exporter_version='0.13.0'
   prometheus_blackbox_exporter_repository_version: |
     ARG blackbox_exporter_version='0.19.0'
+  neutron_base_footer:
+    RUN pip3 install -U ovs==2.16.*
+  nova_base_footer:
+    RUN pip3 install -U ovs==2.16.*
+  octavia_base_footer:
+    RUN pip3 install -U ovs==2.16.*
 
 # Dict mapping image customization variable names to their values.
 # Each variable takes the form:

--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -7,11 +7,9 @@ grafana_tag: wallaby-20220210T160332
 horizon_tag: wallaby-20220119T122428
 magnum_tag: wallaby-20220223T104005
 manila_tag: wallaby-20211210T140839
-neutron_tag: wallaby-20220104T102739
-neutron_server_tag: wallaby-20220211T160636
-neutron_ovn_metadata_agent_tag: wallaby-20220211T160636
-neutron_metadata_agent_tag: wallaby-20220211T160636
-neutron_sriov_agent_tag: wallaby-20220110T113538
+neutron_tag: wallaby-20220224T120546
+nova_tag: wallaby-20220224T120546
+octavia_tag: wallaby-20220224T120546
 ovn_tag: wallaby-20220223T143249
 openvswitch_tag: wallaby-20220223T143249
 prometheus_jiralert_tag: wallaby-20220119T122428


### PR DESCRIPTION
Due to https://bugs.launchpad.net/neutron/+bug/1949059
New tag: wallaby-20220224T120546