### PR TITLE
Generate pulp package versions

### DIFF
--- a/etc/kayobe/ansible/pulp-package-versions.yml
+++ b/etc/kayobe/ansible/pulp-package-versions.yml
@@ -1,0 +1,13 @@
+---
+
+- hosts: localhost
+  vars:
+    # Stop ansible blowing up
+    os_distribution:
+  tasks:
+    - include_role:
+        name: pulp-packages
+      vars:
+        pulp_packages_repo_definition: "{{ item }}"
+      loop: "{{ stackhpc_pulp_repository_rpm_repos }}"
+

--- a/etc/kayobe/ansible/roles/pulp-packages/defaults/main.yml
+++ b/etc/kayobe/ansible/roles/pulp-packages/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+
+pulp_packages_repo_defintion: {}
+pulp_packages_output_path: /tmp/pulp-packages

--- a/etc/kayobe/ansible/roles/pulp-packages/files/get-packages.py
+++ b/etc/kayobe/ansible/roles/pulp-packages/files/get-packages.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+import argparse
+import subprocess
+from shlex import split as sh
+import sys
+import json
+from urllib.parse import urlsplit, ParseResult
+
+def run(cmd):
+  print(f"Running cmd: {cmd}", file=sys.stderr)
+  stdout = subprocess.check_output(sh(cmd))
+  return json.loads(stdout)
+
+def page(href):
+   page = run(f"pulp show --href '{href}'")
+   next = page["next"]
+   results = page["results"]
+   while next != None:
+     parsed = urlsplit(page["next"])
+     href = parsed._replace(scheme="")._replace(netloc="").geturl()
+     page = run(f"pulp show --href '{href}'")
+     next = page["next"]
+     results.extend(page["results"])
+   return results
+
+if __name__ == "__main__":
+
+  parser = argparse.ArgumentParser(description='Package versions')
+  parser.add_argument('base_path', metavar='path', type=str,
+			    help='Base path of distribution')
+  args = parser.parse_args()
+  base_path = args.base_path
+  distributions = run(f"pulp rpm distribution list --base-path '{ args.base_path }'")
+  if not distributions:
+     raise ValueError("No distribution found")
+  if len(distributions) > 1:
+     raise ValueError("Found more than on distribution")
+  distribution = distributions[0]
+  publication_href = distribution['publication']
+  publication = run(f"pulp rpm publication show --href '{ publication_href }'")
+  if not publication:
+    raise ValueError("publication not found")
+  repository_version = publication["repository_version"]
+  packages = page(f"pulp/api/v3/content/rpm/packages/?repository_version={repository_version}&fields=name,version,release,arch&limit=1000")
+  packages = sorted(packages, key=lambda xs: xs['name']) 
+  print(json.dumps(packages, indent=2))
+

--- a/etc/kayobe/ansible/roles/pulp-packages/tasks/main.yml
+++ b/etc/kayobe/ansible/roles/pulp-packages/tasks/main.yml
@@ -1,0 +1,31 @@
+---
+
+- name: Set fact containing version
+  set_fact:
+    pulp_packages_repo_version: "{{ pulp_packages_repo_definition.url.split('/')[-1] }}"
+    pulp_packages_relative_url: "{{ pulp_packages_repo_definition.url.replace(stackhpc_release_pulp_content_url ,'')[1:] }}"
+
+- name: Ensure output directory exists
+  file:
+    state: directory
+    path: "{{ pulp_packages_output_path }}/{{ pulp_packages_relative_url }}"
+
+- debug:
+    msg: "{{ pulp_packages_repo_version }}"
+
+- debug:
+    msg: "{{ pulp_packages_relative_url }}"
+
+- name: Get package versions
+  script: get-packages.py {{ pulp_packages_relative_url }}
+  vars:
+    ansible_connection: local
+  register: versions_result
+  changed_when: false
+
+- name: Write packages to file
+  vars:
+    variable: "{{ versions_result.stdout | from_json | to_nice_json }}"
+  template:
+   src: "variable.j2"
+   dest: "{{ pulp_packages_output_path }}/{{ pulp_packages_relative_url }}/packages.json"

--- a/etc/kayobe/ansible/roles/pulp-packages/templates/variable.j2
+++ b/etc/kayobe/ansible/roles/pulp-packages/templates/variable.j2
@@ -1,0 +1,2 @@
+#jinja2: trim_blocks:False
+{{ variable }}


### PR DESCRIPTION
This is used to generate: https://github.com/stackhpc/stackhpc-release-train-package-versions. Instructions:

- Login to test pulp with:

```
(venv-pulp) [cloud-user@will-control-host-0 ~]$ pulp config create --username admin --base-url http://10.205.3.187:8080 --password <> --overwrite
```
- Run playbook. The default output is to /tmp/pulp-packages.

