### PR TITLE
xena ceph fixes

### DIFF
--- a/etc/kayobe/ansible/requirements.yml
+++ b/etc/kayobe/ansible/requirements.yml
@@ -1,7 +1,7 @@
 ---
 collections:
   - name: stackhpc.cephadm
-    version: 1.7.0
+    version: 1.8.0
   - name: stackhpc.pulp
     version: 0.3.0
   - name: pulp.squeezer

--- a/etc/kayobe/cephadm.yml
+++ b/etc/kayobe/cephadm.yml
@@ -23,6 +23,9 @@ cephadm_registry_username: "{{ stackhpc_docker_registry_username }}"
 # Ceph container image registry password.
 cephadm_registry_password: "{{ stackhpc_docker_registry_password }}"
 
+# Cephadm admin network interface.
+cephadm_admin_interface: "{{ admin_oc_net_name | net_interface }}"
+
 # Ceph public network interface.
 cephadm_public_interface: "{{ storage_net_name | net_interface }}"
 

--- a/etc/kayobe/pulp.yml
+++ b/etc/kayobe/pulp.yml
@@ -597,6 +597,7 @@ stackhpc_pulp_repository_container_repos_ceph:
     url: "https://quay.io"
     policy: on_demand
     state: present
+    include_tags: "{{ cephadm_image_tag }}"
     required: "{{ stackhpc_sync_ceph_images | bool }}"
 
 # List of Ceph container image distributions.


### PR DESCRIPTION
- cephadm: Bump collection to 1.8.0
- cephadm: use admin overcloud network for SSH access
- cephadm: sync only a specific container image tag
