### PR TITLE
Xena: Cephadm image & DNF repos fixes

### DIFF
--- a/etc/kayobe/cephadm.yml
+++ b/etc/kayobe/cephadm.yml
@@ -9,7 +9,7 @@ cephadm_ceph_release: "pacific"
 #cephadm_fsid:
 
 # Ceph container image.
-cephadm_image: "{{ stackhpc_docker_registry }}/ceph/ceph:{{ cephadm_image_tag }}"
+cephadm_image: "{{ stackhpc_docker_registry if stackhpc_sync_ceph_images | bool else 'quay.io' }}/ceph/ceph:{{ cephadm_image_tag }}"
 
 # Ceph container image tag.
 cephadm_image_tag: "v16.2.5"

--- a/etc/kayobe/dnf.yml
+++ b/etc/kayobe/dnf.yml
@@ -41,6 +41,12 @@
 #     file: myrepo
 #     gpgkey: http://gpgkey
 #     gpgcheck: yes
+#dnf_custom_repos:
+
+# A dict of custom repositories that point to the local Pulp server.
+# To use these repos, set dnf_custom_repos to the value of stackhpc_dnf_repos.
+# This is done by default for hosts in the overcloud group via a group_vars
+# file.
 stackhpc_dnf_repos: "{{ dnf_custom_repos_el8 | combine(lookup('vars', 'dnf_custom_repos_' ~ ansible_facts.distribution | lower )) }}"
 
 # Custom repositories shared between all RHEL derivatives.

--- a/etc/kayobe/environments/ci-multinode/cephadm.yml
+++ b/etc/kayobe/environments/ci-multinode/cephadm.yml
@@ -2,9 +2,6 @@
 ###############################################################################
 # Cephadm deployment configuration.
 
-# Ceph container image.
-cephadm_image: "quay.io/ceph/ceph:v16.2.5"
-
 # Ceph OSD specification.
 cephadm_osd_spec:
   service_type: osd


### PR DESCRIPTION
- cephadm: Use quay.io for cephadm_image by default
- dnf: separate dnf_custom_repos from stackhpc_dnf_repos
