### PR TITLE
Switch to using a specific version of CentOS Stream

### DIFF
--- a/.github/workflows/stackhpc-all-in-one.yml
+++ b/.github/workflows/stackhpc-all-in-one.yml
@@ -22,7 +22,7 @@ on:
       vm_image:
         description: Image for the all-in-one VM
         type: string
-        default: 7efda0b1-e296-447f-896e-c066d0af5c53
+        default: bb8c0a34-533f-42fb-a49b-3461e677f3f6
       vm_interface:
         description: Default network interface name
         type: string

--- a/.github/workflows/stackhpc-all-in-one.yml
+++ b/.github/workflows/stackhpc-all-in-one.yml
@@ -22,7 +22,7 @@ on:
       vm_image:
         description: Image for the all-in-one VM
         type: string
-        default: CentOS-stream8
+        default: 7efda0b1-e296-447f-896e-c066d0af5c53
       vm_interface:
         description: Default network interface name
         type: string

--- a/terraform/aio/vm.tf
+++ b/terraform/aio/vm.tf
@@ -34,7 +34,7 @@ variable "aio_vm_subnet" {
 }
 
 locals {
-  image_is_uuid = length(regexall('^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$', var.aio_vm_image)) > 0
+  image_is_uuid = length(regexall("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", var.aio_vm_image)) > 0
 }
 
 data "openstack_images_image_v2" "image" {

--- a/terraform/aio/vm.tf
+++ b/terraform/aio/vm.tf
@@ -34,7 +34,7 @@ variable "aio_vm_subnet" {
 }
 
 locals {
-  image_is_uuid = length(regexall('^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$', aio_vm_image)) > 0
+  image_is_uuid = length(regexall('^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$', var.aio_vm_image)) > 0
 }
 
 data "openstack_images_image_v2" "image" {

--- a/terraform/aio/vm.tf
+++ b/terraform/aio/vm.tf
@@ -13,7 +13,7 @@ variable "aio_vm_name" {
 
 variable "aio_vm_image" {
   type    = string
-  default = "CentOS-stream8.2023-03-20"
+  default = "bb8c0a34-533f-42fb-a49b-3461e677f3f6"
 }
 
 variable "aio_vm_interface" {

--- a/terraform/aio/vm.tf
+++ b/terraform/aio/vm.tf
@@ -57,7 +57,7 @@ resource "openstack_compute_instance_v2" "kayobe-aio" {
   }
 
   block_device {
-    uuid                  = local.image_is_uuid ? var.aio_vm_image: data.openstack_images_image_v2.image.id
+    uuid                  = local.image_is_uuid ? var.aio_vm_image: data.openstack_images_image_v2.image[0].id
     source_type           = "image"
     volume_size           = 100
     boot_index            = 0

--- a/terraform/aio/vm.tf
+++ b/terraform/aio/vm.tf
@@ -33,9 +33,14 @@ variable "aio_vm_subnet" {
   type = string
 }
 
+locals {
+  image_is_uuid = length(regexall('^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$', aio_vm_image)) > 0
+}
+
 data "openstack_images_image_v2" "image" {
   name        = var.aio_vm_image
   most_recent = true
+  count = local.image_is_uuid ? 0 : 1
 }
 
 data "openstack_networking_subnet_v2" "network" {
@@ -52,7 +57,7 @@ resource "openstack_compute_instance_v2" "kayobe-aio" {
   }
 
   block_device {
-    uuid                  = data.openstack_images_image_v2.image.id
+    uuid                  = local.image_is_uuid ? var.aio_vm_image: data.openstack_images_image_v2.image.id
     source_type           = "image"
     volume_size           = 100
     boot_index            = 0

--- a/terraform/aio/vm.tf
+++ b/terraform/aio/vm.tf
@@ -13,7 +13,7 @@ variable "aio_vm_name" {
 
 variable "aio_vm_image" {
   type    = string
-  default = "bb8c0a34-533f-42fb-a49b-3461e677f3f6"
+  default = "7efda0b1-e296-447f-896e-c066d0af5c53"
 }
 
 variable "aio_vm_interface" {

--- a/terraform/aio/vm.tf
+++ b/terraform/aio/vm.tf
@@ -13,7 +13,7 @@ variable "aio_vm_name" {
 
 variable "aio_vm_image" {
   type    = string
-  default = "CentOS-stream8"
+  default = "CentOS-stream8.2023-03-20"
 }
 
 variable "aio_vm_interface" {

--- a/terraform/aio/vm.tf
+++ b/terraform/aio/vm.tf
@@ -18,7 +18,7 @@ variable "aio_vm_image" {
 
 variable "aio_vm_interface" {
   type = string
-  default = "eth0"
+  default = "ens3"
 }
 
 variable "aio_vm_flavor" {

--- a/terraform/aio/vm.tf
+++ b/terraform/aio/vm.tf
@@ -13,12 +13,12 @@ variable "aio_vm_name" {
 
 variable "aio_vm_image" {
   type    = string
-  default = "7efda0b1-e296-447f-896e-c066d0af5c53"
+  default = "CentOS-stream8"
 }
 
 variable "aio_vm_interface" {
   type = string
-  default = "ens3"
+  default = "eth0"
 }
 
 variable "aio_vm_flavor" {


### PR DESCRIPTION
This is to workaround the following breakage:
```
TASK [MichaelRigart.interfaces : RedHat | ensure network service is started and enabled] ***
Tuesday 21 March 2023  09:43:32 +0000 (0:00:00.347)       0:02:20.016 ********* 
fatal: [controller0]: FAILED! => changed=false 
  msg: |-
    Unable to start service network: Job for network.service failed because the control process exited with error code.
    See "systemctl status network.service" and "journalctl -xe" for details.
```