### PR TITLE
Fix SMART bug where old metrics wouldn't be overwritten

### DIFF
--- a/etc/kayobe/ansible/scripts/smartmon.sh
+++ b/etc/kayobe/ansible/scripts/smartmon.sh
@@ -115,7 +115,7 @@ parse_smartctl_info() {
     case "${info_type}" in
     Model_Family) model_family="${info_value}" ;;
     Device_Model) device_model="${info_value}" ;;
-    Serial_Number) serial_number="${info_value}" ;;
+    Serial_Number) serial_number="$(echo ${info_value} | tr '[:upper:]' '[:lower:]')" ;;
     Firmware_Version) fw_version="${info_value}" ;;
     Vendor) vendor="${info_value}" ;;
     Product) product="${info_value}" ;;

--- a/etc/kayobe/ansible/smartmon-tools.yml
+++ b/etc/kayobe/ansible/smartmon-tools.yml
@@ -36,7 +36,7 @@
         name: "SMART metrics for drive monitoring using {{ item }}"
         user: root
         minute: "*/5"
-        job: "/usr/local/bin/{{ item }}.sh > /var/lib/docker/volumes/textfile/_data/{{ item }}.prom.temp && mv /var/lib/docker/volumes/textfile/_data/{{ item }}.prom.temp /var/lib/docker/volumes/textfile/_data/{{ item }}.prom"
+        job: "/usr/local/bin/{{ item }}.sh > /var/lib/docker/volumes/textfile/_data/{{ item }}.prom.temp && mv -f /var/lib/docker/volumes/textfile/_data/{{ item }}.prom.temp /var/lib/docker/volumes/textfile/_data/{{ item }}.prom"
       loop:
         - smartmon
         - nvmemon


### PR DESCRIPTION
The mv command wasnt overwriting the textcollector file. mv -f is now being used

Additionally, serial numbers are now all lowercase