### PR TITLE
Fix smartmon script

### DIFF
--- a/etc/kayobe/ansible/scripts/smartmon.sh
+++ b/etc/kayobe/ansible/scripts/smartmon.sh
@@ -106,6 +106,7 @@ parse_smartctl_scsi_attributes() {
 }
 
 parse_smartctl_info() {
+  shopt -s nocasematch
   local -i smart_available=0 smart_enabled=0 smart_healthy=
   local disk="$1" disk_type="$2"
   local model_family='' device_model='' serial_number='' fw_version='' vendor='' product='' revision='' lun_id=''

--- a/releasenotes/notes/fix-smartmon-script-db2a38df1b245e58.yaml
+++ b/releasenotes/notes/fix-smartmon-script-db2a38df1b245e58.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixes the smartmon script to be case insensitive when checking for
+    the inital SMART info. This is to ensure that the script works
+    correctly on systems where the output of `smartctl -i` is not
+    capitalised as previously expected by the script. This leads to
+    badly formatted .prom files which lead to node_exporter failing to
+    scrape the file.


### PR DESCRIPTION
Fixes the smartmon script to detect SMART info values regardless of their case. Previously, this would lead to wrongly formatted .prom files resulting in node_exporter failing to parse them.