### PR TITLE
Switch to using absolute limit for low memory alert

### DIFF
--- a/etc/kayobe/kolla/config/prometheus/system.rules
+++ b/etc/kayobe/kolla/config/prometheus/system.rules
@@ -16,13 +16,13 @@ groups:
       description: "{{ $labels.device }} is {{ $value }}% full."
 
   - alert: LowMemory
-    expr: ( ( node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes - (node_memory_Hugepagesize_bytes * node_memory_HugePages_Total)) / (node_memory_MemTotal_bytes - (node_memory_Hugepagesize_bytes * node_memory_HugePages_Total))) * 100 >= 80
+    expr: (node_memory_MemAvailable_bytes / 1024^3) < {{ alertmanager_low_memory_threshold_gb }}
     for: 1m
     labels:
       severity: alert
     annotations:
       summary: "Prometheus exporter at {{ $labels.instance }} reports low memory"
-      description: "Memory is {{ $value }}% full."
+      description: "Available memory is {{ $value }}."
 
   - alert: HostOomKillDetected
     expr: increase(node_vmstat_oom_kill[5m]) > 0

--- a/etc/kayobe/kolla/config/prometheus/system.rules
+++ b/etc/kayobe/kolla/config/prometheus/system.rules
@@ -16,7 +16,7 @@ groups:
       description: "{{ $labels.device }} is {{ $value }}% full."
 
   - alert: LowMemory
-    expr: (node_memory_MemAvailable_bytes / 1024^3) < {{ alertmanager_low_memory_threshold_gb }}
+    expr: (node_memory_MemAvailable_bytes / 1024^3) < {{ alertmanager_low_memory_threshold_gib }}
     for: 1m
     labels:
       severity: alert

--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -12,9 +12,8 @@ bifrost_tag: xena-20221102T110017
 
 es_heap_size: 8g
 prometheus_cmdline_extras: "--storage.tsdb.retention.time=30d"
-# Threshold to trigger a LowMemory alert in Gibibytes (GiB). When the
-# amount of free memory is lower than this value an alert will
-# be triggered.
+# Threshold to trigger a LowMemory alert in Gibibytes (GiB). When the amount
+# of free memory is lower than this value an alert will be triggered.
 alertmanager_low_memory_threshold_gib: 5
 
 #############################################################################

--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -7,6 +7,14 @@ docker_yum_gpgkey: "https://download.docker.com/linux/centos/gpg"
 bifrost_tag: xena-20221102T110017
 {% endif %}
 
+#############################################################################
 # Monitoring and alerting related settings
+
 es_heap_size: 8g
 prometheus_cmdline_extras: "--storage.tsdb.retention.time=30d"
+# Threshold to trigger a LowMemory alert in Gibibytes (GiB). When the
+# amount of free memory is lower that this value an alert will
+# be triggered.
+alertmanager_low_memory_threshold_gb: 5
+
+#############################################################################

--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -13,8 +13,8 @@ bifrost_tag: xena-20221102T110017
 es_heap_size: 8g
 prometheus_cmdline_extras: "--storage.tsdb.retention.time=30d"
 # Threshold to trigger a LowMemory alert in Gibibytes (GiB). When the
-# amount of free memory is lower that this value an alert will
+# amount of free memory is lower than this value an alert will
 # be triggered.
-alertmanager_low_memory_threshold_gb: 5
+alertmanager_low_memory_threshold_gib: 5
 
 #############################################################################


### PR DESCRIPTION
Nodes with alot of ram can end up triggering this low memory alert even when they have a significant amount of free memory e.g for a node with 512GiB ram, when we hit the current alert (which is configured to be 80%) we still have 102.5GiB free.