### PR TITLE
Ubuntu: Stop using StackHPC host package repos, start using StackHPC container images (Wallaby)

### DIFF
--- a/etc/kayobe/apt.yml
+++ b/etc/kayobe/apt.yml
@@ -17,21 +17,13 @@
 # * filename: name of a file in /etc/apt/apt.conf.d/ in which to write the
 #   configuration
 # Default is an empty list.
-apt_config:
-  # NOTE: Currently the Pulp verbatim publisher does not sync translation
-  # files, which results in apt update failing. Disable translations until this
-  # is resolved.
-  - content: |
-      Acquire::Languages "none";
-    filename: 99no-languages
+#apt_config:
 
 # List of apt keys. Each item is a dict containing the following keys:
 # * url: URL of key
 # * filename: Name of a file in which to store the downloaded key
 # Default is an empty list.
-apt_keys:
-  - url: "https://download.docker.com/linux/ubuntu/gpg"
-    filename: docker.asc
+#apt_keys:
 
 # A list of Apt repositories.
 # * types: whitespace-separated list of repository types, e.g. deb or deb-src
@@ -46,22 +38,12 @@ apt_keys:
 # * architecture: whitespace-separated list of architectures that will be used
 #   (optional, default is unset)
 # Default is an empty list.
-apt_repositories:
-  - url: "{{ stackhpc_repo_ubuntu_focal_url }}"
-    suites: "{{ ansible_facts.distribution_release }} {{ ansible_facts.distribution_release }}-updates {{ ansible_facts.distribution_release }}-backports"
-    components: main restricted universe multiverse
-  - url: "{{ stackhpc_repo_ubuntu_focal_security_url }}"
-    suites: "{{ ansible_facts.distribution_release }}-security"
-    components: main restricted universe multiverse
-  - url: "{{ stackhpc_repo_docker_ce_ubuntu_url }}"
-    suites: "{{ ansible_facts.distribution_release }}"
-    components: stable
-    signed_by: docker.asc
+#apt_repositories:
 
 # Whether to disable repositories in /etc/apt/sources.list. This may be used
 # when replacing the distribution repositories via apt_repositories.
 # Default is false.
-apt_disable_sources_list: true
+#apt_disable_sources_list:
 
 ###############################################################################
 # Dummy variable to allow Ansible to accept this file.

--- a/etc/kayobe/hooks/seed-container-image-build/post.d/50-write-kolla-tag.yml
+++ b/etc/kayobe/hooks/seed-container-image-build/post.d/50-write-kolla-tag.yml
@@ -1,0 +1,1 @@
+../../../ansible/write-kolla-tag.yml

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -211,13 +211,16 @@ kolla_build_blocks:
                -e 's/^[# ]*\(baseurl *=.*\)/#\1/g' \
                -e '/#baseurl.*/a baseurl={{ repo.url }}' /etc/yum.repos.d/{{ repo.file }}{% if not loop.last %} &&{% endif %} \
     {% endfor %}
-  base_ubuntu_package_sources_list: |
-    RUN \
-        rm -f /etc/apt/sources.list && \
-    {% for repo in stackhpc_ubuntu_focal_repos %}
-        echo '{{ repo }}' >> /etc/apt/sources.list {% if not loop.last %} && \
-    {% endif %}
-    {% endfor %}
+  # NOTE: Not currently syncing Ubuntu packages, since the on_demand mirror in
+  # Ark does not work if the upstream mirror pulls packages (which it does
+  # sometimes).
+  # base_ubuntu_package_sources_list: |
+  #   RUN \
+  #       rm -f /etc/apt/sources.list && \
+  #   {% for repo in stackhpc_ubuntu_focal_repos %}
+  #       echo '{{ repo }}' >> /etc/apt/sources.list {% if not loop.last %} && \
+  #   {% endif %}
+  #   {% endfor %}
   grafana_plugins_install: |
     RUN grafana-cli plugins install vonage-status-panel
   ironic_inspector_header: |

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -91,7 +91,7 @@ kolla_docker_registry_password: "{{ stackhpc_docker_registry_password }}"
 
 # Kolla OpenStack release version. This should be a Docker image tag.
 # Default is {{ openstack_release }}.
-kolla_openstack_release: wallaby-20211207T102718
+kolla_openstack_release: "{% if kolla_base_distro == 'centos' %}wallaby-20211207T102718{% else %}wallaby-20220819T112725{% endif %}"
 
 # Docker tag applied to built container images. Default is
 # {{ kolla_openstack_release }}.

--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -3,7 +3,6 @@
 docker_yum_baseurl: "{{ stackhpc_repo_docker_url }}"
 docker_yum_gpgkey: "https://download.docker.com/linux/{% raw %}{{ ansible_facts.distribution | lower }}{% endraw %}/gpg"
 
-{# We are not currently providing container images for Ubuntu in Wallaby. #}
 {% if kolla_base_distro == 'centos' %}
 barbican_tag: wallaby-20220311T133847
 cinder_tag: wallaby-20220309T083940

--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -25,4 +25,6 @@ prometheus_libvirt_exporter_tag: wallaby-20220325T122042
 prometheus_msteams_tag: wallaby-20220119T122428
 prometheus_openstack_exporter_tag: wallaby-20220705T132206
 skydive_tag: wallaby-20220811T091848
+{% else %}
+bifrost_tag: wallaby-20220819T150635
 {% endif %}

--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -1,7 +1,5 @@
 # yamllint disable-file
 ---
-enable_docker_repo: "{% raw %}{{ ansible_facts.os_family == 'RedHat' }}{% endraw %}"
-
 docker_yum_baseurl: "{{ stackhpc_repo_docker_url }}"
 docker_yum_gpgkey: "https://download.docker.com/linux/{% raw %}{{ ansible_facts.distribution | lower }}{% endraw %}/gpg"
 

--- a/etc/kayobe/pulp.yml
+++ b/etc/kayobe/pulp.yml
@@ -32,7 +32,10 @@ stackhpc_release_pulp_content_url: "{{ stackhpc_release_pulp_url }}/pulp/content
 # Debs
 
 # Whether to sync Ubuntu packages.
-stackhpc_pulp_sync_ubuntu_focal: "{{ os_distribution == 'ubuntu' }}"
+# NOTE: Not currently syncing Ubuntu packages, since the on_demand mirror in
+# Ark does not work if the upstream mirror pulls packages (which it does
+# sometimes).
+stackhpc_pulp_sync_ubuntu_focal: false
 
 stackhpc_pulp_repository_deb_repos:
   # Base Ubuntu Focal repositories


### PR DESCRIPTION
* The on_demand mirror in Ark does not work if the upstream mirror pulls packages (which it does sometimes).
* A set of Ubuntu images has been built with tag `wallaby-20220819T112725`.