### PR TITLE
Xena: generate all release notes

### DIFF
--- a/releasenotes/config.yaml
+++ b/releasenotes/config.yaml
@@ -1,4 +1,3 @@
 ---
 # This needs to be updated to the latest release.
-default_branch: stackhpc/xena
 release_tag_re: stackhpc/11\.\d+\.\d+\.\d

--- a/releasenotes/notes/release-train-02-2023-package-refresh-9de8049f8cb08a5e.yaml
+++ b/releasenotes/notes/release-train-02-2023-package-refresh-9de8049f8cb08a5e.yaml
@@ -5,14 +5,21 @@ features:
     Key packages to note are:
 
     * Kernel
+
       * version: 4.18.0
       * release: 448.el8
+
     * Libvirt
+
       * version: 8.0.0
       * release: 6.module_el8.7.0+1140+ff0772f9
+
     * OVS
+
       * version: 2.17.0
       * release: 71.el8s
+
     * OVN
+
       * version: 22.09.0
       * release: 11.el8s

--- a/releasenotes/notes/release-train-02-2023-package-refresh-ubuntu-a9fe8a1c3c2f2796.yaml
+++ b/releasenotes/notes/release-train-02-2023-package-refresh-ubuntu-a9fe8a1c3c2f2796.yaml
@@ -5,11 +5,16 @@ features:
     Key packages to note are:
 
     * Libvirt (unchanged since last container build)
+
       * version: 6.0.0
       * release: 0ubuntu8.16
+
     * OVS
+
       * version: 2.17.3
       * release: 0ubuntu0.22.04.1~cloud0
+
     * OVN (unchanged since last container build)
+
       * version: 22.03.0
       * release: 0ubuntu1~cloud0

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ commands =
 allowlist_externals = rm
 skip_install = true
 deps =
-  -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/xena}
+  -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/yoga}
   -r{toxinidir}/releasenotes/requirements.txt
 commands =
   rm -rf releasenotes/build/html


### PR DESCRIPTION
- Fix release train 02-2023 renos
- release notes: Remove default_branch config option
- Use yoga upper constraints for releasenotes tox env
