### PR TITLE
Update Openstack Dashboard

### DIFF
--- a/etc/kayobe/kolla/config/grafana/dashboards/openstack/openstack.json
+++ b/etc/kayobe/kolla/config/grafana/dashboards/openstack/openstack.json
@@ -2168,7 +2168,7 @@
                     },
                     {
                       "color": "#EAB839",
-                      "value": 300
+                      "value": 301
                     },
                     {
                       "color": "red",

--- a/releasenotes/notes/openstack-dash-ff7bf179e37c8e4b.yaml
+++ b/releasenotes/notes/openstack-dash-ff7bf179e37c8e4b.yaml
@@ -1,0 +1,5 @@
+---
+other:
+  - |
+    Changes the openstack dashboard to show http status 300 as green instead of
+    orange.

--- a/releasenotes/notes/openstack-dash-ff7bf179e37c8e4b.yaml
+++ b/releasenotes/notes/openstack-dash-ff7bf179e37c8e4b.yaml
@@ -1,5 +1,5 @@
 ---
 other:
   - |
-    Changes the openstack dashboard to show http status 300 as green instead of
+    Changes the Grafana OpenStack dashboard to show HTTP status 300 as green instead of
     orange.


### PR DESCRIPTION
Updates the Openstack dashboard to show http 300 status codes as green as this is the expected return code from some services.