### PR TITLE
Revert "Remove unsupported variables from overcloud-dib.yml"

### DIFF
--- a/etc/kayobe/overcloud-dib.yml
+++ b/etc/kayobe/overcloud-dib.yml
@@ -10,6 +10,14 @@
 # is {{ os_distribution == 'rocky' }}. This will change in a future release.
 #overcloud_dib_build_host_images:
 
+# List of overcloud host disk images to build. Each element is a dict defining
+# an image in a format accepted by the stackhpc.os-images role. Default is to
+# build an image named "deployment_image" configured with the overcloud_dib_*
+# variables defined below: {"name": "deployment_image", "elements": "{{
+# overcloud_dib_elements }}", "env": "{{ overcloud_dib_env_vars }}",
+# "packages": "{{ overcloud_dib_packages }}"}.
+#overcloud_dib_host_images:
+
 # DIB base OS element. Default is {{ 'rocky-container' if os_distribution ==
 # 'rocky' else os_distribution }}.
 #overcloud_dib_os_element:
@@ -49,6 +57,19 @@
 
 # List of DIB packages to install. Default is to install no extra packages.
 #overcloud_dib_packages:
+
+# List of default git repositories containing Diskimage Builder (DIB) elements.
+# See stackhpc.os-images role for usage. Default is empty.
+#overcloud_dib_git_elements_default:
+
+# List of additional git repositories containing Diskimage Builder (DIB)
+# elements. See stackhpc.os-images role for usage. Default is empty.
+#overcloud_dib_git_elements_extra:
+
+# List of git repositories containing Diskimage Builder (DIB) elements. See
+# stackhpc.os-images role for usage. Default is a combination of
+# overcloud_dib_git_elements_default and overcloud_dib_git_elements_extra.
+#overcloud_dib_git_elements:
 
 # Upper constraints file for installing packages in the virtual environment
 # used for building overcloud host disk images. Default is {{


### PR DESCRIPTION
This reverts commit df1721eb2bfde416fab7f260cc3dfbaa23bc69b9.

The necessary code has been backported to Kayobe in
https://github.com/stackhpc/kayobe/pull/23