### PR TITLE
Update openstack-exporter to wallaby-20220705T132206

### DIFF
--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -21,4 +21,4 @@ prometheus_tag: wallaby-20220525T174700
 prometheus_jiralert_tag: wallaby-20220119T122428
 prometheus_libvirt_exporter_tag: wallaby-20220325T122042
 prometheus_msteams_tag: wallaby-20220119T122428
-prometheus_openstack_exporter_tag: wallaby-20220119T122428
+prometheus_openstack_exporter_tag: wallaby-20220705T132206


### PR DESCRIPTION
This container image includes openstack-exporter 1.6.0.