### PR TITLE
Add PyYAML as dependency for HashiCorp Vault ops

### DIFF
--- a/etc/kayobe/ansible/vault-deploy-seed.yml
+++ b/etc/kayobe/ansible/vault-deploy-seed.yml
@@ -16,9 +16,11 @@
         - not ansible_python_interpreter.startswith('/bin/')
         - not ansible_python_interpreter.startswith('/usr/bin/')
 
-    - name: Ensure Python hvac module is installed
+    - name: Ensure Python PyYAML and hvac modules are installed
       pip:
-        name: hvac
+        name:
+          - PyYAML
+          - hvac
         state: latest
         extra_args: "{% if pip_upper_constraints_file %}-c {{ pip_upper_constraints_file }}{% endif %}"
         virtualenv: "{{ virtualenv is defined | ternary(virtualenv, omit) }}"


### PR DESCRIPTION
Needs installing in the Seed Node virtualenv for HashiCorp Vault PKI operations.