### PR TITLE
fix setting admin password for pulp

### DIFF
--- a/etc/kayobe/containers/pulp/post.yml
+++ b/etc/kayobe/containers/pulp/post.yml
@@ -10,7 +10,7 @@
 - name: Set the Pulp admin password
   become: true
   command: >-
-    docker exec -u root {{ seed_containers.pulp.name }}
+    docker exec -u root pulp
     bash -c
       'pulpcore-manager reset-admin-password -p {{ pulp_password }}'
   no_log: true

--- a/etc/kayobe/seed.yml
+++ b/etc/kayobe/seed.yml
@@ -93,7 +93,6 @@ seed_pulp_container_enabled: true
 
 seed_pulp_container:
   pulp:
-    name: pulp
     image: pulp/pulp
     pre: "{{ kayobe_config_path }}/containers/pulp/pre.yml"
     post: "{{ kayobe_config_path }}/containers/pulp/post.yml"

--- a/etc/kayobe/seed.yml
+++ b/etc/kayobe/seed.yml
@@ -93,6 +93,7 @@ seed_pulp_container_enabled: true
 
 seed_pulp_container:
   pulp:
+    name: pulp
     image: pulp/pulp
     pre: "{{ kayobe_config_path }}/containers/pulp/pre.yml"
     post: "{{ kayobe_config_path }}/containers/pulp/post.yml"


### PR DESCRIPTION
Add name to pulp container to fix setting admin password

this part is checking for name:
https://github.com/stackhpc/stackhpc-kayobe-config/blob/stackhpc/wallaby/etc/kayobe/containers/pulp/post.yml#L13

error log:

`TASK [deploy-containers : Set the Pulp admin password] *********************************************************************************************************************************************************
fatal: [intern-os-seed-vm]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'dict object' has no attribute 'name'\n\nThe error appears to be in '/home/stackhpc/wallaby-upgrade/src/kayobe-config/etc/kayobe/containers/pulp/post.yml': line 10, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Set the Pulp admin password\n  ^ here\n"}`