### PR TITLE
Adds missing images needed by Scientific OpenStack. 

### DIFF
--- a/.github/workflows/stackhpc-container-image-build.yml
+++ b/.github/workflows/stackhpc-container-image-build.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: stackhpc/kayobe
-          ref: refs/heads/stackhpc/wallaby
+          ref: refs/heads/wallaby/caso
           path: src/kayobe
 
       # FIXME: Failed in kolla-ansible : Ensure the latest version of pip is installed

--- a/.github/workflows/stackhpc-container-image-build.yml
+++ b/.github/workflows/stackhpc-container-image-build.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: stackhpc/kayobe
-          ref: refs/heads/wallaby/caso
+          ref: refs/heads/stackhpc/wallaby
           path: src/kayobe
 
       # FIXME: Failed in kolla-ansible : Ensure the latest version of pip is installed

--- a/etc/kayobe/environments/ci-builder/stackhpc-ci.yml
+++ b/etc/kayobe/environments/ci-builder/stackhpc-ci.yml
@@ -7,6 +7,7 @@ kolla_docker_namespace: stackhpc-dev
 
 # Kolla feature flag configuration.
 kolla_enable_barbican: true
+kolla_enable_blazar: true
 kolla_enable_caso: true
 kolla_enable_central_logging: true
 kolla_enable_cinder: true

--- a/etc/kayobe/environments/ci-builder/stackhpc-ci.yml
+++ b/etc/kayobe/environments/ci-builder/stackhpc-ci.yml
@@ -7,6 +7,7 @@ kolla_docker_namespace: stackhpc-dev
 
 # Kolla feature flag configuration.
 kolla_enable_barbican: true
+kolla_enable_caso: true
 kolla_enable_central_logging: true
 kolla_enable_cinder: true
 kolla_enable_cloudkitty: true

--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -5,8 +5,12 @@ docker_yum_gpgkey: "https://download.docker.com/linux/centos/gpg"
 
 {% if kolla_base_distro == 'centos' %}
 bifrost_tag: wallaby-20230207T194135
+blazar_tag: wallaby-20230303T172322
+caso_tag: wallaby-20230303T172322
 {% else %}
 bifrost_tag: wallaby-20230215T160405
+blazar_tag: wallaby-20230303T172458
+caso_tag: wallaby-20230303T172458
 {% endif %}
 
 glance_tls_proxy_tag: "{% raw %}{{ haproxy_tag | default(openstack_tag) }}{% endraw %}"

--- a/releasenotes/notes/add-blazar-fa6ecce8b21c73b4.yaml
+++ b/releasenotes/notes/add-blazar-fa6ecce8b21c73b4.yaml
@@ -1,0 +1,7 @@
+---
+ features:
+   - |
+     Add ``blazar`` project Kolla container images. ``Blazar``  is a resource
+     reservation service for OpenStack. ``Blazar`` enables users to reserve a
+     specific type/amount of resources for a specific time period and it leases
+     these resources to users based on their reservations.

--- a/releasenotes/notes/add-caso-f36b98453be10169.yaml
+++ b/releasenotes/notes/add-caso-f36b98453be10169.yaml
@@ -1,0 +1,8 @@
+---
+ features:
+   - |
+     Adds ``caso`` container images. ``cASO``  is an is an accounting reporter
+     that supports Cloud Accounting Usage Records. For more information, see
+     the `upstream docs <https://caso.readthedocs.io/en/stable/>`__. Note that
+     this container does not exist in upstream Kolla and is maintained
+     downstream by StackHPC. 


### PR DESCRIPTION
This is required for the scientific-openstack/release train merge.

See: https://caso.readthedocs.io/en/stable/. 

Needs:

-  https://github.com/stackhpc/kayobe/pull/100
- https://github.com/stackhpc/stackhpc-release-train/pull/177

to work.