### PR TITLE
CI: fix docker image prune

### DIFF
--- a/.github/workflows/stackhpc-all-in-one.yml
+++ b/.github/workflows/stackhpc-all-in-one.yml
@@ -235,5 +235,5 @@ jobs:
 
       - name: Prune Docker images over 1 week old
         # May fail if another prune is running
-        run: sudo docker image prune --force --filter until=168h || true
+        run: sudo docker image prune --all --force --filter until=168h || true
         if: always()

--- a/.github/workflows/stackhpc-container-image-build.yml
+++ b/.github/workflows/stackhpc-container-image-build.yml
@@ -143,9 +143,9 @@ jobs:
           retention-days: 7
         if: github.event.inputs.seed == 'true'
 
-      - name: Prune local Kolla container images
+      - name: Prune local Kolla container images over 1 week old
         run: |
-          sudo docker image prune --force --filter="label=kolla_version"
+          sudo docker image prune --all --force --filter until=168h --filter="label=kolla_version"
 
   sync-container-repositories:
     name: Trigger container image repository sync


### PR DESCRIPTION
Without the --all flag, only dangling images are pruned. This doesn't help much.

Also, only prune images over 1 week old on the builder runner.
