### PR TITLE
ovn: bump to 21.12

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -229,15 +229,15 @@ kolla_build_customizations:
   ironic_inspector_pip_packages_append:
     - /additions/*
   ovn_base_packages_override:
-    - ovn-2021-21.06.0
+    - ovn-2021-21.12.0
   ovn_controller_packages_override:
-    - ovn-2021-host-21.06.0
+    - ovn-2021-host-21.12.0
   ovn_nb_db_server_packages_override:
-    - ovn-2021-central-21.06.0
+    - ovn-2021-central-21.12.0
   ovn_northd_packages_override:
-    - ovn-2021-central-21.06.0
+    - ovn-2021-central-21.12.0
   ovn_sb_db_server_packages_override:
-    - ovn-2021-central-21.06.0
+    - ovn-2021-central-21.12.0
   openvswitch_base_packages_override:
     - libibverbs
     - openvswitch2.16


### PR DESCRIPTION
After [1] all previous versions of OVN got removed from CentOS SPEC,
therefore no new 21.06 versions will be published - let's switch
to 21.12.

[1]: https://git.centos.org/rpms/ovn/c/5c758677050699dba0e4ba0821c860389dc5ebc4?branch=c8-sig-nfv-ovn-2021