### PR TITLE
Update the hardware overview dashboard

### DIFF
--- a/etc/kayobe/kolla/config/grafana/dashboards/openstack/hardware_overview.json
+++ b/etc/kayobe/kolla/config/grafana/dashboards/openstack/hardware_overview.json
@@ -25,6 +25,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
+  "id": 1935501,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -251,23 +252,7 @@
             "filterable": false,
             "inspect": false
           },
-          "mappings": [
-            {
-              "options": {
-                "0": {
-                  "color": "red",
-                  "index": 1,
-                  "text": "Failed"
-                },
-                "1": {
-                  "color": "dark-green",
-                  "index": 0,
-                  "text": "Ok"
-                }
-              },
-              "type": "value"
-            }
-          ],
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -306,7 +291,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "Value"
+              "options": "Value #Health"
             },
             "properties": [
               {
@@ -315,13 +300,37 @@
               },
               {
                 "id": "custom.width"
+              },
+              {
+                "id": "displayName",
+                "value": "Health"
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "red",
+                        "index": 1,
+                        "text": "Bad"
+                      },
+                      "1": {
+                        "color": "green",
+                        "index": 0,
+                        "text": "Ok"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
               }
             ]
           },
           {
             "matcher": {
               "id": "byName",
-              "options": "type"
+              "options": "type 1"
             },
             "properties": [
               {
@@ -353,7 +362,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "Time"
+              "options": "Time 1"
             },
             "properties": [
               {
@@ -365,7 +374,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "disk"
+              "options": "disk 1"
             },
             "properties": [
               {
@@ -381,7 +390,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "instance"
+              "options": "instance 1"
             },
             "properties": [
               {
@@ -391,28 +400,6 @@
               {
                 "id": "displayName",
                 "value": "Hostname"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Type"
-            },
-            "properties": [
-              {
-                "id": "custom.width"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Serial Number"
-            },
-            "properties": [
-              {
-                "id": "custom.width"
               }
             ]
           },
@@ -430,11 +417,60 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "Disk"
+              "options": "group 1"
             },
             "properties": [
               {
-                "id": "custom.width"
+                "id": "displayName",
+                "value": "Group"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "smart_id"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".* 2"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value #Temp"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Temperature"
+              },
+              {
+                "id": "unit",
+                "value": "celsius"
+              },
+              {
+                "id": "noValue",
+                "value": "-"
+              },
+              {
+                "id": "custom.displayMode",
+                "value": "color-text"
               }
             ]
           }
@@ -442,7 +478,7 @@
       },
       "gridPos": {
         "h": 13,
-        "w": 18,
+        "w": 20,
         "x": 0,
         "y": 7
       },
@@ -455,6 +491,7 @@
           ],
           "show": false
         },
+        "frameIndex": 1,
         "showHeader": true,
         "sortBy": []
       },
@@ -481,13 +518,64 @@
           "interval": "",
           "legendFormat": "",
           "range": false,
-          "refId": "A",
+          "refId": "Health",
           "units": "none",
           "valueHandler": "Number Threshold",
           "warn": 0
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "smartmon_temperature_case_raw_value",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "range": false,
+          "refId": "Temp"
         }
       ],
-      "title": "Panel Title",
+      "title": "SMART Info",
+      "transformations": [
+        {
+          "id": "seriesToColumns",
+          "options": {
+            "byField": "serial_number"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {
+              "Time 1": 3,
+              "Time 2": 10,
+              "Value #Health": 8,
+              "Value #Temp": 9,
+              "__name__ 1": 4,
+              "__name__ 2": 11,
+              "disk 1": 5,
+              "disk 2": 12,
+              "group 1": 0,
+              "group 2": 13,
+              "instance 1": 1,
+              "instance 2": 14,
+              "job 1": 6,
+              "job 2": 15,
+              "serial_number": 7,
+              "smart_id": 16,
+              "type 1": 2,
+              "type 2": 17
+            },
+            "renameByName": {}
+          }
+        }
+      ],
       "transparent": true,
       "type": "table"
     }
@@ -511,7 +599,7 @@
       },
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "Prometheus",
           "value": "Prometheus"
         },
@@ -537,7 +625,7 @@
   "timezone": "",
   "title": "Hardware Overview",
   "uid": "TCN51Y25P",
-  "version": 1,
+  "version": 3,
   "weekStart": ""
 }
 {% endraw %}

--- a/etc/kayobe/kolla/config/grafana/dashboards/openstack/hardware_overview.json
+++ b/etc/kayobe/kolla/config/grafana/dashboards/openstack/hardware_overview.json
@@ -84,7 +84,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "count(smartmon_device_smart_healthy > 0)",
+          "expr": "count(smartmon_device_smart_healthy{instance=~\"$node\"} > 0 )",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -157,7 +157,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "count(smartmon_device_smart_healthy < 1) ",
+          "expr": "count(smartmon_device_smart_healthy{instance=~\"$node\"} < 1) ",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -225,7 +225,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "count(smartmon_device_smart_healthy)",
+          "expr": "count(smartmon_device_smart_healthy{instance=~\"$node\"})",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -477,7 +477,7 @@
         ]
       },
       "gridPos": {
-        "h": 13,
+        "h": 10,
         "w": 20,
         "x": 0,
         "y": 7
@@ -512,7 +512,7 @@
           "displayValueWithAlias": "Never",
           "editorMode": "code",
           "exemplar": false,
-          "expr": "smartmon_device_smart_healthy",
+          "expr": "smartmon_device_smart_healthy{instance=~\"$node\"}",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -530,7 +530,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "smartmon_temperature_case_raw_value",
+          "expr": "smartmon_temperature_case_raw_value{instance=~\"$node\"}",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -578,6 +578,102 @@
       ],
       "transparent": true,
       "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Temperature (°C)",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 20,
+        "x": 0,
+        "y": 17
+      },
+      "hideTimeOverride": false,
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "avg_over_time(smartmon_temperature_case_raw_value{instance=~\"$node\"}[1h])",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{instance}} - {{disk}} - {{serial_number}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Disk Temperatures",
+      "type": "timeseries"
     }
   ],
   "refresh": false,
@@ -599,7 +695,7 @@
       },
       {
         "current": {
-          "selected": false,
+          "selected": true,
           "text": "Prometheus",
           "value": "Prometheus"
         },
@@ -614,18 +710,46 @@
         "regex": "",
         "skipUrlSync": false,
         "type": "datasource"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(node_cpu_seconds_total{job=\"node\"}, instance)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Host:",
+        "multi": false,
+        "name": "node",
+        "options": [],
+        "query": {
+          "query": "label_values(node_cpu_seconds_total{job=\"node\"}, instance)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
       }
     ]
   },
   "time": {
-    "from": "now-1h",
+    "from": "now-24h",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "Hardware Overview",
   "uid": "TCN51Y25P",
-  "version": 3,
+  "version": 5,
   "weekStart": ""
 }
 {% endraw %}

--- a/releasenotes/notes/feature-smartmon-65cacfe893f0eb47.yaml
+++ b/releasenotes/notes/feature-smartmon-65cacfe893f0eb47.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Adds drive temperatures to the table on the hardware overview dashboard
+    and a timeseries to show the temperature over time.
+  - |
+    Adds picker to hardware overview dashboard to select a specific host to 
+    show drive information for.


### PR DESCRIPTION
Adds the temperature of drives as a column to the table.
Adds a timeseries to track the history of the temperature.
Introduces a variable dropdown picker for nodes so that only information about disks on a specific node is shown.