### PR TITLE
Add tag for ironic neutron agent

### DIFF
--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -9,6 +9,7 @@ ironic_pxe_tag: wallaby-20220216T152518
 magnum_tag: wallaby-20220223T104005
 manila_tag: wallaby-20211210T140839
 neutron_tag: wallaby-20220224T120546
+ironic_neutron_agent_tag: wallaby-20220104T102739
 nova_tag: wallaby-20220224T120546
 octavia_tag: wallaby-20220224T120546
 ovn_tag: wallaby-20220223T143249


### PR DESCRIPTION
This container is deployed by the neutron role in kolla-ansible:

https://github.com/openstack/kolla-ansible/blob/b668e27356adcd9824a67703d4d96b1a229d9a3c/ansible/roles/neutron/defaults/main.yml#L269

We do not have a version with the current neutron tag in ark.stackhpc.com.