### PR TITLE
Wallaby: Use newer liblasso package version in Ubuntu

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -274,6 +274,14 @@ kolla_build_blocks:
         && grafana-cli plugins install grafana-piechart-panel
   ironic_inspector_header: |
     ADD additions-archive /
+  keystone_base_footer: |
+    {% raw %}
+    {% if base_package_type == 'deb' %}
+    RUN curl -sLO https://github.com/stackhpc/lasso/releases/download/applied%2F2.7.0-2build3/liblasso3_2.7.0-2build3_amd64.deb && \
+        sudo dpkg -i liblasso3_2.7.0-2build3_amd64.deb && \
+        rm -f liblasso3_2.7.0-2build3_amd64.deb
+    {% endif %}
+    {% endraw %}
   prometheus_v2_server_repository_version: |
     ARG prometheus_version='2.35.0'
   prometheus_alertmanager_repository_version: |

--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -12,6 +12,7 @@ neutron_tag: wallaby-20230307T113517
 bifrost_tag: wallaby-20230215T160405
 blazar_tag: wallaby-20230303T172458
 caso_tag: wallaby-20230303T172458
+keystone_tag: wallaby-20230308T104024
 neutron_tag: wallaby-20230307T121824
 {% endif %}
 

--- a/releasenotes/notes/fix-liblasso-netiq-issue-afec5b2ee7de2a1e.yaml
+++ b/releasenotes/notes/fix-liblasso-netiq-issue-afec5b2ee7de2a1e.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes the `issue <https://dev.entrouvert.org/issues/25640>`__ with using
+    SAML2 federation in Keystone against NetIQ IdP.


### PR DESCRIPTION
Fixes https://dev.entrouvert.org/issues/25640.