### PR TITLE
Fix InstanceDown alert

### DIFF
--- a/etc/kayobe/kolla/config/prometheus/system.rules
+++ b/etc/kayobe/kolla/config/prometheus/system.rules
@@ -53,7 +53,7 @@ groups:
 
   - alert: InstanceDown
     expr: up{job="node"} == 0
-    for: 1m
+    for: 5m
     labels:
       severity: alert
     annotations:

--- a/releasenotes/notes/fixes-InstanceDown-Alert-570a295e3d5006f7.yaml
+++ b/releasenotes/notes/fixes-InstanceDown-Alert-570a295e3d5006f7.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixes the InstanceDown alerting rule wait time to be consistent with
+    the alert message. The alert message says "for 5 minutes" but the rule
+    was set to wait for 1 minute.
+


### PR DESCRIPTION
Fixes the InstanceDown alerting rule wait time to be consistent with the alert message. The alert message says "for 5 minutes" but the rule was set to wait for 1 minute.

Setting the wait to 5m also matches the example alert provided by prometheus