### PR TITLE
Don't use interactive docker cmds in rabbitmq-reset.yml

### DIFF
--- a/etc/kayobe/ansible/rabbitmq-reset.yml
+++ b/etc/kayobe/ansible/rabbitmq-reset.yml
@@ -29,20 +29,20 @@
       delay: 6
 
     - name: Wait for the rabbitmq node to automatically start on container start
-      command: "docker exec -it {{ container_name }} /bin/bash -c 'rabbitmqctl wait /var/lib/rabbitmq/mnesia/rabbitmq.pid --timeout 60'"
+      command: "docker exec {{ container_name }} /bin/bash -c 'rabbitmqctl wait /var/lib/rabbitmq/mnesia/rabbitmq.pid --timeout 60'"
       when: inspection.stdout == 'false'
 
     - name: Stop app
-      command: "docker exec -it {{ container_name }} /bin/bash -c 'rabbitmqctl stop_app'"
+      command: "docker exec {{ container_name }} /bin/bash -c 'rabbitmqctl stop_app'"
 
     - name: Force reset app
-      command: "docker exec -it {{ container_name }} /bin/bash -c 'rabbitmqctl force_reset'"
+      command: "docker exec {{ container_name }} /bin/bash -c 'rabbitmqctl force_reset'"
 
     - name: Start app
-      command: "docker exec -it {{ container_name }} /bin/bash -c 'rabbitmqctl start_app'"
+      command: "docker exec {{ container_name }} /bin/bash -c 'rabbitmqctl start_app'"
 
     - name: Wait for all nodes to join the cluster
-      command: "docker exec -it {{ container_name }} /bin/bash -c 'rabbitmqctl await_online_nodes {{ groups['controllers'] | length }}'"
+      command: "docker exec {{ container_name }} /bin/bash -c 'rabbitmqctl await_online_nodes {{ groups['controllers'] | length }}'"
 
 - name: Restart OpenStack services
   hosts: controllers:compute


### PR DESCRIPTION
Remove --interactive and --tty args to docker exec commands in rabbitmq-reset.yml.