### PR TITLE
Bump node exporter to 1.5.0

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -362,7 +362,7 @@ kolla_build_args:
   haproxy_exporter_version: "0.13.0"
   memcached_exporter_version: "0.9.0"
   mysqld_exporter_version: "0.13.0"
-  node_exporter_version: "1.3.1"
+  node_exporter_version: "1.5.0"
   prometheus_version: "2.35.0"
   prometheus_alertmanager_version: "0.24.0"
   prometheus_cadvisor_sha256sum: "8e3df91eee70c72ac3f3184b9fab1229b037c2e850ff1593103b2bd9028c57c0"

--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -12,12 +12,14 @@ bifrost_tag: xena-20230214T165534
 blazar_tag: xena-20230315T122920
 caso_tag: xena-20230315T122920
 neutron_tag: xena-20230307T142413
+prometheus_node_exporter_tag: xena-20230310T170439
 {% else %}
 bifrost_tag: xena-20230215T195824
 blazar_tag: xena-20230315T122918
 caso_tag: xena-20230315T122918
 keystone_tag: xena-20230308T120251
 neutron_tag: xena-20230307T142414
+prometheus_node_exporter_tag: xena-20230315T164024
 {% endif %}
 
 glance_tls_proxy_tag: "{% raw %}{{ haproxy_tag | default(openstack_tag) }}{% endraw %}"

--- a/releasenotes/notes/node-exporter-1.5.0-5e3764790a5a0190.yaml
+++ b/releasenotes/notes/node-exporter-1.5.0-5e3764790a5a0190.yaml
@@ -1,0 +1,9 @@
+---
+features:
+  - |
+    Updates Prometheus Node exporter to version 1.5.0.
+fixes:
+  - |
+    Fixes a `Prometheus Node exporter crash
+    <https://github.com/prometheus/node_exporter/issues/2299>`__ which may
+    affect nodes with AMD processors (first seen on HPE DL385).


### PR DESCRIPTION
This fixes a crash seen on HPE DL385 nodes [1]:

    panic: "node_rapl_package-0-die-0_joules_total" is not a valid metric name

[1] https://github.com/prometheus/node_exporter/issues/2299