### PR TITLE
Add timing information to tasks

### DIFF
--- a/etc/kayobe/ansible.cfg
+++ b/etc/kayobe/ansible.cfg
@@ -6,6 +6,8 @@ stdout_callback = yaml
 bin_ansible_callbacks = True
 # Disable fact variable injection to improve performance.
 inject_facts_as_vars = False
+# Add timing information to output
+callback_whitelist = ansible.posix.profile_tasks
 
 [ssh_connection]
 pipelining = True

--- a/releasenotes/notes/ansible-profile-tasks-3d341727a39dadcb.yaml
+++ b/releasenotes/notes/ansible-profile-tasks-3d341727a39dadcb.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Adds time information to tasks using the `ansible.posix.profile_tasks`
+    callback.


### PR DESCRIPTION
Add ansible.posix.profile_tasks to callback_whitelist, which enables the output of task timing information when running `kayobe` commands.