### PR TITLE
xena: wallaby merge

### DIFF
--- a/etc/kayobe/ansible/rabbitmq-reset.yml
+++ b/etc/kayobe/ansible/rabbitmq-reset.yml
@@ -11,6 +11,21 @@
   vars:
     - container_name: rabbitmq
   tasks:
+    - name: Checking timedatectl status
+      become: true
+      command: timedatectl status
+      register: timedatectl_status
+      changed_when: false
+
+    - name: Fail if the clock is not synchronized
+      fail:
+        msg: >-
+          timedatectl sees the system clock as unsynchronized.
+          You may need to force synchronisation using `chronyc makestep`.
+          Otherwise, please wait for synchronization.
+      when:
+        - "'synchronized: yes' not in timedatectl_status.stdout"
+
     - name: Inspect the {{ container_name }} container
       shell:
         cmd: "docker container inspect --format '{{ '{{' }} .State.Running {{ '}}' }}' {{ container_name }}"

--- a/etc/kayobe/ansible/rabbitmq-reset.yml
+++ b/etc/kayobe/ansible/rabbitmq-reset.yml
@@ -29,20 +29,20 @@
       delay: 6
 
     - name: Wait for the rabbitmq node to automatically start on container start
-      command: "docker exec -it {{ container_name }} /bin/bash -c 'rabbitmqctl wait /var/lib/rabbitmq/mnesia/rabbitmq.pid --timeout 60'"
+      command: "docker exec {{ container_name }} /bin/bash -c 'rabbitmqctl wait /var/lib/rabbitmq/mnesia/rabbitmq.pid --timeout 60'"
       when: inspection.stdout == 'false'
 
     - name: Stop app
-      command: "docker exec -it {{ container_name }} /bin/bash -c 'rabbitmqctl stop_app'"
+      command: "docker exec {{ container_name }} /bin/bash -c 'rabbitmqctl stop_app'"
 
     - name: Force reset app
-      command: "docker exec -it {{ container_name }} /bin/bash -c 'rabbitmqctl force_reset'"
+      command: "docker exec {{ container_name }} /bin/bash -c 'rabbitmqctl force_reset'"
 
     - name: Start app
-      command: "docker exec -it {{ container_name }} /bin/bash -c 'rabbitmqctl start_app'"
+      command: "docker exec {{ container_name }} /bin/bash -c 'rabbitmqctl start_app'"
 
     - name: Wait for all nodes to join the cluster
-      command: "docker exec -it {{ container_name }} /bin/bash -c 'rabbitmqctl await_online_nodes {{ groups['controllers'] | length }}'"
+      command: "docker exec {{ container_name }} /bin/bash -c 'rabbitmqctl await_online_nodes {{ groups['controllers'] | length }}'"
 
 - name: Restart OpenStack services
   hosts: controllers:compute

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -221,6 +221,27 @@ kolla_build_blocks:
                -e 's/^[# ]*\(baseurl *=.*\)/#\1/g' \
                -e '/#baseurl.*/a baseurl={{ repo.url }}' /etc/yum.repos.d/{{ repo.file }}{% if not loop.last %} &&{% endif %} \
     {% endfor %}
+  # NOTE: The Open vSwitch and OVN packages in Ubuntu Wallaby UCA repository
+  # are quite old - 2.15 and 20.12 respectively. Pull in these packages from
+  # the Yoga UCA, which are 2.17 and 22.03, to more closely match the CentOS
+  # packages.
+  base_debian_after_sources_list: |
+    RUN echo "\
+    deb http://ubuntu-cloud.archive.canonical.com/ubuntu focal-updates/yoga main"\
+    > /etc/apt/sources.list.d/uca-yoga.list
+    RUN echo "\
+    Package: *\n\
+    Pin: release focal-updates/yoga\n\
+    Pin-Priority: -1\n\
+    \n\
+    Package: ovn*\n\
+    Pin: release focal-updates/yoga\n\
+    Pin-Priority: 500\n\
+    \n\
+    Package: openvswitch* python3-openvswitch\n\
+    Pin: release focal-updates/yoga\n\
+    Pin-Priority: 500"\
+    > /etc/apt/preferences.d/uca-yoga
   # NOTE: Not currently syncing Ubuntu packages, since the on_demand mirror in
   # Ark does not work if the upstream mirror pulls packages (which it does
   # sometimes).

--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -7,4 +7,5 @@ docker_yum_gpgkey: "https://download.docker.com/linux/centos/gpg"
 bifrost_tag: wallaby-20220921T100954
 {% else %}
 bifrost_tag: wallaby-20220825T112231
+cloudkitty_tag: wallaby-20221215T220154
 {% endif %}


### PR DESCRIPTION
- Ubuntu: bump OVS and OVN packages
- Don't use interactive docker cmds in rabbitmq-reset.yml
- Fail if the controller clocks are not synced
- Bump cloudkitty tag
