### PR TITLE
Use upstream Horizon

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -112,10 +112,6 @@ kolla_sources:
     type: git
     location: https://github.com/stackhpc/cloudkitty.git
     reference: stackhpc/wallaby
-  horizon:
-    type: git
-    location: https://github.com/stackhpc/horizon.git
-    reference: stackhpc/wallaby
   horizon-plugin-cloudkitty-dashboard:
     type: git
     location: https://github.com/stackhpc/cloudkitty-dashboard.git


### PR DESCRIPTION
The fix for the "Resize instance" button has been merged upstream [1] and also includes an additional cherry-pick to avoid an extra call to flavor_get in the resize server form.

There are also other fixes merged on this upstream branch.

[1] https://review.opendev.org/c/openstack/horizon/+/829663