### PR TITLE
Patch edk2-ovmf file to fix UEFI support

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -275,6 +275,14 @@ kolla_build_blocks:
     ARG mysqld_exporter_version='0.13.0'
   prometheus_blackbox_exporter_repository_version: |
     ARG blackbox_exporter_version='0.19.0'
+  nova_base_footer: |
+    # Fix for https://bugs.launchpad.net/nova/+bug/1955035, i.e.
+    # https://bugzilla.redhat.com/show_bug.cgi?id=2090752 on c8s
+    {% raw %}
+    {% if base_package_type == 'rpm' %}
+    RUN sed -i 's/"pc-q35-rhel8.5.0"/"pc-q35-*"/' /usr/share/qemu/firmware/50-edk2-ovmf-cc.json
+    {% endif %}
+    {% endraw %}
 
 kolla_build_customizations_common:
   bifrost_base_pip_packages_append:


### PR DESCRIPTION
The file 50-edk2-ovmf-cc.json is used by Nova in get_loader() when lauching UEFI instances without Secure Boot.

It only supports machine type pc-q35-rhel8.5.0. However, with recent nova-compute container images built on CentOS Stream 8, the machine type is pc-q35-rhel8.6.0, which results in failures to launch instances with:

    nova.exception.UEFINotSupported: UEFI is not supported

There is a fix for RHEL9/c9s [1], but not for RHEL8/c8s. Also see [2] for more details.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=2090752
[2] https://bugs.launchpad.net/nova/+bug/1955035