### PR TITLE
Add unit (GiB) to LowMemory alert

### DIFF
--- a/etc/kayobe/kolla/config/prometheus/system.rules
+++ b/etc/kayobe/kolla/config/prometheus/system.rules
@@ -22,7 +22,7 @@ groups:
       severity: alert
     annotations:
       summary: "Prometheus exporter at {{ $labels.instance }} reports low memory"
-      description: "Available memory is {{ $value }}."
+      description: "Available memory is {{ $value }} GiB."
 
   - alert: HostOomKillDetected
     expr: increase(node_vmstat_oom_kill[5m]) > 0

--- a/releasenotes/notes/low-memory-alert-units-a6fde380ff9b7839.yaml
+++ b/releasenotes/notes/low-memory-alert-units-a6fde380ff9b7839.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Add unit to LowMemory alert description.


### PR DESCRIPTION
Adds the word `GB` to the low memory alert to make more sense of the alert