### PR TITLE
CI: use cloud-user as bootstrap user on CentOS

### DIFF
--- a/etc/kayobe/environments/ci-aio/controllers.yml
+++ b/etc/kayobe/environments/ci-aio/controllers.yml
@@ -1,0 +1,7 @@
+---
+###############################################################################
+# Controller node configuration.
+
+# User with which to access the controllers via SSH during bootstrap, in order
+# to setup the Kayobe user account. Default is {{ os_distribution }}.
+controller_bootstrap_user: "{{ os_distribution if os_distribution == 'ubuntu' else 'cloud-user' }}"

--- a/etc/kayobe/environments/ci-builder/seed.yml
+++ b/etc/kayobe/environments/ci-builder/seed.yml
@@ -1,0 +1,7 @@
+---
+###############################################################################
+# Seed node configuration.
+
+# User with which to access the seed via SSH during bootstrap, in order
+# to setup the Kayobe user account. Default is {{ os_distribution }}.
+seed_bootstrap_user: "{{ os_distribution if os_distribution == 'ubuntu' else 'cloud-user' }}"

--- a/terraform/aio/vm.tf
+++ b/terraform/aio/vm.tf
@@ -67,25 +67,25 @@ resource "openstack_compute_instance_v2" "kayobe-aio" {
 
   provisioner "file" {
     source      = "scripts/configure-local-networking.sh"
-    destination = "/home/centos/configure-local-networking.sh"
+    destination = "/home/cloud-user/configure-local-networking.sh"
 
     connection {
       type        = "ssh"
       host        = self.access_ip_v4
-      user        = "centos"
+      user        = "cloud-user"
       private_key = file(var.ssh_private_key)
     }
   }
 
   provisioner "remote-exec" {
     inline = [
-      "sudo bash /home/centos/configure-local-networking.sh"
+      "sudo bash /home/cloud-user/configure-local-networking.sh"
     ]
 
     connection {
       type        = "ssh"
       host        = self.access_ip_v4
-      user        = "centos"
+      user        = "cloud-user"
       private_key = file(var.ssh_private_key)
     }
 


### PR DESCRIPTION
cloud-init was changed to make CentOS more similar to RHEL, using a
cloud-user account rather than centos.

https://github.com/canonical/cloud-init/pull/1639
