### PR TITLE
Fix oom-killer graph

### DIFF
--- a/etc/kayobe/kolla/config/grafana/dashboards/openstack/node_exporter_full.json
+++ b/etc/kayobe/kolla/config/grafana/dashboards/openstack/node_exporter_full.json
@@ -4886,7 +4886,7 @@
         "Total Swap": "#614D93",
         "VmallocUsed": "#EA6460"
       },
-      "bars": false,
+      "bars": true,
       "dashLength": 10,
       "dashes": false,
       "datasource": {
@@ -4921,7 +4921,7 @@
         "total": false,
         "values": true
       },
-      "lines": true,
+      "lines": false,
       "linewidth": 1,
       "links": [],
       "maxPerRow": 6,
@@ -4940,9 +4940,9 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(node_vmstat_oom_kill{instance=\"$node\",job=\"$job\"}[5m])",
+          "expr": "max_over_time(node_vmstat_oom_kill{instance=\"$node\",job=\"$job\"}[$__rate_interval:]) - (min_over_time(node_vmstat_oom_kill{instance=\"$node\",job=\"$job\"}[$__rate_interval:]))",
           "format": "time_series",
-          "interval": "",
+          "interval": "30s",
           "intervalFactor": 2,
           "legendFormat": "oom killer invocations ",
           "refId": "A",


### PR DESCRIPTION
Changes the oom-killer graph from a smoothed irate to a discrete delta function.

This is because the Irate would smooth out the event and would make it difficult to notice
