### PR TITLE
Ubuntu: bump OVN & Open vSwitch packages

### DIFF
--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -8,4 +8,11 @@ bifrost_tag: wallaby-20220921T100954
 {% else %}
 bifrost_tag: wallaby-20220825T112231
 cloudkitty_tag: wallaby-20221215T220154
+kolla_toolbox_tag: wallaby-20221222T161624
+neutron_tag: wallaby-20221222T161624
+neutron_tls_proxy_tag: "{% raw %}{{ openstack_tag }}{% endraw %}"
+nova_tag: wallaby-20221222T161624
+octavia_tag: wallaby-20221222T161624
+openvswitch_tag: wallaby-20221222T161624
+ovn_tag: wallaby-20221222T161624
 {% endif %}

--- a/releasenotes/notes/ubuntu-bump-ovn-ovs-ed99bcac9f8bd7ca.yaml
+++ b/releasenotes/notes/ubuntu-bump-ovn-ovs-ed99bcac9f8bd7ca.yaml
@@ -1,0 +1,12 @@
+---
+features:
+  - |
+    Update Open vSwitch to 2.17 and OVN to 22.03 in Ubuntu images. This affects
+    the following services:
+
+    * kolla-toolbox
+    * neutron
+    * nova
+    * octavia
+    * openvswitch
+    * ovn


### PR DESCRIPTION
The Open vSwitch and OVN packages in Ubuntu Wallaby UCA repository are
quite old - 2.15 and 20.12 respectively. Pull in these packages from the
Yoga UCA, which are 2.17 and 22.03, to more closely match the CentOS
packages.

This change uses newly built containers with these packages.
