### PR TITLE
CI: add bifrost to container sync filter

### DIFF
--- a/.github/workflows/stackhpc-container-image-build.yml
+++ b/.github/workflows/stackhpc-container-image-build.yml
@@ -158,10 +158,15 @@ jobs:
       # stackhpc-release-train repository.
       - name: Trigger container image repository sync
         run: |
+          filter='${{ inputs.regexes }}'
+          if [[ -n $filter ]] && [[ ${{ github.event.inputs.seed }} == 'true' ]]; then
+            filter="$filter bifrost"
+          fi
           gh workflow run \
           container-sync.yml \
           --repo stackhpc/stackhpc-release-train \
-          --ref main
+          --ref main \
+          -f filter="$filter"
         env:
           GITHUB_TOKEN: ${{ secrets.STACKHPC_RELEASE_TRAIN_TOKEN }}
 


### PR DESCRIPTION
Without this, if an image build regex is provided then bifrost images
would not also be synced.
