### PR TITLE
Wallaby: Additional Grafana panel plugin

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -234,7 +234,8 @@ kolla_build_blocks:
   bifrost_base_header: |
     ADD additions-archive /
   grafana_plugins_install: |
-    RUN grafana-cli plugins install vonage-status-panel
+    RUN grafana-cli plugins install vonage-status-panel \
+        && grafana-cli plugins install grafana-piechart-panel
   ironic_inspector_header: |
     ADD additions-archive /
   prometheus_v2_server_repository_version: |


### PR DESCRIPTION
The old version is still required by some (namely Ceph) dashboards.