### PR TITLE
Update HAProxy alerting rules

### DIFF
--- a/etc/kayobe/kolla/config/prometheus/haproxy.rules
+++ b/etc/kayobe/kolla/config/prometheus/haproxy.rules
@@ -30,7 +30,7 @@ groups:
     labels:
       severity: critical
     annotations:
-      summary: "HAProxy server down (instance {{ $labels.instance }})"
-      description: "HAProxy server is down"
+      summary: "HAProxy server down at {{ $labels.server }}"
+      description: "HAProxy server for {{ $labels.backend }} is down at {{ $labels.server }}"
 
 {% endraw %}

--- a/releasenotes/notes/update-haproxy-alerting-rules-5594547666659c0f.yaml
+++ b/releasenotes/notes/update-haproxy-alerting-rules-5594547666659c0f.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    HAProxy alerting rules have been updated to use the server name that is
+    down, rather than the name of the instance that reported the down server.


### PR DESCRIPTION
HAProxy alerting rules have been updated to use the server name that is down, rather than the name of the instance that reported the down server.