### PR TITLE
Increase job timeout for kolla image build GitHub Actions workflow

### DIFF
--- a/.github/workflows/stackhpc-container-image-build.yml
+++ b/.github/workflows/stackhpc-container-image-build.yml
@@ -34,6 +34,7 @@ jobs:
     name: Build Kolla container images
     if: github.repository == 'stackhpc/stackhpc-kayobe-config'
     runs-on: [self-hosted, stackhpc-kayobe-config-kolla-builder]
+    timeout-minutes: 720
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Doubles the job-timeout for the container image build GitHub Actions workflow, from a default of 360 minutes to 720 minutes.

The default timeout can be hit when building and pushing a completely fresh release/baseos combination, although hopefully once layers are available in the registry, subsequent build/push should be a bit quicker.