### PR TITLE
Switch to downstream fork of sahara-dashboard

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -122,6 +122,10 @@ kolla_sources:
     type: git
     location: https://github.com/stackhpc/cloudkitty-dashboard.git
     reference: stackhpc/wallaby
+  horizon-plugin-sahara-dashboard:
+    type: git
+    location: https://github.com/stackhpc/sahara-dashboard.git
+    reference: stackhpc/wallaby
   ironic-inspector-additions-stackhpc-inspector-plugins:
     # Install our custom inspector plugins.
     type: git


### PR DESCRIPTION
This fixes accessing Sahara when the public API is not reachable from
the Horizon server, as kolla-ansible uses internalURL as the default
OPENSTACK_ENDPOINT_TYPE.

Depends on https://github.com/stackhpc/sahara-dashboard/pull/1