### PR TITLE
Wallaby: CI: update community actions

### DIFF
--- a/.github/workflows/stackhpc-all-in-one.yml
+++ b/.github/workflows/stackhpc-all-in-one.yml
@@ -64,12 +64,12 @@ jobs:
       KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
       KAYOBE_IMAGE: ${{ inputs.kayobe_image }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
            submodules: true
 
       - name: Install terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v2
 
       - name: Initialise terraform
         run: terraform init

--- a/.github/workflows/stackhpc-all-in-one.yml
+++ b/.github/workflows/stackhpc-all-in-one.yml
@@ -167,16 +167,14 @@ jobs:
           ENABLE_OVN: ${{ inputs.neutron_plugin == 'ovn' }}
           OS_DISTRIBUTION: ${{ inputs.os_distribution }}
 
-      # https://renehernandez.io/snippets/multiline-strings-as-a-job-output-in-github-actions/
+      # Use a heredoc to define a multiline string output
+      # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
       - name: Set SSH key output
         id: ssh_key
         run: |
-          ssh_key="$(cat terraform/aio/id_rsa)"
-          ssh_key="${ssh_key//'%'/'%25'}"
-          ssh_key="${ssh_key//$'\n'/'%0A'}"
-          ssh_key="${ssh_key//$'\r'/'%0D'}"
-          echo "::add-mask::$ssh_key"
-          echo "ssh_key=$ssh_key" >> $GITHUB_OUTPUT
+          echo "ssh_key<<EOF" >> $GITHUB_OUTPUT
+          cat terraform/aio/id_rsa >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
 
       # The same tag may be reused (e.g. pr-123), so ensure we have the latest image.
       - name: Pull latest Kayobe image

--- a/.github/workflows/stackhpc-all-in-one.yml
+++ b/.github/workflows/stackhpc-all-in-one.yml
@@ -176,7 +176,7 @@ jobs:
           ssh_key="${ssh_key//$'\n'/'%0A'}"
           ssh_key="${ssh_key//$'\r'/'%0D'}"
           echo "::add-mask::$ssh_key"
-          echo "::set-output name=ssh_key::$ssh_key"
+          echo "ssh_key=$ssh_key" >> $GITHUB_OUTPUT
 
       # The same tag may be reused (e.g. pr-123), so ensure we have the latest image.
       - name: Pull latest Kayobe image

--- a/.github/workflows/stackhpc-build-kayobe-image.yml
+++ b/.github/workflows/stackhpc-build-kayobe-image.yml
@@ -37,12 +37,12 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout kayobe config
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
            submodules: true
 
       - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -50,7 +50,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 

--- a/.github/workflows/stackhpc-pull-request.yml
+++ b/.github/workflows/stackhpc-pull-request.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup Python ${{ matrix.python-version }} 🐍
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Tox 📦


### PR DESCRIPTION
- CI: Update versions used of community GitHub Actions
- Stop using deprecated set-output command in workflows
