### PR TITLE
Fix Squid crash on startup

### DIFF
--- a/etc/kayobe/containers/squid_proxy/squid.conf
+++ b/etc/kayobe/containers/squid_proxy/squid.conf
@@ -63,6 +63,10 @@ cache_dir ufs /var/spool/squid 4096 16 256
 cache_mem 768 MB
 maximum_object_size_in_memory 64 MB
 
+# Set a sensible cap on the number of open file descriptors.
+# Rocky Linux 8.6 sets this to ~2^30 which results in alloc failure on start.
+max_filedescriptors 10000
+
 # Leave coredumps in the first cache dir
 coredump_dir /var/spool/squid
 


### PR DESCRIPTION
Fix squid fatal error of this form:
FATAL: xcalloc: Unable to allocate 1073741816 blocks of 432 bytes!

Relating to max open files being 2^30 in Rocky base image. Set a sensible cap of 10000 open FDs.