### PR TITLE
Bump neutron containers to support DellOS10/trunking

### DIFF
--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -9,8 +9,10 @@ enable_docker_repo: {% raw %}"{{ 'overcloud' not in group_names or ansible_facts
 
 {% if kolla_base_distro == 'centos' %}
 bifrost_tag: xena-20230214T165534
+neutron_tag: xena-20230222T141338
 {% else %}
 bifrost_tag: xena-20230215T195824
+neutron_tag: xena-20230222T150855
 {% endif %}
 
 glance_tls_proxy_tag: "{% raw %}{{ haproxy_tag | default(openstack_tag) }}{% endraw %}"

--- a/releasenotes/notes/adds-support-for-trunk-ports-7301a258dca0c469.yaml
+++ b/releasenotes/notes/adds-support-for-trunk-ports-7301a258dca0c469.yaml
@@ -1,0 +1,14 @@
+---
+features:
+  - |
+    Updates neutron containers to contain a version of
+    networking-generic-switch with support for trunk ports when using DellOS 10
+    or Cisco switches. See this `PR
+    <https://github.com/stackhpc/networking-generic-switch/pull/53>`_ for more
+    details.
+  - |
+    Updates neutron containers to contain a version of
+    networking-generic-switch with support for DellOS 10. See this `PR
+    <https://github.com/stackhpc/networking-generic-switch/pull/51>`_ for more
+    details.
+


### PR DESCRIPTION
Brings in the following networking-generic-switch-changes:

- Adds support for DellOS10
- Adds support for trunk ports