### PR TITLE
Add defaults for cephadm_commands_{pre,post}

### DIFF
--- a/etc/kayobe/ansible/cephadm-commands-post.yml
+++ b/etc/kayobe/ansible/cephadm-commands-post.yml
@@ -10,4 +10,4 @@
     - import_role:
         name: stackhpc.cephadm.commands
       vars:
-        cephadm_commands: "{{ cephadm_commands_post }}"
+        cephadm_commands: "{{ cephadm_commands_post | default([]) }}"

--- a/etc/kayobe/ansible/cephadm-commands-pre.yml
+++ b/etc/kayobe/ansible/cephadm-commands-pre.yml
@@ -10,4 +10,4 @@
     - import_role:
         name: stackhpc.cephadm.commands
       vars:
-        cephadm_commands: "{{ cephadm_commands_pre }}"
+        cephadm_commands: "{{ cephadm_commands_pre | default([]) }}"


### PR DESCRIPTION
Without a default value we get:

    'cephadm_commands_pre' is undefined