### PR TITLE
Xena: sync with Wallaby

### DIFF
--- a/.github/workflows/stackhpc-all-in-one.yml
+++ b/.github/workflows/stackhpc-all-in-one.yml
@@ -232,3 +232,8 @@ jobs:
           OS_APPLICATION_CREDENTIAL_ID: ${{ secrets.OS_APPLICATION_CREDENTIAL_ID }}
           OS_APPLICATION_CREDENTIAL_SECRET: ${{ secrets.OS_APPLICATION_CREDENTIAL_SECRET }}
         if: always()
+
+      - name: Prune Docker images over 1 week old
+        # May fail if another prune is running
+        run: sudo docker image prune --force --filter until=168h || true
+        if: always()

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -48,7 +48,12 @@ kolla_ansible_source_version: "{{ stackhpc_kolla_ansible_source_version }}"
 #kolla_ansible_venv:
 
 # Extra requirements to install inside the kolla-ansible virtualenv.
-#kolla_ansible_venv_extra_requirements:
+kolla_ansible_venv_extra_requirements: "{{ lookup('vars', 'kolla_ansible_venv_extra_requirements_' ~ os_distribution, default=[]) }}"
+
+# Rocky specific requirements in the kolla-ansible virtualenv
+kolla_ansible_venv_extra_requirements_rocky:
+  # NOTE(wszumski): This is wallaby specific as we can use ansiblec-core 2.11 in Xena.
+  - 'ansible-base@git+https://github.com/stackhpc/ansible@stackhpc/2.10/rocky'
 
 # Pip requirement specifier for the ansible package. NOTE: This limits the
 # version of ansible used by kolla-ansible to avoid new releases from breaking

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -48,12 +48,7 @@ kolla_ansible_source_version: "{{ stackhpc_kolla_ansible_source_version }}"
 #kolla_ansible_venv:
 
 # Extra requirements to install inside the kolla-ansible virtualenv.
-kolla_ansible_venv_extra_requirements: "{{ lookup('vars', 'kolla_ansible_venv_extra_requirements_' ~ os_distribution, default=[]) }}"
-
-# Rocky specific requirements in the kolla-ansible virtualenv
-kolla_ansible_venv_extra_requirements_rocky:
-  # NOTE(wszumski): This is wallaby specific as we can use ansible-core 2.11 in Xena.
-  - 'ansible-base@git+https://github.com/stackhpc/ansible@stackhpc/2.10/rocky'
+#kolla_ansible_venv_extra_requirements:
 
 # Pip requirement specifier for the ansible package. NOTE: This limits the
 # version of ansible used by kolla-ansible to avoid new releases from breaking

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -234,7 +234,8 @@ kolla_build_blocks:
   bifrost_base_header: |
     ADD additions-archive /
   grafana_plugins_install: |
-    RUN grafana-cli plugins install vonage-status-panel
+    RUN grafana-cli plugins install vonage-status-panel \
+        && grafana-cli plugins install grafana-piechart-panel
   ironic_inspector_header: |
     ADD additions-archive /
   prometheus_v2_server_repository_version: |

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -52,7 +52,7 @@ kolla_ansible_venv_extra_requirements: "{{ lookup('vars', 'kolla_ansible_venv_ex
 
 # Rocky specific requirements in the kolla-ansible virtualenv
 kolla_ansible_venv_extra_requirements_rocky:
-  # NOTE(wszumski): This is wallaby specific as we can use ansiblec-core 2.11 in Xena.
+  # NOTE(wszumski): This is wallaby specific as we can use ansible-core 2.11 in Xena.
   - 'ansible-base@git+https://github.com/stackhpc/ansible@stackhpc/2.10/rocky'
 
 # Pip requirement specifier for the ansible package. NOTE: This limits the

--- a/terraform/aio/README.rst
+++ b/terraform/aio/README.rst
@@ -104,12 +104,6 @@ Apply the changes:
 
    terraform apply -auto-approve
 
-Use the ci-aio environment:
-
-.. code-block:: console
-
-   export KAYOBE_ENVIRONMENT=ci-aio
-
 Write Terraform outputs to a Kayobe config file:
 
 .. code-block:: console
@@ -151,6 +145,12 @@ Build a Kayobe image:
 .. code-block:: console
 
    sudo DOCKER_BUILDKIT=1 docker build --file .automation/docker/kayobe/Dockerfile --tag kayobe:latest .
+
+Use the ci-aio environment:
+
+.. code-block:: console
+
+   export KAYOBE_ENVIRONMENT=ci-aio
 
 Set the Kayobe Vault password env var:
 


### PR DESCRIPTION
- setup.cfg: Replace dashes with underscores
- Synchronize kayobe-config
- Sync kayobe-config with kayobe changes
- Update .gitreview for stable/xena
- Update TOX_CONSTRAINTS_FILE for stable/xena
- Fix configuration sync for infra-vms
- Sync kayobe-config with kayobe changes
- CI: Use ansible_facts for ci-aio and ci-builder environments
- Xena: source is now default for kolla_install_type
- Xena: drop prometheus-server image
- Xena: update README
- Xena: update package repositories and Kolla image build config
- Xena: update image tags
- Xena: update Github Actions workflows
- Xena: configure test pulp server as insecure in CI environments
- Xena: update Pulp repository versions
- Sync with stackhpc/kayobe @ ae2e0ed2fc78c1a61d299b4f6c2aba5d190345bb
- Xena: drop comment in tox.ini
- Xena: update release notes
- Revert multi-image overcloud-dib config
- Fix up seed config after Wallaby merge
- Add custom playbooks for Cephadm
- Add Ceph image to Pulp registry
- Add cephadm.yml configuration defaults
- Add Cephadm groups to inventory
- Add a playbook to generate Kayobe configuration for Ceph via Cephadm
- Add multiple overcloud DIB image support config
- Add StackHPC overcloud DIB configuration
- Add StackHPC LVM configuration
- Add swap.yml custom playbook
- Add growroot.yml custom playbook
- Xena: drop downstream Barbican
- Xena: Replace kolla build blocks with ARG overrides
- Xena: add initial Kolla tags
- docker: enable live restore
- Add basic Ansible tuning
- Xena: use Kayobe stackhpc/xena branch in requirements.txt
- Xena: use openstack_release for UCA distribution
- Update kayobe-automation to fix rsync issue
- feat: automatic update of workflows stackhpc/xena
- feat: automatic update of community files stackhpc/xena
- feat: automatic update of workflows stackhpc/xena
- growpart.yml: Don't assume facts are present
- Overcloud DIB: stop using StackHPC package repos for Ubuntu image
- Support filtering Kolla container images to sync/publish
- growroot.yml: Fail if the expected volume group doesn't exist
- growroot: Avoid package installation when growpart is installed
- Add ceph group as a child of the storage group
- Adds Rocky 8 repository config for local pulp (#146)
- Update docker baseurl to work with Rocky 8 (#153)
- Bump rocky snapshot
- Adds OFED 5.7.x
- Use output from release train
- cephadm: Bump collection to 1.8.0
- cephadm: use admin overcloud network for SSH access
- cephadm: sync only a specific container image tag
- Cephadm: Remove leading tabs from generated ceph.conf
- Cephadm: Fix keyring generation
- Ceph: add a trailing newline to ceph.conf
- Prevent 'base' type images from syncing / publishing
- Prevent failures when dhclient is not running
- Let Ansible Galaxy handle dependencies
- Bump up the Cephadm collection version
- Bump repos to the same versions as Wallaby
- Remove duplicate opstools repo
- Xena: Add system logging custom playbook
- Enable Kolla features
- Elasticsearch memory tuning
- Add standard alerting rules and dashboards
- Use sane defaults for basic monitoring stack
- Consider agents that are auto-downed
- feat: create `ci-multinode` environment
- feat: successfully configure two controllers
- feat: succesfully configure three controllers with VXLAN
- feat: add `kayobe-compute-01`
- feat: add `growroot` playbook for successful deployment
- feat: successfully deploy environment
- fix: syntax issues raised by `yamllint`
- added notes
- removed TODO
- feat: update vxlan role version and expand hosts
- feat: enable ceph and ceph related services
- feat: pull vxlan from ansible galaxy
- Removing vxlan hook
- added cephadm.yml to multinode environment.
- feat: add storage group vars
- Adding LVM configuration for storage nodes
- Reencrypting docker_registry_password
- ci-multinode: Use insecure Docker registry
- Removing unnecessary config parts. Compute hosts are BM's
- Matching with ci-builder env
- ci-multinode: fix pep8 issues
- Adds Rocky 8 pulp repositories to dnf.yml (#152)
- Removing the conditional. Forcing pvresize Growroot is being executed by cloud-init. Bug in growroot implementation doesnt extend the pv.
- Hashing out previously used conditional. Adding bug explanation
- Indicate source of the alert rules
- Add monitoring group
- Use shorter regexp for catching physical network cards
- Build Grafana with additional panel plugin
- changing release to point to latest build
- dropping not needed overrides
- Add basic docs template structure
- Add basic docs template structure
- Add basic docs template structure
- Add basic docs template structure
- Remove openstack reference
- Changes based on Mark's comments
- Revert "Rocky 8: Install a compatible version of ansible in the kolla venv"
