### PR TITLE
Enable Mariabackup by default

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -555,7 +555,7 @@ kolla_enable_grafana: true
 #kolla_enable_manila_backend_generic:
 #kolla_enable_manila_backend_glusterfs_nfs:
 #kolla_enable_manila_backend_hnas:
-#kolla_enable_mariabackup:
+kolla_enable_mariabackup: True
 #kolla_enable_mariadb:
 #kolla_enable_masakari:
 #kolla_enable_memcached:

--- a/releasenotes/notes/enable-mariabackup-97834ea8d87e14a9.yaml
+++ b/releasenotes/notes/enable-mariabackup-97834ea8d87e14a9.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Mariabackup is now enabled by default.


### PR DESCRIPTION
This will make it easier to back up any StackHPC OpenStack deployment.