### PR TITLE
remove ceph from storage group

### DIFF
--- a/etc/kayobe/inventory/groups
+++ b/etc/kayobe/inventory/groups
@@ -101,9 +101,6 @@ hs-switches
 ###############################################################################
 # Ceph groups.
 
-[storage:children]
-ceph
-
 [ceph:children]
 mons
 mgrs


### PR DESCRIPTION
    this can leads to problem in hyperconverged setup
    where one can already have ceph subgroups members