### PR TITLE
Rephrase the match logic for interfaces monitored for package drops

### DIFF
--- a/etc/kayobe/kolla/config/prometheus/ceph.rules
+++ b/etc/kayobe/kolla/config/prometheus/ceph.rules
@@ -154,7 +154,7 @@ groups:
 
   # alert on nic packet errors and drops rates > 1 packet/s
   - alert: NetworkPacketsDropped
-    expr: irate(node_network_receive_drop_total{device=~"en.*|eth.*"}[5m]) + irate(node_network_transmit_drop_total{device=~"en.*|eth.*"}[5m]) > 1
+    expr: irate(node_network_receive_drop_total{device!~"lo|br.*|.*-ovs|tap.*"}[5m]) + irate(node_network_transmit_drop_total{device!~"lo|br.*|.*-ovs|tap.*"}[5m]) > 1
     labels:
       severity: warning
     annotations:


### PR DESCRIPTION
OVS bridge interfaces drop packets during normal operation, generating lots of spurious alerts.  Change the regex to filter out interfaces that don't matter for packet drops.