### PR TITLE
Add workaround for buggy etcdgw library

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -310,7 +310,7 @@ kolla_build_blocks:
   neutron_server_footer: |
     # This is a workaround for a bug in etcd3gw that was fixed in 1.0.1, but not in v0.2.3.
     # https://opendev.org/openstack/etcd3gw/commit/ed899b34e464862525f76fff2377a2cceeb65af7
-    RUN sed -i 's/decode_unicode=True/decode_unicode=False/' /var/lib/kolla/venv/lib/python3.8/site-packages/etcd3gw/watch.py
+    RUN sed -i 's/decode_unicode=True/decode_unicode=False/' /var/lib/kolla/venv/lib/python3.6/site-packages/etcd3gw/watch.py
 
 kolla_build_customizations_common:
   bifrost_base_pip_packages_append:

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -310,7 +310,13 @@ kolla_build_blocks:
   neutron_server_footer: |
     # This is a workaround for a bug in etcd3gw that was fixed in 1.0.1, but not in v0.2.3.
     # https://opendev.org/openstack/etcd3gw/commit/ed899b34e464862525f76fff2377a2cceeb65af7
+    {% raw %}
+    {% if base_distro == 'centos' %}
     RUN sed -i 's/decode_unicode=True/decode_unicode=False/' /var/lib/kolla/venv/lib/python3.6/site-packages/etcd3gw/watch.py
+    {% elif base_distro == 'ubuntu' %}
+    RUN sed -i 's/decode_unicode=True/decode_unicode=False/' /var/lib/kolla/venv/lib/python3.8/site-packages/etcd3gw/watch.py
+    {% endif %}
+    {% endraw %}
 
 kolla_build_customizations_common:
   bifrost_base_pip_packages_append:

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -307,6 +307,10 @@ kolla_build_blocks:
     RUN sed -i 's/"pc-q35-rhel8.5.0"/"pc-q35-*"/' /usr/share/qemu/firmware/50-edk2-ovmf-cc.json
     {% endif %}
     {% endraw %}
+  neutron_server_footer: |
+    # This is a workaround for a bug in etcd3gw that was fixed in 1.0.1, but not in v0.2.3.
+    # https://opendev.org/openstack/etcd3gw/commit/ed899b34e464862525f76fff2377a2cceeb65af7
+    RUN sed -i 's/decode_unicode=True/decode_unicode=False/' /var/lib/kolla/venv/lib/python3.8/site-packages/etcd3gw/watch.py
 
 kolla_build_customizations_common:
   bifrost_base_pip_packages_append:

--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -7,13 +7,13 @@ docker_yum_gpgkey: "https://download.docker.com/linux/centos/gpg"
 bifrost_tag: wallaby-20230207T194135
 blazar_tag: wallaby-20230303T172322
 caso_tag: wallaby-20230303T172322
-neutron_tag: wallaby-20230307T113517
+neutron_tag: wallaby-20230317T170927
 {% else %}
 bifrost_tag: wallaby-20230215T160405
 blazar_tag: wallaby-20230303T172458
 caso_tag: wallaby-20230303T172458
 keystone_tag: wallaby-20230308T104024
-neutron_tag: wallaby-20230307T121824
+neutron_tag: wallaby-20230317T170930
 {% endif %}
 
 glance_tls_proxy_tag: "{% raw %}{{ haproxy_tag | default(openstack_tag) }}{% endraw %}"

--- a/releasenotes/notes/fixes-broken-etcdgw-library-2af353ec0dc42109.yaml
+++ b/releasenotes/notes/fixes-broken-etcdgw-library-2af353ec0dc42109.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    The etcdgw library in the neutron-server container has been patched to
+    workaround a python3 incompatability. This affects the batching feature in
+    networking generic switch.


### PR DESCRIPTION
Symptom was:

```
2023-02-06 14:12:47.826 674 ERROR neutron.plugins.ml2.managers Exception: ('timed out waiting for key: %s', '/ngs/batch/172.23.61.14/output/f1a17d6c-3cc4-40fe-88bb-91725e602ea1')
```

When using the networking generic switch batching mode. Original patch by Mark.