### PR TITLE
Removing the conditional. Forcing pvresize

### DIFF
--- a/etc/kayobe/ansible/growroot.yml
+++ b/etc/kayobe/ansible/growroot.yml
@@ -76,3 +76,7 @@
         pv: "{{ pvs.stdout | from_json }}"
         disk: "{{ pv.report[0].pv[0].pv_name }}"
       become: True
+#      when: "'NOCHANGE' not in growpart.stdout"
+# Commenting out the conditional because growpart is already triggered by cloud-init - hence it emits NOCHANGE
+# Cloud-Inits growpart implementation has a bug https://bugzilla.redhat.com/show_bug.cgi?id=2122575
+# PVresize is not being triggered

--- a/etc/kayobe/ansible/growroot.yml
+++ b/etc/kayobe/ansible/growroot.yml
@@ -76,4 +76,3 @@
         pv: "{{ pvs.stdout | from_json }}"
         disk: "{{ pv.report[0].pv[0].pv_name }}"
       become: True
-      when: "'NOCHANGE' not in growpart.stdout"


### PR DESCRIPTION
Growroot is being executed by cloud-init.
Bug in growroot implementation doesnt extend the pv.