### PR TITLE
CI: change VM image for testing

### DIFF
--- a/.github/workflows/stackhpc-all-in-one.yml
+++ b/.github/workflows/stackhpc-all-in-one.yml
@@ -18,7 +18,7 @@ on:
       vm_image:
         description: Image for the all-in-one VM
         type: string
-        default: CentOS-stream8
+        default: CentOS-stream8-no-kmod-test
       vm_flavor:
         description: Flavor for the all-in-one VM
         type: string

--- a/etc/kayobe/environments/ci-aio/stackhpc-ci.yml
+++ b/etc/kayobe/environments/ci-aio/stackhpc-ci.yml
@@ -8,9 +8,9 @@ kolla_docker_namespace: stackhpc-dev
 ###############################################################################
 # Network configuration.
 
-# Don't touch resolv.conf: use Neutron DNS for accessing Pulp server via
-# hostname.
-resolv_is_managed: false
+# WORKAROUND: DNS snooping broken in SMS lab - use neutron DHCP agent.
+resolv_nameservers:
+  - 10.205.0.3
 
 ###############################################################################
 # StackHPC configuration.

--- a/terraform/aio/scripts/configure-local-networking.sh
+++ b/terraform/aio/scripts/configure-local-networking.sh
@@ -8,6 +8,11 @@ cat << EOF | sudo tee -a /etc/hosts
 10.205.3.187 pulp-server pulp-server.internal.sms-cloud
 EOF
 
+# WORKAROUND: DNS snooping broken in SMS lab - use neutron DHCP agent.
+cat << EOF | sudo tee /etc/resolv.conf
+nameserver 10.205.0.3
+EOF
+
 # IP of the seed hypervisor on the OpenStack 'public' network created by init-runonce.sh.
 public_ip="10.0.2.1"
 


### PR DESCRIPTION
The CentOS-stream8 image is in a broken half-deleted state.
CentOS-stream8-no-kmod-test is more up to date.
