### PR TITLE
Disable PG deviation alert

### DIFF
--- a/etc/kayobe/kolla/config/prometheus/ceph.rules
+++ b/etc/kayobe/kolla/config/prometheus/ceph.rules
@@ -102,22 +102,6 @@ groups:
         marked down and back up at {{ $value | humanize }} times once a
         minute for 5 minutes.
 
-  # alert on high deviation from average PG count
-  - alert: HighPgCountDeviation
-    expr: |
-      abs(
-      (
-        (ceph_osd_numpg > 0) - on (job) group_left avg(ceph_osd_numpg > 0) by (job)
-      ) / on (job) group_left avg(ceph_osd_numpg > 0) by (job)
-      ) * on(ceph_daemon) group_left(hostname) ceph_osd_metadata > 0.35
-    for: 5m
-    labels:
-      severity: warning
-    annotations:
-      description: >
-        OSD {{ $labels.ceph_daemon }} on {{ $labels.hostname }} deviates
-        by more than 30% from average PG count.
-
 - name: pgs
   rules:
   - alert: PgsInactive


### PR DESCRIPTION
This alert does not make much sense on clusters with multiple device classes. It is perfectly fine to have PG distribution like this:
```
ID   CLASS  WEIGHT    REWEIGHT  SIZE     RAW USE  DATA     OMAP     META      AVAIL    %USE  VAR   PGS  STATUS
...
223    hdd  16.49229   1.00000   16 TiB  564 GiB  440 GiB    9 KiB   1.7 GiB   16 TiB  3.34  1.00  148      up
234    hdd  16.49229   1.00000   16 TiB  564 GiB  440 GiB   11 KiB   1.4 GiB   16 TiB  3.34  1.00  146      up
245    hdd  16.49229   1.00000   16 TiB  564 GiB  439 GiB    1 KiB   1.7 GiB   16 TiB  3.34  1.00  145      up
257    hdd  16.49229   1.00000   16 TiB  564 GiB  440 GiB   39 KiB   1.4 GiB   16 TiB  3.34  1.00  146      up
268    hdd  16.49229   1.00000   16 TiB  564 GiB  440 GiB    9 KiB   1.4 GiB   16 TiB  3.34  1.00  148      up
279    hdd  16.49229   1.00000   16 TiB  564 GiB  440 GiB    2 KiB   1.4 GiB   16 TiB  3.34  1.00  149      up
290    hdd  16.49229   1.00000   16 TiB  563 GiB  439 GiB   43 KiB   1.4 GiB   16 TiB  3.33  1.00  147      up
301    hdd  16.49229   1.00000   16 TiB  563 GiB  439 GiB    1 KiB   1.8 GiB   16 TiB  3.33  1.00  148      up
  1    ssd   1.45549   1.00000  1.5 TiB   44 GiB   43 GiB    8 KiB   692 MiB  1.4 TiB  2.96  0.89   16      up
 12    ssd   1.45549   1.00000  1.5 TiB   37 GiB   36 GiB   11 KiB   704 MiB  1.4 TiB  2.45  0.74   16      up
 17    ssd   1.45549   1.00000  1.5 TiB   44 GiB   43 GiB    6 KiB   837 MiB  1.4 TiB  2.95  0.89   16      up
 26    ssd   1.45549   1.00000  1.5 TiB   44 GiB   44 GiB   11 KiB   756 MiB  1.4 TiB  2.97  0.89   17      up
                         TOTAL  4.3 PiB  147 TiB  115 TiB  3.7 GiB   453 GiB  4.2 PiB  3.34
MIN/MAX VAR: 0.74/1.02  STDDEV: 0.19
```
Yet, `HighPgCountDeviation` rule would make Alertmanager complain about it.
It is better to disable the alert and let cluster administrator(s) decide how to spread placement groups.