### PR TITLE
pulp: use pulp_url as advertised content origin

### DIFF
--- a/etc/kayobe/containers/pulp/settings.py
+++ b/etc/kayobe/containers/pulp/settings.py
@@ -1,4 +1,4 @@
-CONTENT_ORIGIN='http://{{ ansible_facts.fqdn }}'
-ANSIBLE_API_HOSTNAME='http://{{ ansible_facts.fqdn }}'
-ANSIBLE_CONTENT_HOSTNAME='http://{{ ansible_facts.fqdn }}/pulp/content'
+CONTENT_ORIGIN='{{ pulp_url }}'
+ANSIBLE_API_HOSTNAME='{{ pulp_url }}'
+ANSIBLE_CONTENT_HOSTNAME='{{ pulp_url }}/pulp/content'
 TOKEN_AUTH_DISABLED=True


### PR DESCRIPTION
This fixes an issue where a container image pull would fail if the
seed's hostname is not resolvable from the host pulling the image.
Typically it will not be.

This hasn't always been an issue, and it's unclear what has changed.
Perhaps something in the Pulp container registry code.
