### PR TITLE
CI: Workaround container image builder power cycle issue

### DIFF
--- a/.github/workflows/stackhpc-container-image-build.yml
+++ b/.github/workflows/stackhpc-container-image-build.yml
@@ -66,6 +66,14 @@ jobs:
           sudo ip l set dummy1 up
           sudo ip l set dummy1 master breth1
 
+      # FIXME: Without this workaround we see the following issue after the runner is power cycled:
+      # TASK [MichaelRigart.interfaces : RedHat | ensure network service is started and enabled] ***
+      #   Unable to start service network: Job for network.service failed because the control process exited with error code.
+      #   See \"systemctl status network.service\" and \"journalctl -xe\" for details.
+      - name: Kill dhclient (workaround)
+        run: |
+          (sudo killall dhclient || true) && sudo systemctl restart network
+
       - name: Install Kayobe
         run: |
           mkdir -p venvs &&


### PR DESCRIPTION
While not pretty, this workaround avoids manual intervention after the
runner is power cycled.
