### PR TITLE
Update neutron containers to wallaby-20220610T145122

### DIFF
--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -8,10 +8,11 @@ cloudkitty_tag: wallaby-20220119T122428
 grafana_tag: wallaby-20220210T160332
 horizon_tag: wallaby-20220525T174700
 ironic_inspector_tag: wallaby-20220606T093448
+ironic_neutron_agent_tag: wallaby-20220412T124526
 ironic_pxe_tag: wallaby-20220216T152518
 magnum_tag: wallaby-20220603T085526
 manila_tag: wallaby-20211210T140839
-neutron_tag: wallaby-20220412T124526
+neutron_tag: wallaby-20220610T145122
 nova_tag: wallaby-20220328T103755
 octavia_tag: wallaby-20220524T085900
 ovn_tag: wallaby-20220223T143249


### PR DESCRIPTION
This includes an updated networking-generic-switch plugin, with support
for port groups on Cumulus devices.