### PR TITLE
Bump Horizon tag to wallaby-20220525T174700

### DIFF
--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -6,7 +6,7 @@ barbican_tag: wallaby-20220311T133847
 cinder_tag: wallaby-20220309T083940
 cloudkitty_tag: wallaby-20220119T122428
 grafana_tag: wallaby-20220210T160332
-horizon_tag: wallaby-20220302T133644
+horizon_tag: wallaby-20220525T174700
 ironic_pxe_tag: wallaby-20220216T152518
 magnum_tag: wallaby-20220518T134148
 manila_tag: wallaby-20211210T140839


### PR DESCRIPTION
The Horizon image is now built from upstream stable/wallaby.