### PR TITLE
ironic inspector: bump stackhpc-inspector-plugins to 1.3.0

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -120,7 +120,7 @@ kolla_sources:
     # Install our custom inspector plugins.
     type: git
     location: https://github.com/stackhpc/stackhpc-inspector-plugins.git
-    reference: 1.1.2
+    reference: 1.3.0
   magnum-base:
     type: git
     location: https://github.com/stackhpc/magnum.git

--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -7,6 +7,7 @@ cinder_tag: wallaby-20220309T083940
 cloudkitty_tag: wallaby-20220119T122428
 grafana_tag: wallaby-20220210T160332
 horizon_tag: wallaby-20220525T174700
+ironic_inspector_tag: wallaby-20220606T093448
 ironic_pxe_tag: wallaby-20220216T152518
 magnum_tag: wallaby-20220603T085526
 manila_tag: wallaby-20211210T140839


### PR DESCRIPTION
Fixes an issue with system_name_physnet and ib_physnet plugins.