### PR TITLE
Bypass pulp on seed hypervisor and seed vm

### DIFF
--- a/etc/kayobe/dnf.yml
+++ b/etc/kayobe/dnf.yml
@@ -41,7 +41,7 @@
 #     file: myrepo
 #     gpgkey: http://gpgkey
 #     gpgcheck: yes
-dnf_custom_repos: "{{ dnf_custom_repos_el8 | combine(lookup('vars', 'dnf_custom_repos_' ~ ansible_facts.distribution | lower )) }}"
+stackhpc_dnf_repos: "{{ dnf_custom_repos_el8 | combine(lookup('vars', 'dnf_custom_repos_' ~ ansible_facts.distribution | lower )) }}"
 
 # Custom repositories shared between all RHEL derivatives.
 dnf_custom_repos_el8:
@@ -58,6 +58,13 @@ dnf_custom_repos_el8:
     enabled: "{{ dnf_enable_epel | bool }}"
     file: epel-modular
     gpgkey: "{{ dnf_epel_gpg_key_url }}"
+    gpgcheck: yes
+  docker:
+    baseurl: "{{ stackhpc_repo_docker_url }}"
+    description: "Package repository for installing docker"
+    enabled: "{{ dnf_enable_docker | bool }}"
+    file: docker
+    gpgkey: "{{ dnf_docker_gpg_key_url }}"
     gpgcheck: yes
 
 # CentOS Stream 8 specific repositories
@@ -111,6 +118,13 @@ dnf_epel_gpg_key_url: "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8"
 # Whether to install the epel-release package. This affects RedHat-based
 # systems only. Default value is 'true'.
 dnf_install_epel: false
+
+# Whether to enable docker dnf repo in stackhpc_dnf_repos
+dnf_enable_docker: true
+
+#URL of docker repo GPG key
+dnf_docker_gpg_key_url: "https://download.docker.com/linux/centos/gpg"
+
 
 ###############################################################################
 # DNF Automatic configuration.

--- a/etc/kayobe/inventory/group_vars/overcloud/stackhpc-dnf-repos
+++ b/etc/kayobe/inventory/group_vars/overcloud/stackhpc-dnf-repos
@@ -1,0 +1,5 @@
+# Only use local pulp mirrors for overcloud hosts
+# to avoid situations where the seed-hypervisor 
+# tries to use a local pulp repo on the seed VM
+# before the seed vm has been provisioned
+dnf_custom_repos: "{{ stackhpc_dnf_repos }}"

--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -1,7 +1,11 @@
 # yamllint disable-file
 ---
-docker_yum_baseurl: "{{ stackhpc_repo_docker_url }}"
-docker_yum_gpgkey: "https://download.docker.com/linux/centos/gpg"
+
+# To work around issue of trying to install docker from 
+# empty pulp server, use upstream docker dnf repo on 
+# non-overcloud hosts
+enable_docker_repo: {% raw %}"{{ 'overcloud' not in group_names }}"{% endraw %}
+
 
 {% if kolla_base_distro == 'centos' %}
 bifrost_tag: xena-20221128T101757


### PR DESCRIPTION
This avoids the problem of trying to install packages from the local pulp server on the seed VM before that server exists.