### PR TITLE
Drop Glance and Cinder forks

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -123,18 +123,10 @@ kolla_sources:
     type: git
     location: https://github.com/stackhpc/stackhpc-inspector-plugins.git
     reference: 1.3.0
-  cinder-base:
-    type: git
-    location: https://github.com/stackhpc/cinder.git
-    reference: stackhpc/{{ openstack_release }}
   cloudkitty-base:
     type: git
     location: https://github.com/stackhpc/cloudkitty.git
     reference: stackhpc/wallaby
-  glance-base:
-    type: git
-    location: https://github.com/stackhpc/glance.git
-    reference: stackhpc/{{ openstack_release }}
   horizon-plugin-cloudkitty-dashboard:
     type: git
     location: https://github.com/stackhpc/cloudkitty-dashboard.git


### PR DESCRIPTION
Our downstream patches for OSSA-2023-002 have landed upstream. We have
one other patch for Nova in Wallaby that has not merged upstream.
