### PR TITLE
Fix default when ANSIBLE_SERIAL not set

### DIFF
--- a/etc/kayobe/ansible/reboot.yml
+++ b/etc/kayobe/ansible/reboot.yml
@@ -1,7 +1,7 @@
 ---
 - name: Reboot the host
   hosts: seed-hypervisor:seed:overcloud:infra-vms
-  serial: "{{ lookup('env', 'ANSIBLE_SERIAL') | default(0) }}"
+  serial: "{{ lookup('env', 'ANSIBLE_SERIAL') | default(0, true) }}"
   tags:
     - reboot
   tasks:


### PR DESCRIPTION
You will see:

```
ERROR! Unexpected Exception, this is probably a bug: invalid literal for int() with base 10: ''
```

This is because the default filter only works on undefined variables and the lookup returns an empty string. We can use the boolean parameter on the default filter, see:

https://jinja.palletsprojects.com/en/3.1.x/templates/#jinja-filters.default