### PR TITLE
Compute maintenance playbooks

### DIFF
--- a/etc/kayobe/ansible/nova-compute-disable.yml
+++ b/etc/kayobe/ansible/nova-compute-disable.yml
@@ -1,0 +1,47 @@
+---
+- name: Disable nova compute service
+  hosts: compute
+  gather_facts: yes
+  tags:
+    - nova-compute-disable
+  vars:
+    venv: "{{ virtualenv_path }}/openstack"
+    disabled_reason: "Down for maintenance by nova-compute-disable.yml"
+  tasks:
+    - name: Set up openstack cli virtualenv
+      pip:
+        virtualenv: "{{ venv }}"
+        name:
+          - python-openstackclient
+        state: latest
+        extra_args: "{% if pip_upper_constraints_file %}-c {{ pip_upper_constraints_file }}{% endif %}"
+      run_once: true
+      delegate_to: "{{ groups['controllers'][0] }}"
+      vars:
+        ansible_host: "{{ hostvars[groups['controllers'][0]].ansible_host }}"
+
+    - name: Query nova compute services
+      command: >
+        {{ venv }}/bin/openstack
+        compute service list
+        --format json
+        --service nova-compute --host {{ ansible_facts.nodename }}
+      environment: "{{ openstack_auth_env }}"
+      delegate_to: "{{ groups['controllers'][0] }}"
+      register: compute_services
+      vars:
+        ansible_host: "{{ hostvars[groups['controllers'][0]].ansible_host }}"
+
+    - name: Disable nova compute service
+      command: >
+        {{ venv }}/bin/openstack
+        compute service set
+        {{ ansible_facts.nodename }} nova-compute
+        --disable --disable-reason '{{ disabled_reason }}'
+      environment: "{{ openstack_auth_env }}"
+      delegate_to: "{{ groups['controllers'][0] }}"
+      vars:
+        service: "{{ compute_services.stdout | from_json | first }}"
+        ansible_host: "{{ hostvars[groups['controllers'][0]].ansible_host }}"
+      when:
+        - service.Status != 'disabled'

--- a/etc/kayobe/ansible/nova-compute-drain.yml
+++ b/etc/kayobe/ansible/nova-compute-drain.yml
@@ -31,6 +31,7 @@
         - name: Live migrate instances
           command: >
             {{ venv }}/bin/openstack
+            --os-compute-api-version 2.25
             server migrate
             {{ instance_uuid }}
             --live-migration

--- a/etc/kayobe/ansible/nova-compute-drain.yml
+++ b/etc/kayobe/ansible/nova-compute-drain.yml
@@ -1,0 +1,71 @@
+---
+- name: Drain a nova compute host of instances
+  hosts: compute
+  gather_facts: yes
+  tags:
+    - nova-compute-drain
+  vars:
+    venv: "{{ virtualenv_path }}/openstack"
+    live_migration_fatal: true
+  tasks:
+    - name: Set up openstack cli virtualenv
+      pip:
+        virtualenv: "{{ venv }}"
+        name:
+          - python-openstackclient
+        state: latest
+        extra_args: "{% if pip_upper_constraints_file %}-c {{ pip_upper_constraints_file }}{% endif %}"
+      run_once: true
+      delegate_to: "{{ groups['controllers'][0] }}"
+
+    - block:
+        - name: Query instances
+          command: >
+            {{ venv }}/bin/openstack
+            server list --host {{ ansible_facts.nodename }}
+            --all-projects
+            --status ACTIVE
+            --format json
+          register: instances
+
+        - name: Live migrate instances
+          command: >
+            {{ venv }}/bin/openstack
+            server migrate
+            {{ instance_uuid }}
+            --live-migration
+            --wait
+          loop: "{{ instances.stdout | from_json }}"
+          loop_control:
+            label: "{{ instance_uuid }}"
+          vars:
+            instance_uuid: "{{ item.ID | default }}"
+          register: result
+          failed_when:
+            - live_migration_fatal | bool
+            - result is failed
+
+        - name: Query instances
+          command: >
+            {{ venv }}/bin/openstack
+            server list --host {{ ansible_facts.nodename }}
+            --all-projects
+            --status ACTIVE
+            --format json
+          register: instances
+
+        - name: Fail if there are instances still on the host
+          fail:
+            msg: >
+              Instances still on {{ inventory_hostname }}: {{ instances.stdout | from_json }}
+          when:
+            - live_migration_fatal | bool
+            - instances.stdout | from_json | length > 0
+
+      delegate_to: "{{ groups['controllers'][0] }}"
+      environment: "{{ openstack_auth_env }}"
+      when:
+        - "'compute' in group_names"
+        - groups['compute'] | length > 1
+      vars:
+        ansible_host: "{{ hostvars[groups['controllers'][0]].ansible_host }}"

--- a/etc/kayobe/ansible/nova-compute-enable.yml
+++ b/etc/kayobe/ansible/nova-compute-enable.yml
@@ -1,0 +1,50 @@
+---
+- name: Enable nova compute service
+  hosts: compute
+  gather_facts: yes
+  tags:
+    - nova-compute-enable
+  vars:
+    venv: "{{ virtualenv_path }}/openstack"
+    disabled_reason: "Down for maintenance by nova-compute-disable.yml"
+  tasks:
+    - name: Set up openstack cli virtualenv
+      pip:
+        virtualenv: "{{ venv }}"
+        name:
+          - python-openstackclient
+        state: latest
+        extra_args: "{% if pip_upper_constraints_file %}-c {{ pip_upper_constraints_file }}{% endif %}"
+      run_once: true
+      delegate_to: "{{ groups['controllers'][0] }}"
+      vars:
+        ansible_host: "{{ hostvars[groups['controllers'][0]].ansible_host }}"
+
+    - name: Query nova compute services
+      command: >
+        {{ venv }}/bin/openstack
+        compute service list
+        --format json
+        --service nova-compute --host {{ ansible_facts.nodename }} --long
+      environment: "{{ openstack_auth_env }}"
+      delegate_to: "{{ groups['controllers'][0] }}"
+      register: compute_services
+      vars:
+        ansible_host: "{{ hostvars[groups['controllers'][0]].ansible_host }}"
+
+    - name: Enable nova compute service
+      command: >
+        {{ venv }}/bin/openstack
+        compute service set
+        {{ ansible_facts.nodename }} nova-compute
+        --enable
+      environment: "{{ openstack_auth_env }}"
+      delegate_to: "{{ groups['controllers'][0] }}"
+      vars:
+        service: "{{ compute_services.stdout | from_json | first }}"
+        ansible_host: "{{ hostvars[groups['controllers'][0]].ansible_host }}"
+      when:
+        # Don't enable the compute service if it was not disabled by
+        # nova-compute-disable.yml
+        - service.Status == 'disabled'
+        - service['Disabled Reason'] == disabled_reason

--- a/etc/kayobe/ansible/reboot.yml
+++ b/etc/kayobe/ansible/reboot.yml
@@ -1,6 +1,7 @@
 ---
 - name: Reboot the host
   hosts: seed-hypervisor:seed:overcloud:infra-vms
+  serial: "{{ lookup('env', 'ANSIBLE_SERIAL') | default(0) }}"
   tags:
     - reboot
   tasks:

--- a/etc/kayobe/ansible/reboot.yml
+++ b/etc/kayobe/ansible/reboot.yml
@@ -1,0 +1,9 @@
+---
+- name: Reboot the host
+  hosts: seed-hypervisor:seed:overcloud:infra-vms
+  tags:
+    - reboot
+  tasks:
+    - name: Reboot and wait
+      become: true
+      reboot:


### PR DESCRIPTION
Add playbooks and scripts to aid in performing maintainence on hypervisors
    
These may be used to perform package updates that require a reboot:
    
* disable compute service (nova-compute-disable.yml)
* live migrate VMs away (nova-compute-drain.yml)
* reboot (reboot.yml)
* enable compute service (nova-compute-enable.yml)

They may also be used to drain a compute node before a rebuild:
    
* disable compute service (nova-compute-disable.yml)
* live migrate VMs away (nova-compute-drain.yml)
* stop services (kayobe overcloud service stop)