### PR TITLE
Fix publication of TreasureData 4 repository

### DIFF
--- a/etc/kayobe/pulp.yml
+++ b/etc/kayobe/pulp.yml
@@ -796,7 +796,7 @@ stackhpc_pulp_distribution_rpm_development:
   # Additional RHEL 9 repositories
   - name: "rhel-9-treasuredata-4-development"
     base_path: "treasuredata/4/redhat/9/x86_64/development"
-    repository: TreasureData 4 for RHEl 9
+    repository: TreasureData 4 for RHEL 9
     state: present
     required: "{{ stackhpc_pulp_sync_for_local_container_build | bool and stackhpc_pulp_sync_el_9 | bool }}"
   - name: "rhel-9-mariadb-10-6-development"


### PR DESCRIPTION
There was a typo in the repository name causing pulp-repo-publish to fail on Rocky Linux 9.