### PR TITLE
Bump nova images

### DIFF
--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -23,7 +23,7 @@ blazar_tag: yoga-20230315T130918
 caso_tag: yoga-20230315T130918
 ironic_tag: yoga-20230316T170311
 ironic_dnsmasq_tag: yoga-20230310T170929
-nova_tag: FIXME
+nova_tag: yoga-20230331T113516
 opensearch_tag: yoga-20230324T090413
 prometheus_node_exporter_tag: yoga-20230315T170614
 {% else %}
@@ -31,7 +31,7 @@ bifrost_tag: yoga-20230220T184947
 blazar_tag: yoga-20230315T125441
 caso_tag: yoga-20230315T125441
 neutron_tag: yoga-20230309T123143
-nova_tag: FIXME
+nova_tag: yoga-20230331T110423
 ironic_tag: yoga-20230316T154704
 ironic_dnsmasq_tag: yoga-20230220T181235
 opensearch_tag: yoga-20230324T090345

--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -14,6 +14,7 @@ caso_tag: yoga-20230315T125157
 ironic_tag: yoga-20230316T154655
 ironic_dnsmasq_tag: yoga-20230217T135826
 neutron_tag: yoga-20230309T123152
+nova_tag: yoga-20230331T102705
 opensearch_tag: yoga-20230324T084510
 prometheus_node_exporter_tag: yoga-20230310T173747
 {% elif kolla_base_distro == 'rocky' %}
@@ -22,6 +23,7 @@ blazar_tag: yoga-20230315T130918
 caso_tag: yoga-20230315T130918
 ironic_tag: yoga-20230316T170311
 ironic_dnsmasq_tag: yoga-20230310T170929
+nova_tag: FIXME
 opensearch_tag: yoga-20230324T090413
 prometheus_node_exporter_tag: yoga-20230315T170614
 {% else %}
@@ -29,6 +31,7 @@ bifrost_tag: yoga-20230220T184947
 blazar_tag: yoga-20230315T125441
 caso_tag: yoga-20230315T125441
 neutron_tag: yoga-20230309T123143
+nova_tag: FIXME
 ironic_tag: yoga-20230316T154704
 ironic_dnsmasq_tag: yoga-20230220T181235
 opensearch_tag: yoga-20230324T090345

--- a/releasenotes/notes/fixes-mdev-uuid-parsing-4c9e972c3c424760.yaml
+++ b/releasenotes/notes/fixes-mdev-uuid-parsing-4c9e972c3c424760.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Updates nova image to bring in a fix for parsing mdev uuids when using
+    libvirt>=7.7. See `bug <https://bugs.launchpad.net/nova/+bug/1951656>`__
+    for more details.


### PR DESCRIPTION
This brings in:

https://github.com/stackhpc/nova/commit/7252072591c43ce079cd59e82bb77ca7c661f206

and fixes nova compute errors with the signature:

```
2022-07-06 13:18:35.913 7 ERROR nova.compute.manager   File "/var/lib/kolla/venv/lib/python3.6/site-packages/nova/virt/libvirt/driver.py", line 7726, in _get_mediated_device_information
2022-07-06 13:18:35.913 7 ERROR nova.compute.manager     "uuid": libvirt_utils.mdev_name2uuid(cfgdev.name),
2022-07-06 13:18:35.913 7 ERROR nova.compute.manager   File "/var/lib/kolla/venv/lib/python3.6/site-packages/nova/virt/libvirt/utils.py", line 583, in mdev_name2uuid
2022-07-06 13:18:35.913 7 ERROR nova.compute.manager     return str(uuid.UUID(mdev_name[5:].replace('_', '-')))
2022-07-06 13:18:35.913 7 ERROR nova.compute.manager   File "/usr/lib64/python3.6/uuid.py", line 140, in __init__
2022-07-06 13:18:35.913 7 ERROR nova.compute.manager     raise ValueError('badly formed hexadecimal UUID string')
2022-07-06 13:18:35.913 7 ERROR nova.compute.manager ValueError: badly formed hexadecimal UUID string
```