### PR TITLE
Fix multinode failures from seed misconfiguration

### DIFF
--- a/etc/kayobe/environments/ci-multinode/seed.yml
+++ b/etc/kayobe/environments/ci-multinode/seed.yml
@@ -3,9 +3,7 @@ seed_bootstrap_user: "{{ os_distribution if os_distribution == 'ubuntu' else 'cl
 seed_lvm_groups:
   - "{{ stackhpc_lvm_group_rootvg }}"
 
-seed_extra_network_interfaces: >
-  "{{ seed_extra_network_interfaces_external +
-  (seed_extra_network_interfaces_manila if (kolla_enable_manila | bool and kolla_enable_manila_backend_cephfs_native | bool) else []) }}"
+seed_extra_network_interfaces: "{{ seed_extra_network_interfaces_external + seed_extra_network_interfaces_manila if (kolla_enable_manila | bool and kolla_enable_manila_backend_cephfs_native | bool) else [] }}"
 
 # Seed has been provided an external interface
 # for tempest tests and SSH access to machines.
@@ -26,6 +24,6 @@ snat_rules_default:
     source_ip: "{{ ansible_facts.default_ipv4.address }}"
 snat_rules_manila:
   - interface: "{{ storage_interface }}"
-    source_ip: "{{ ansible_facts[storage_interface].ipv4.address }}"
+    source_ip: "{{ ansible_facts[storage_interface].ipv4.address | default }}"
 # Only add the storage snat rule if we are using manila-cephfs.
 snat_rules: "{{ snat_rules_default + snat_rules_manila if (kolla_enable_manila | bool and kolla_enable_manila_backend_cephfs_native | bool) else snat_rules_default }}"


### PR DESCRIPTION
This patch contains two fixes.

The first changes the structure of `seed_extra_network_interfaces` as it was previously invalid, resulting in errors about concatenating a string with a dict.

The second catches a failure that occurs when manila is not enabled. It was assumed that the seed had a storage interface even though it not configured by default. 