### PR TITLE
Use stricter permissions for Pulp TLS cert and key

### DIFF
--- a/etc/kayobe/containers/pulp/pre.yml
+++ b/etc/kayobe/containers/pulp/pre.yml
@@ -33,7 +33,7 @@
       template:
         src: "{{ item.src }}"
         dest: "/opt/kayobe/containers/pulp/certs/{{ item.dest }}"
-        mode: 0644
+        mode: 0600
       become: true
       loop:
         - src: "{{ pulp_cert_path }}"


### PR DESCRIPTION
Pulp runs as root inside its container. It has no problem reading files with 0600 permissions. There is no reason use 0644, especially for the key which is readable by any user on the seed.