### PR TITLE
CI: Prune Kolla container images after build job finishes

### DIFF
--- a/.github/workflows/container-image-build.yml
+++ b/.github/workflows/container-image-build.yml
@@ -135,6 +135,10 @@ jobs:
           retention-days: 7
         if: github.event.input.seed
 
+      - name: Prune local Kolla container images
+        run: |
+          sudo docker image prune --force --filter="label=kolla_version"
+
   sync-container-repositories:
     name: Trigger container image repository sync
     needs:


### PR DESCRIPTION
The GitHub Actions runner can easily fill its disk after a few image
builds. Prune the images at the end of the run. The downside is that we
won't benefit from Docker caching. OTOH, it's non-trivial to prune
images in a way that frees up sufficient space and keeps some images
around.

Prune all Kolla images after each container image build job.
