### PR TITLE
Use latest release of Prometheus Openstack Exporter

### DIFF
--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -6,6 +6,7 @@ docker_yum_gpgkey: "https://download.docker.com/linux/centos/gpg"
 {% if kolla_base_distro == 'centos' %}
 bifrost_tag: yoga-20221007T134036
 neutron_tag: yoga-20221115T101524
+prometheus_openstack_exporter_tag: yoga-20221128T164623
 {% endif %}
 
 #############################################################################


### PR DESCRIPTION
The previous centos-source-prometheus-openstack-exporter image for yoga was built from a branch of our fork derived from release v1.3.0.

Switch to an image built from upstream release v1.6.0.