### PR TITLE
Specify ironic_dnsmasq_tag

### DIFF
--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -12,6 +12,7 @@ bifrost_tag: yoga-20230217T160618
 blazar_tag: yoga-20230315T125157
 caso_tag: yoga-20230315T125157
 ironic_tag: yoga-20230316T154655
+ironic_dnsmasq_tag: yoga-20230217T135826
 neutron_tag: yoga-20230309T123152
 prometheus_node_exporter_tag: yoga-20230310T173747
 {% elif kolla_base_distro == 'rocky' %}
@@ -19,6 +20,7 @@ bifrost_tag: yoga-20230310T194732
 blazar_tag: yoga-20230315T130918
 caso_tag: yoga-20230315T130918
 ironic_tag: yoga-20230316T170311
+ironic_dnsmasq_tag: yoga-20230310T170929
 prometheus_node_exporter_tag: yoga-20230315T170614
 {% else %}
 bifrost_tag: yoga-20230220T184947
@@ -26,6 +28,7 @@ blazar_tag: yoga-20230315T125441
 caso_tag: yoga-20230315T125441
 neutron_tag: yoga-20230309T123143
 ironic_tag: yoga-20230316T154704
+ironic_dnsmasq_tag: yoga-20230220T181235
 prometheus_node_exporter_tag: yoga-20230315T170541
 {% endif %}
 


### PR DESCRIPTION
The ironic_dnsmasq container was missed during the ironic container builds. As such, ironic_dnsmasq_tag is explicilty set to the same as the operating-system-equivalent kolla_openstack_release.