### PR TITLE
Wallaby: Fixes for OSSA-2023-002

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -123,10 +123,18 @@ kolla_sources:
     type: git
     location: https://github.com/stackhpc/stackhpc-inspector-plugins.git
     reference: 1.3.0
+  cinder-base:
+    type: git
+    location: https://github.com/stackhpc/cinder.git
+    reference: stackhpc/{{ openstack_release }}
   cloudkitty-base:
     type: git
     location: https://github.com/stackhpc/cloudkitty.git
     reference: stackhpc/wallaby
+  glance-base:
+    type: git
+    location: https://github.com/stackhpc/glance.git
+    reference: stackhpc/{{ openstack_release }}
   horizon-plugin-cloudkitty-dashboard:
     type: git
     location: https://github.com/stackhpc/cloudkitty-dashboard.git
@@ -144,6 +152,10 @@ kolla_sources:
     type: git
     location: https://github.com/stackhpc/networking-generic-switch.git
     reference: stackhpc/wallaby
+  nova-base:
+    type: git
+    location: https://github.com/stackhpc/nova.git
+    reference: stackhpc/{{ openstack_release }}
 
 ###############################################################################
 # Kolla image build configuration.

--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -5,17 +5,21 @@ docker_yum_gpgkey: "https://download.docker.com/linux/centos/gpg"
 
 {% if kolla_base_distro == 'centos' %}
 bifrost_tag: wallaby-20220921T100954
+cinder_tag: wallaby-20230125T101644
+glance_tag: wallaby-20230125T101644
 magnum_tag: wallaby-20230111T101726
-nova_tag: wallaby-20230119T093225
+nova_tag: wallaby-20230125T101644
 rabbitmq_tag: wallaby-20221205T160115
 {% else %}
 bifrost_tag: wallaby-20220825T112231
+cinder_tag: wallaby-20230125T132411
 cloudkitty_tag: wallaby-20221215T220154
+glance_tag: wallaby-20230125T132411
 kolla_toolbox_tag: wallaby-20221222T161624
 magnum_tag: wallaby-20230111T103759
 neutron_tag: wallaby-20221222T161624
 neutron_tls_proxy_tag: "{% raw %}{{ openstack_tag }}{% endraw %}"
-nova_tag: wallaby-20221222T161624
+nova_tag: wallaby-20230125T132411
 octavia_tag: wallaby-20221222T161624
 openvswitch_tag: wallaby-20221222T161624
 ovn_tag: wallaby-20221222T161624


### PR DESCRIPTION
Updates cinder, glance and nova images with fixes for 

https://security.openstack.org/ossa/OSSA-2023-002.html
