### PR TITLE
CI: symlink to prometheus & grafana config in ci-aio & ci-multinode

### DIFF
--- a/etc/kayobe/environments/ci-aio/kolla/config/grafana
+++ b/etc/kayobe/environments/ci-aio/kolla/config/grafana
@@ -1,0 +1,1 @@
+../../../../kolla/config/grafana/

--- a/etc/kayobe/environments/ci-aio/kolla/config/prometheus
+++ b/etc/kayobe/environments/ci-aio/kolla/config/prometheus
@@ -1,0 +1,1 @@
+../../../../kolla/config/prometheus/

--- a/etc/kayobe/environments/ci-multinode/kolla/config/grafana
+++ b/etc/kayobe/environments/ci-multinode/kolla/config/grafana
@@ -1,0 +1,1 @@
+../../../../kolla/config/grafana/

--- a/etc/kayobe/environments/ci-multinode/kolla/config/prometheus
+++ b/etc/kayobe/environments/ci-multinode/kolla/config/prometheus
@@ -1,0 +1,1 @@
+../../../../kolla/config/prometheus/


### PR DESCRIPTION
Symlinks created via:

  ln -s ../../../../kolla/config/grafana/ etc/kayobe/environments/ci-aio/kolla/config/
  ln -s ../../../../kolla/config/prometheus/ etc/kayobe/environments/ci-aio/kolla/config/

  ln -s ../../../../kolla/config/grafana/ etc/kayobe/environments/ci-multinode/kolla/config/
  ln -s ../../../../kolla/config/prometheus/ etc/kayobe/environments/ci-multinode/kolla/config/
