### PR TITLE
Sets kolla_docker_registry_insecure to true

### DIFF
--- a/etc/kayobe/environments/ci-aio/stackhpc-ci.yml
+++ b/etc/kayobe/environments/ci-aio/stackhpc-ci.yml
@@ -5,11 +5,6 @@
 # Docker namespace to use for Kolla images. Default is 'kolla'.
 kolla_docker_namespace: stackhpc-dev
 
-# Whether docker should be configured to use an insecure registry for Kolla
-# images. Default is false, unless docker_registry_enabled is true and
-# docker_registry_enable_tls is false.
-kolla_docker_registry_insecure: "{{ 'https' not in stackhpc_repo_mirror_url }}"
-
 ###############################################################################
 # Network configuration.
 

--- a/etc/kayobe/environments/ci-builder/stackhpc-ci.yml
+++ b/etc/kayobe/environments/ci-builder/stackhpc-ci.yml
@@ -5,11 +5,6 @@
 # Docker namespace to use for Kolla images. Default is 'kolla'.
 kolla_docker_namespace: stackhpc-dev
 
-# Whether docker should be configured to use an insecure registry for Kolla
-# images. Default is false, unless docker_registry_enabled is true and
-# docker_registry_enable_tls is false.
-kolla_docker_registry_insecure: "{{ 'https' not in stackhpc_repo_mirror_url }}"
-
 # Kolla feature flag configuration.
 kolla_enable_barbican: true
 kolla_enable_central_logging: true

--- a/etc/kayobe/environments/ci-multinode/stackhpc-ci.yml
+++ b/etc/kayobe/environments/ci-multinode/stackhpc-ci.yml
@@ -5,11 +5,6 @@
 # Docker namespace to use for Kolla images. Default is 'kolla'.
 kolla_docker_namespace: stackhpc-dev
 
-# Whether docker should be configured to use an insecure registry for Kolla
-# # images. Default is false, unless docker_registry_enabled is true and
-# # docker_registry_enable_tls is false.
-kolla_docker_registry_insecure: "{{ 'https' not in stackhpc_repo_mirror_url }}"
-
 ###############################################################################
 # Network configuration.
 

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -84,7 +84,7 @@ kolla_docker_namespace: stackhpc
 # Whether docker should be configured to use an insecure registry for Kolla
 # images. Default is false, unless docker_registry_enabled is true and
 # docker_registry_enable_tls is false.
-kolla_docker_registry_insecure: true
+kolla_docker_registry_insecure: "{{ 'https' not in stackhpc_repo_mirror_url }}"
 
 # Username to use to access a docker registry. Default is not set, in which
 # case the registry will be used without authentication.

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -84,7 +84,7 @@ kolla_docker_namespace: stackhpc
 # Whether docker should be configured to use an insecure registry for Kolla
 # images. Default is false, unless docker_registry_enabled is true and
 # docker_registry_enable_tls is false.
-#kolla_docker_registry_insecure:
+kolla_docker_registry_insecure: true
 
 # Username to use to access a docker registry. Default is not set, in which
 # case the registry will be used without authentication.


### PR DESCRIPTION
We currently don't configure TLS for the the local pulp registry.  This adds the pulp server to the list of insecure-registries, so that we can pull images.