### PR TITLE
Add 2m wait to some blackbox rules

### DIFF
--- a/etc/kayobe/kolla/config/prometheus/blackbox.rules
+++ b/etc/kayobe/kolla/config/prometheus/blackbox.rules
@@ -7,7 +7,7 @@ groups:
   rules:
   - alert: BlackboxProbeFailed
     expr: probe_success == 0
-    for: 0m
+    for: 2m
     labels:
       severity: critical
     annotations:
@@ -25,12 +25,12 @@ groups:
 
   - alert: BlackboxProbeHttpFailure
     expr: probe_http_status_code <= 199 OR probe_http_status_code >= 400
-    for: 0m
+    for: 2m
     labels:
       severity: critical
     annotations:
       summary: Blackbox probe HTTP failure (instance {{ $labels.instance }})
-      description: "HTTP status code is not 200-399"
+      description: "HTTP status code is not 200-399. Blackbox exporter got status code: {{ $value }}"
 
   - alert: BlackboxSslCertificateWillExpireSoon
     expr: probe_ssl_earliest_cert_expiry - time() < 86400 * 30


### PR DESCRIPTION
Adds a 2m wait to some blackbox rules to allow for temporary DNS failures to resolve. This also should stop false positives in the case of a probe timeout that gets resolved by the next probe. Also shows the status code on probe http failures.

