### PR TITLE
Rocky 8: Install a compatible version of ansible in the kolla venv

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -48,7 +48,12 @@ kolla_ansible_source_version: "{{ stackhpc_kolla_ansible_source_version }}"
 #kolla_ansible_venv:
 
 # Extra requirements to install inside the kolla-ansible virtualenv.
-#kolla_ansible_venv_extra_requirements:
+kolla_ansible_venv_extra_requirements: "{{ lookup('vars', 'kolla_ansible_venv_extra_requirements_' ~ os_distribution, default=[]) }}"
+
+# Rocky specific requirements in the kolla-ansible virtualenv
+kolla_ansible_venv_extra_requirements_rocky:
+  # NOTE(wszumski): This is wallaby specific as we can use ansiblec-core 2.11 in Xena.
+  - 'ansible-base@git+https://github.com/stackhpc/ansible@stackhpc/2.10/rocky'
 
 # Pip requirement specifier for the ansible package. NOTE: This limits the
 # version of ansible used by kolla-ansible to avoid new releases from breaking

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -52,7 +52,7 @@ kolla_ansible_venv_extra_requirements: "{{ lookup('vars', 'kolla_ansible_venv_ex
 
 # Rocky specific requirements in the kolla-ansible virtualenv
 kolla_ansible_venv_extra_requirements_rocky:
-  # NOTE(wszumski): This is wallaby specific as we can use ansiblec-core 2.11 in Xena.
+  # NOTE(wszumski): This is wallaby specific as we can use ansible-core 2.11 in Xena.
   - 'ansible-base@git+https://github.com/stackhpc/ansible@stackhpc/2.10/rocky'
 
 # Pip requirement specifier for the ansible package. NOTE: This limits the


### PR DESCRIPTION
This improves support out of the box. You still need to make sure that
you install a compatible version of ansible in the kayobe virtualenv:

```
git clone https://github.com/stackhpc/stackhpc-kayobe-config -b stackhpc/wallaby
cd stackhpc-kayobe-config
pip install -U ansible-base@git+https://github.com/stackhpc/ansible@stackhpc/2.10/rocky -e .
```

The above example installs a fork of ansible with support for Rocky 8.