### PR TITLE
Put Pulp admin password in quotes

### DIFF
--- a/etc/kayobe/containers/pulp/post.yml
+++ b/etc/kayobe/containers/pulp/post.yml
@@ -12,7 +12,7 @@
   command: >-
     docker exec -u root pulp
     bash -c
-      'pulpcore-manager reset-admin-password -p {{ pulp_password }}'
+      "pulpcore-manager reset-admin-password -p \"{{ pulp_password }}\""
   no_log: true
   register: pulp_manager_result
   failed_when:


### PR DESCRIPTION
We can't set a Pulp admin password with spaces in it.  The invocation of pulpcore-manager reset-admin-password needs to put the password parameter in quotes.