### PR TITLE
Support filtering Kolla container images to sync/publish

### DIFF
--- a/etc/kayobe/pulp.yml
+++ b/etc/kayobe/pulp.yml
@@ -428,6 +428,15 @@ stackhpc_pulp_images_kolla:
   - redis-base
   - redis-sentinel
 
+# Whitespace-separated list of regular expressions matching Kolla image names.
+# Usage is similar to kolla-build CLI arguments.
+# Example:
+# kayobe playbook run ... -e stackhpc_pulp_images_kolla_filter='"^glance nova-compute$"'
+stackhpc_pulp_images_kolla_filter: ".*"
+
+# Filtered list of Kolla container image names.
+stackhpc_pulp_images_kolla_filtered: "{{ stackhpc_pulp_images_kolla | select('search', '(' ~ stackhpc_pulp_images_kolla_filter.split() | join('|') ~ ')') | list }}"
+
 # Common parameters for container image repositories.
 stackhpc_pulp_repository_container_repos_kolla_common:
   url: "{{ stackhpc_release_pulp_registry_url }}"
@@ -440,7 +449,7 @@ stackhpc_pulp_repository_container_repos_kolla_common:
 # List of Kolla container image repositories.
 stackhpc_pulp_repository_container_repos_kolla: >-
   {%- set repos = [] -%}
-  {%- for image in stackhpc_pulp_images_kolla -%}
+  {%- for image in stackhpc_pulp_images_kolla_filtered -%}
   {%- set image_repo = kolla_docker_namespace ~ "/" ~ kolla_base_distro ~ "-" ~ kolla_install_type ~ "-" ~ image -%}
   {%- set repo = {"name": image_repo} -%}
   {%- set _ = repos.append(stackhpc_pulp_repository_container_repos_kolla_common | combine(repo)) -%}
@@ -455,7 +464,7 @@ stackhpc_pulp_distribution_container_kolla_common:
 # List of Kolla container image distributions.
 stackhpc_pulp_distribution_container_kolla: >-
   {%- set distributions = [] -%}
-  {%- for image in stackhpc_pulp_images_kolla -%}
+  {%- for image in stackhpc_pulp_images_kolla_filtered -%}
   {%- set image_repo = kolla_docker_namespace ~ "/" ~ kolla_base_distro ~ "-" ~ kolla_install_type ~ "-" ~ image -%}
   {%- set distribution = {"name": image_repo, "repository": image_repo, "base_path": image_repo} -%}
   {%- set _ = distributions.append(stackhpc_pulp_distribution_container_kolla_common | combine(distribution)) -%}


### PR DESCRIPTION
It can take a long time to sync and publish all Kolla container images
to the local Pulp service. Sometimes we know we just need to update a
few images. This change adds support for filtering the image list, using
regexes in a similar way to kolla-build.

Example:

  kayobe playbook run ... -e stackhpc_pulp_images_kolla_filter='"^glance nova-compute$"'
