### PR TITLE
xena: wallaby merge

### DIFF
--- a/.github/workflows/stackhpc-pull-request.yml
+++ b/.github/workflows/stackhpc-pull-request.yml
@@ -72,7 +72,9 @@ jobs:
       kayobe_image: ${{ needs.build-kayobe-image.outputs.kayobe_image }}
       os_distribution: rocky
       neutron_plugin: ovs
-      vm_image: Rocky8
+      # NOTE: The current SMS lab Rocky8 image has moved ahead of our release
+      # train snapshots, causing failures installing some packages.
+      vm_image: Rocky8-2022-11-08
       vm_interface: ens3
       OS_CLOUD: sms-lab-release
     secrets: inherit
@@ -87,7 +89,9 @@ jobs:
       kayobe_image: ${{ needs.build-kayobe-image.outputs.kayobe_image }}
       os_distribution: rocky
       neutron_plugin: ovn
-      vm_image: Rocky8
+      # NOTE: The current SMS lab Rocky8 image has moved ahead of our release
+      # train snapshots, causing failures installing some packages.
+      vm_image: Rocky8-2022-11-08
       vm_interface: ens3
       OS_CLOUD: sms-lab-release
     secrets: inherit

--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -11,6 +11,13 @@ enable_docker_repo: {% raw %}"{{ 'overcloud' not in group_names or ansible_facts
 bifrost_tag: xena-20221128T101757
 {% else %}
 bifrost_tag: xena-20221213T224057
+kolla_toolbox_tag: xena-20230104T145414
+neutron_tag: xena-20230104T145414
+neutron_tls_proxy_tag: "{% raw %}{{ openstack_tag }}{% endraw %}"
+nova_tag: xena-20230104T145414
+octavia_tag: xena-20230104T145414
+openvswitch_tag: xena-20230104T145414
+ovn_tag: xena-20230104T145414
 {% endif %}
 
 #############################################################################

--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -8,4 +8,11 @@ bifrost_tag: wallaby-20220921T100954
 {% else %}
 bifrost_tag: wallaby-20220825T112231
 cloudkitty_tag: wallaby-20221215T220154
+kolla_toolbox_tag: wallaby-20221222T161624
+neutron_tag: wallaby-20221222T161624
+neutron_tls_proxy_tag: "{% raw %}{{ openstack_tag }}{% endraw %}"
+nova_tag: wallaby-20221222T161624
+octavia_tag: wallaby-20221222T161624
+openvswitch_tag: wallaby-20221222T161624
+ovn_tag: wallaby-20221222T161624
 {% endif %}

--- a/releasenotes/notes/ubuntu-bump-ovn-ovs-ed99bcac9f8bd7ca.yaml
+++ b/releasenotes/notes/ubuntu-bump-ovn-ovs-ed99bcac9f8bd7ca.yaml
@@ -1,0 +1,12 @@
+---
+features:
+  - |
+    Update Open vSwitch to 2.17 and OVN to 22.03 in Ubuntu images. This affects
+    the following services:
+
+    * kolla-toolbox
+    * neutron
+    * nova
+    * octavia
+    * openvswitch
+    * ovn


### PR DESCRIPTION
- Ubuntu: bump OVN & Open vSwitch packages
- CI: Pin Rocky8 to an older image
- Ubuntu: bump OVN & Open vSwitch packages
