### PR TITLE
fix: task would fail to delegate and run on host

### DIFF
--- a/etc/kayobe/ansible/nova-compute-drain.yml
+++ b/etc/kayobe/ansible/nova-compute-drain.yml
@@ -17,6 +17,8 @@
         extra_args: "{% if pip_upper_constraints_file %}-c {{ pip_upper_constraints_file }}{% endif %}"
       run_once: true
       delegate_to: "{{ groups['controllers'][0] }}"
+      vars:
+        ansible_host: "{{ hostvars[groups['controllers'][0]].ansible_host }}"
 
     - block:
         - name: Query instances


### PR DESCRIPTION
When attempting to run `nova-compute-drain` the task would fail to delegate to the controller and instead run on the hypervisor. This is an issue as the hypervisor is missing required libraries.

Related to how kayobe sets `ansible_host`.