### PR TITLE
Build Neutron from stackhpc fork

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -148,6 +148,10 @@ kolla_sources:
     type: git
     location: https://github.com/stackhpc/magnum.git
     reference: stackhpc/wallaby
+  neutron-base:
+    type: git
+    location: https://github.com/stackhpc/neutron.git
+    reference: stackhpc/{{ openstack_release }}
   neutron-base-plugin-networking-generic-switch:
     type: git
     location: https://github.com/stackhpc/networking-generic-switch.git


### PR DESCRIPTION
This is required to include our IPv6 metadata workaround.