### PR TITLE
Updated hostname command

### DIFF
--- a/etc/kayobe/environments/ci-multinode/README.md
+++ b/etc/kayobe/environments/ci-multinode/README.md
@@ -28,7 +28,7 @@ Also storage nodes which back OpenStack such as Cinder, Glance and Nova are apar
     4. For the storage nodes ensure the hostname is not FQDN
 
     ```
-    sudo hostname "$(hostname -s)"
+    sudo hostnamectl set-hostname "$(hostname -s)"
     ```
 
 ## Setup of Kayobe Config


### PR DESCRIPTION
previous command only set transient hostname, which in some cases might be preceded by static hostname which still had the long name