### PR TITLE
Bump cloudkitty tag

### DIFF
--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -7,4 +7,5 @@ docker_yum_gpgkey: "https://download.docker.com/linux/centos/gpg"
 bifrost_tag: wallaby-20220921T100954
 {% else %}
 bifrost_tag: wallaby-20220825T112231
+cloudkitty_tag: wallaby-20221215T220154
 {% endif %}


### PR DESCRIPTION
The cloudkitty image was missing our latest backports. Only Ubuntu images have been rebuilt so far.