### PR TITLE
Update docker baseurl to work with Rocky 8

### DIFF
--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -1,7 +1,7 @@
 # yamllint disable-file
 ---
 docker_yum_baseurl: "{{ stackhpc_repo_docker_url }}"
-docker_yum_gpgkey: "https://download.docker.com/linux/{% raw %}{{ ansible_facts.distribution | lower }}{% endraw %}/gpg"
+docker_yum_gpgkey: "https://download.docker.com/linux/centos/gpg"
 
 {% if kolla_base_distro == 'centos' %}
 barbican_tag: xena-20220728T143658


### PR DESCRIPTION
This is the equivalent change of:

https://review.opendev.org/c/openstack/ansible-collection-kolla/+/831642