### PR TITLE
Revert "ovs: Bump up python ovs bindings to OVS pkg version (#45)"

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -218,8 +218,6 @@ kolla_build_blocks:
     ARG mysqld_exporter_version='0.13.0'
   prometheus_blackbox_exporter_repository_version: |
     ARG blackbox_exporter_version='0.19.0'
-  openstack_base_footer: |
-    RUN sed -i s/^ovs===2.13.0/ovs===2.16.0/ /requirements/upper-constraints.txt
 
 # Dict mapping image customization variable names to their values.
 # Each variable takes the form:


### PR DESCRIPTION
This reverts commit 867e3f552e354a019183e1d8ee44471a75616df0.

Revert reason: https://review.opendev.org/c/openstack/kolla/+/831417 has been merged upstream (override no longer required).