### PR TITLE
Fix ubuntu overcloud dib image

### DIFF
--- a/etc/kayobe/stackhpc-overcloud-dib.yml
+++ b/etc/kayobe/stackhpc-overcloud-dib.yml
@@ -58,6 +58,8 @@ stackhpc_overcloud_dib_env_vars:
 stackhpc_overcloud_dib_packages:
   - "logrotate"
   - "net-tools"
+  - "{% if os_distribution == 'ubuntu' %}netbase{% endif %}"
+  - "{% if os_distribution == 'ubuntu' %}iputils-ping{% endif %}"
 
 # StackHPC overcloud DIB image block device configuration.
 # This image layout conforms to the CIS partition benchmarks.


### PR DESCRIPTION
current Ubuntu image does not have netbase package, which is responsible for generating /etc/hosts for instance.
ping is also a useful tool.