### PR TITLE
Bump the default worker count

### DIFF
--- a/etc/kayobe/containers/pulp/settings.py
+++ b/etc/kayobe/containers/pulp/settings.py
@@ -1,4 +1,5 @@
 CONTENT_ORIGIN='{{ pulp_url }}'
+ANALYTICS=False
 ANSIBLE_API_HOSTNAME='{{ pulp_url }}'
 ANSIBLE_CONTENT_HOSTNAME='{{ pulp_url }}/pulp/content'
 TOKEN_AUTH_DISABLED=True

--- a/etc/kayobe/seed.yml
+++ b/etc/kayobe/seed.yml
@@ -106,11 +106,14 @@ seed_pulp_container:
     image: pulp/pulp
     pre: "{{ kayobe_config_path }}/containers/pulp/pre.yml"
     post: "{{ kayobe_config_path }}/containers/pulp/post.yml"
-    tag: "{{ '3.21-https' if pulp_enable_tls | bool else '3.21' }}"
+    tag: "{{ '3.22-https' if pulp_enable_tls | bool else '3.22' }}"
     network_mode: host
     # Override deploy_containers_defaults.init == true to ensure
     # s6-overlay-suexec starts as pid 1
     init: false
+    env:
+      PULP_CONTENT_WORKERS: "{{ ansible_facts.processor_vcpus * 2 + 1 }}"
+      PULP_API_WORKERS: "{{ ansible_facts.processor_vcpus * 2 + 1 }}"
     volumes:
       - /opt/kayobe/containers/pulp:/etc/pulp
       - pulp_storage:/var/lib/pulp

--- a/releasenotes/notes/update-pulp-3.22-aa485b7e619cd380.yaml
+++ b/releasenotes/notes/update-pulp-3.22-aa485b7e619cd380.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - Upgrades Pulp from ``3.21`` to ``3.22``.
+  - Disables Pulp analytics.
+  - |
+    Sets Pulp worker based on available CPU cores. This may improve performance
+    when pulling container images to many hosts simultaneously.


### PR DESCRIPTION
Hoping this will help with the slowness when pulling container images
across multiple hosts. Credit to @m-bull for noticing the option:

https://github.com/pulp/pulp-oci-images/commit/29c29df5bf218bfed80a52316356fc0dc89d7bf1

I've bumped pulp to 3.22 so that we don't have to force pull 3.21 to get
an image with this feature enabled.