### PR TITLE
add new skydive tags

### DIFF
--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -27,5 +27,6 @@ prometheus_jiralert_tag: wallaby-20220119T122428
 prometheus_libvirt_exporter_tag: wallaby-20220325T122042
 prometheus_msteams_tag: wallaby-20220119T122428
 prometheus_openstack_exporter_tag: wallaby-20220705T132206
-skydive_tag: wallaby-20220811T091848
+skydive_agent_tag: wallaby-20220817T151053
+skydive_analyzer_tag: wallaby-20220817T151053
 {% endif %}


### PR DESCRIPTION
Skydive has a bug which prevents app from starting (https://review.opendev.org/c/openstack/kolla/+/853245). New build contains downgraded version.