### PR TITLE
Fix Rocky Linux 9 CRB repository configuration

### DIFF
--- a/etc/kayobe/dnf.yml
+++ b/etc/kayobe/dnf.yml
@@ -149,6 +149,12 @@ dnf_custom_repos_rocky_9:
     file: rocky
     gpgkey: "{{ rocky_9_gpg_key }}"
     gpgcheck: yes
+  crb:
+    baseurl: "{{ stackhpc_repo_rocky_9_crb_url }}"
+    description: "Rocky Linux $releasever - CRB"
+    file: rocky
+    gpgkey: "{{ rocky_9_gpg_key }}"
+    gpgcheck: yes
   extras:
     baseurl: "{{ stackhpc_repo_rocky_9_extras_url }}"
     description: "Rocky Linux $releasever - Extras"

--- a/etc/kayobe/pulp.yml
+++ b/etc/kayobe/pulp.yml
@@ -755,7 +755,7 @@ stackhpc_pulp_distribution_rpm_development:
     required: "{{ stackhpc_pulp_sync_rocky_9 | bool }}"
   - name: "rocky-9-crb-development"
     repository: Rocky Linux 9 - CRB
-    base_path: "rocky/9/crb/x86_64/os/development"
+    base_path: "rocky/9/CRB/x86_64/os/development"
     state: present
     required: "{{ stackhpc_pulp_sync_rocky_9 | bool }}"
   - name: "rocky-9-highavailability-development"
@@ -954,7 +954,7 @@ stackhpc_pulp_distribution_rpm_production:
     required: "{{ stackhpc_pulp_sync_rocky_9 | bool }}"
   - name: "rocky-9-crb-production"
     repository: Rocky Linux 9 - CRB
-    base_path: "rocky/9/crb/x86_64/os/production"
+    base_path: "rocky/9/CRB/x86_64/os/production"
     state: present
     required: "{{ stackhpc_pulp_sync_rocky_9 | bool }}"
   - name: "rocky-9-highavailability-production"

--- a/releasenotes/notes/rocky-crb-b6a6cecfdf4d93a4.yaml
+++ b/releasenotes/notes/rocky-crb-b6a6cecfdf4d93a4.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixes synchronisation and DNF configuration of the Rocky Linux 9 CRB repository.


### PR DESCRIPTION
The CRB repository was missing from `dnf.yml` and its mirroring was misconfigured.