### PR TITLE
Specify unified alerting to avoid migration error

### DIFF
--- a/etc/kayobe/kolla/config/grafana.ini
+++ b/etc/kayobe/kolla/config/grafana.ini
@@ -1,0 +1,2 @@
+[unified_alerting]
+enabled = true


### PR DESCRIPTION
This error is seen, causing Grafana to fail to upgrade:

```
panic: Grafana has already been migrated to Unified Alerting.
Any alert rules created while using Unified Alerting will be deleted by rolling back.

Set force_migration=true in your grafana.ini and restart Grafana to roll back and delete Unified Alerting configuration data.
```