### PR TITLE
Wallaby neutron revert

### DIFF
--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -10,7 +10,7 @@ horizon_tag: wallaby-20220302T133644
 ironic_pxe_tag: wallaby-20220216T152518
 magnum_tag: wallaby-20220518T134148
 manila_tag: wallaby-20211210T140839
-neutron_tag: wallaby-20220509T102625
+neutron_tag: wallaby-20220412T124526
 nova_tag: wallaby-20220328T103755
 octavia_tag: wallaby-20220224T120546
 ovn_tag: wallaby-20220223T143249

--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -10,7 +10,7 @@ horizon_tag: wallaby-20220302T133644
 ironic_pxe_tag: wallaby-20220216T152518
 magnum_tag: wallaby-20220518T134148
 manila_tag: wallaby-20211210T140839
-neutron_tag: wallaby-20220519T131115
+neutron_tag: wallaby-20220509T102625
 nova_tag: wallaby-20220328T103755
 octavia_tag: wallaby-20220224T120546
 ovn_tag: wallaby-20220223T143249


### PR DESCRIPTION
Revert May versions of Neutron Wallaby build - neutron-ovn-db-sync-util is broken.