### PR TITLE
Rephrase the match logic for interfaces monitored for package drops

### DIFF
--- a/etc/kayobe/kolla/config/prometheus/ceph.rules
+++ b/etc/kayobe/kolla/config/prometheus/ceph.rules
@@ -154,7 +154,7 @@ groups:
 
   # alert on nic packet errors and drops rates > 1 packet/s
   - alert: NetworkPacketsDropped
-    expr: irate(node_network_receive_drop_total{device=~"en.*|eth.*"}[5m]) + irate(node_network_transmit_drop_total{device=~"en.*|eth.*"}[5m]) > 1
+    expr: irate(node_network_receive_drop_total{device!~"lo|br.*|.*-ovs|tap.*"}[5m]) + irate(node_network_transmit_drop_total{device!~"lo|br.*|.*-ovs|tap.*"}[5m]) > 1
     labels:
       severity: warning
     annotations:


### PR DESCRIPTION
OVS bridge interfaces drop packets during normal operation.  Change
the regex to filter out interfaces that don't matter for packet
drops.

(cherry picked from commit 9c3f15a1f374d24d08a0bdac63886220247d2a4e)
