### PR TITLE
Remove sahara-dashboard fork from sources

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -122,10 +122,6 @@ kolla_sources:
     type: git
     location: https://github.com/stackhpc/cloudkitty-dashboard.git
     reference: stackhpc/wallaby
-  horizon-plugin-sahara-dashboard:
-    type: git
-    location: https://github.com/stackhpc/sahara-dashboard.git
-    reference: stackhpc/wallaby
   ironic-inspector-additions-stackhpc-inspector-plugins:
     # Install our custom inspector plugins.
     type: git


### PR DESCRIPTION
The fix on stackhpc/wallaby has been merged upstream.