### PR TITLE
[CI] Cancel stale workflows when pushing a new change

### DIFF
--- a/.github/workflows/stackhpc-pull-request.yml
+++ b/.github/workflows/stackhpc-pull-request.yml
@@ -1,5 +1,9 @@
 ---
 
+concurrency:
+  group: stackhpc-pull-request-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 name: Pull request
 'on':
   pull_request:


### PR DESCRIPTION
This prevents workflows from stacking up in the queue. Prior to this change, a new workflow was being created for each commit to a PR. If multiple commits are pushed in quick sucession, a large backlog can be built up in the queue. There is not much point in testing an old version of a PR.

See: https://stackoverflow.com/questions/66335225/how-to-cancel-previous-runs-in-the-pr-when-you-push-new-commitsupdate-the-curre