### PR TITLE
Adding overcloud host image sources

### DIFF
--- a/etc/kayobe/kolla/config/bifrost/bifrost.yml
+++ b/etc/kayobe/kolla/config/bifrost/bifrost.yml
@@ -1,0 +1,12 @@
+---
+# Use images from Ark.
+{% if stackhpc_download_overcloud_images %}
+use_cirros: true
+{% if os_distribution == 'ubuntu' %}
+cirros_deploy_image_upstream_url: "{{ stackhpc_ubuntu_overcloud_host_image_url }}"
+{% elif os_distribution == 'rocky' %}
+cirros_deploy_image_upstream_url: "{{ stackhpc_rocky_overcloud_host_image_url }}"
+{% else %}
+cirros_deploy_image_upstream_url: "{{ stackhpc_centos_overcloud_host_image_url }}"
+{% endif %}
+{% endif %}

--- a/etc/kayobe/stackhpc.yml
+++ b/etc/kayobe/stackhpc.yml
@@ -131,6 +131,23 @@ stackhpc_kolla_ansible_source_url: "https://github.com/stackhpc/kolla-ansible"
 stackhpc_kolla_ansible_source_version: "stackhpc/{{ openstack_release }}"
 
 ###############################################################################
+# Overcloud host image source
+
+stackhpc_download_overcloud_images: false
+
+# Ubuntu overcloud host image source
+stackhpc_ubuntu_overcloud_host_image_url: "{{ stackhpc_release_pulp_content_url }}/kayobe-images/{{ openstack_release }}/ubuntu/focal/{{ stackhpc_ubuntu_overcloud_host_image }}/overcloud-ubuntu-focal.qcow2"
+stackhpc_ubuntu_overcloud_host_image_version: "latest"
+
+# Rocky overcloud host image source
+stackhpc_rocky_overcloud_host_image_url: "{{ stackhpc_release_pulp_content_url }}/kayobe-images/{{ openstack_release }}/rocky/8/{{ stackhpc_rocky_overcloud_host_image_version }}/overcloud-rocky-8.qcow2"
+stackhpc_rocky_overcloud_host_image_version: "latest"
+
+# CentOS overcloud host image source
+stackhpc_centos_overcloud_host_image_url: "{{ stackhpc_release_pulp_content_url }}/kayobe-images/{{ openstack_release }}/centos/stream-8/{{ stackhpc_centos_overcloud_host_image_version }}/overcloud-centos-stream-8.qcow2"
+stackhpc_centos_overcloud_host_image_version: "latest"
+
+###############################################################################
 # Container image registry
 
 # Host and port of container registry.


### PR DESCRIPTION
Adding Ark image sources and configuration option to use them.
They are not the default in this version but probably should be for Zed onwards