### PR TITLE
Replace hardcoded threshold by temp_max value

### DIFF
--- a/etc/kayobe/kolla/config/prometheus/system.rules
+++ b/etc/kayobe/kolla/config/prometheus/system.rules
@@ -34,7 +34,7 @@ groups:
       description: "OOM kill detected"
 
   - alert: Overheating
-    expr: node_hwmon_temp_celsius >= 85
+    expr: node_hwmon_temp_celsius >= node_hwmon_temp_max_celsius
     for: 1m
     labels:
       severity: warning


### PR DESCRIPTION
The temp_max value is dynamically gathered from the device [1]. With Xeon CPUs (coretemp driver), it is often 90C, but sometimes lower.

This can help reduce the frequency of alerts with busy hypervisors.

[1] https://docs.kernel.org/hwmon/coretemp.html