### PR TITLE
CI: Pin Rocky8 to an older image

### DIFF
--- a/.github/workflows/stackhpc-pull-request.yml
+++ b/.github/workflows/stackhpc-pull-request.yml
@@ -72,7 +72,9 @@ jobs:
       kayobe_image: ${{ needs.build-kayobe-image.outputs.kayobe_image }}
       os_distribution: rocky
       neutron_plugin: ovs
-      vm_image: Rocky8
+      # NOTE: The current SMS lab Rocky8 image has moved ahead of our release
+      # train snapshots, causing failures installing some packages.
+      vm_image: Rocky8-2022-11-08
       vm_interface: ens3
       OS_CLOUD: sms-lab-release
     secrets: inherit
@@ -87,7 +89,9 @@ jobs:
       kayobe_image: ${{ needs.build-kayobe-image.outputs.kayobe_image }}
       os_distribution: rocky
       neutron_plugin: ovn
-      vm_image: Rocky8
+      # NOTE: The current SMS lab Rocky8 image has moved ahead of our release
+      # train snapshots, causing failures installing some packages.
+      vm_image: Rocky8-2022-11-08
       vm_interface: ens3
       OS_CLOUD: sms-lab-release
     secrets: inherit


### PR DESCRIPTION
The current SMS lab Rocky8 image has moved ahead of our release train
snapshots, causing failures installing some packages.

  TASK [stackhpc.libvirt-host : Ensure libvirt packages are installed] ***********
  FAILED - RETRYING: Ensure libvirt packages are installed (3 retries left).
  FAILED - RETRYING: Ensure libvirt packages are installed (2 retries left).
  FAILED - RETRYING: Ensure libvirt packages are installed (1 retries left).
  fatal: [controller0]: FAILED! =>
    {"attempts": 3, "changed": false,
     "msg": "Failed to download packages: libverto-0.3.0-5.el8.x86_64: Cannot download, all mirrors were already tried without success",
     "results": []}
