### PR TITLE
Bump nova images to wallaby-20220328T103755 for libvirt SASL

### DIFF
--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -12,7 +12,7 @@ magnum_tag: wallaby-20220223T104005
 manila_tag: wallaby-20211210T140839
 neutron_tag: wallaby-20220224T120546
 ironic_neutron_agent_tag: wallaby-20220104T102739
-nova_tag: wallaby-20220311T133847
+nova_tag: wallaby-20220328T103755
 octavia_tag: wallaby-20220224T120546
 ovn_tag: wallaby-20220223T143249
 openvswitch_tag: wallaby-20220223T143249


### PR DESCRIPTION
Support for libvirt SASL authentication was backported to kolla-ansible
stackhpc/wallaby branches, and requires new nova-compute and
nova-libvirt images with cyrus-sasl packages.