### PR TITLE
Bump neutron containers to support NGS batching

### DIFF
--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -7,12 +7,12 @@ docker_yum_gpgkey: "https://download.docker.com/linux/centos/gpg"
 bifrost_tag: wallaby-20230207T194135
 blazar_tag: wallaby-20230303T172322
 caso_tag: wallaby-20230303T172322
-neutron_tag: wallaby-20230303T174325
+neutron_tag: wallaby-20230307T113517
 {% else %}
 bifrost_tag: wallaby-20230215T160405
 blazar_tag: wallaby-20230303T172458
 caso_tag: wallaby-20230303T172458
-neutron_tag: wallaby-20230303T213058
+neutron_tag: wallaby-20230307T121824
 {% endif %}
 
 glance_tls_proxy_tag: "{% raw %}{{ haproxy_tag | default(openstack_tag) }}{% endraw %}"

--- a/releasenotes/notes/adds-networking-generic-switch-batching-support-adffe038ea2441d0.yaml
+++ b/releasenotes/notes/adds-networking-generic-switch-batching-support-adffe038ea2441d0.yaml
@@ -1,0 +1,9 @@
+---
+features:
+  - |
+    Brings in new neutron container images to add batching support to
+    Networking Generic Switch. This is opt in via the ``ngs_batch_requests``
+    configuration option and only affects Ironic deployments that use
+    Networking Generic Switch. See the following `PR
+    <https://github.com/stackhpc/networking-generic-switch/pull/54>`__ for more
+    details.


### PR DESCRIPTION
This is used by scientific-openstack and is opt in via a config option.

See: https://github.com/stackhpc/networking-generic-switch/pull/54