### PR TITLE
Rocky 8: Generate a more complete overcloud image

### DIFF
--- a/etc/kayobe/overcloud-dib.yml
+++ b/etc/kayobe/overcloud-dib.yml
@@ -71,7 +71,8 @@ overcloud_dib_host_packages_extra:
 overcloud_dib_git_elements_extra:
   - repo: "https://github.com/stackhpc/stackhpc-image-elements"
     local: "{{ source_checkout_path }}/stackhpc-image-elememts"
-    version: "v1.4.0"
+    # FIXME: merge and tag a new release
+    version: "feature/rocky-container-generic"
     elements_path: "elements"
 
 # List of git repositories containing Diskimage Builder (DIB) elements. See

--- a/etc/kayobe/stackhpc-overcloud-dib.yml
+++ b/etc/kayobe/stackhpc-overcloud-dib.yml
@@ -21,7 +21,7 @@ stackhpc_overcloud_dib_name: "deployment_image"
 
 # StackHPC overcloud DIB image elements.
 stackhpc_overcloud_dib_elements:
-  - "{{ os_distribution }}-{% if os_distribution == 'rocky' %}container{% else %}minimal{% endif %}"
+  - "{{ os_distribution }}-{% if os_distribution == 'rocky' %}container-generic{% else %}minimal{% endif %}"
   - "cloud-init-datasources"
   - "{% if os_distribution in ['centos', 'rocky'] %}disable-selinux{% endif %}"
   - "enable-serial-console"


### PR DESCRIPTION
The standard rocky container is very bare-bones and is missing many useful utilities. The container-generic image is supposed to be more like the generic cloud image.