### PR TITLE
Changing container tag to latest promoted

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -91,7 +91,7 @@ kolla_docker_registry_password: "{{ stackhpc_docker_registry_password }}"
 
 # Kolla OpenStack release version. This should be a Docker image tag.
 # Default is {{ openstack_release }}.
-kolla_openstack_release: "{% if kolla_base_distro == 'centos' %}wallaby-20220905T105054{% else %}wallaby-20220819T112725{% endif %}"
+kolla_openstack_release: "{% if kolla_base_distro == 'centos' %}wallaby-20220919T081704{% else %}wallaby-20220819T112725{% endif %}"
 
 # Docker tag applied to built container images. Default is
 # {{ kolla_openstack_release }}.


### PR DESCRIPTION
Changes from between wallaby-20220905T105054 and wallaby-20220919T081704 contained in:
https://github.com/stackhpc/stackhpc-kayobe-config/commit/08f59a33be54d7e1a78faa8cedfadb22252506c7

Deployed and tested on sms-lab.
