### PR TITLE
Bump Magnum tag

### DIFF
--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -8,7 +8,7 @@ cloudkitty_tag: wallaby-20220119T122428
 grafana_tag: wallaby-20220210T160332
 horizon_tag: wallaby-20220302T133644
 ironic_pxe_tag: wallaby-20220216T152518
-magnum_tag: wallaby-20220223T104005
+magnum_tag: wallaby-20220414T082242
 manila_tag: wallaby-20211210T140839
 neutron_tag: wallaby-20220224T120546
 ironic_neutron_agent_tag: wallaby-20220104T102739


### PR DESCRIPTION
Bump Magnum tag after merging Cinder CSI fixes for Kubernetes 1.23