### PR TITLE
Fix seed_extra_network_interfaces without Manila

### DIFF
--- a/etc/kayobe/environments/ci-multinode/seed.yml
+++ b/etc/kayobe/environments/ci-multinode/seed.yml
@@ -3,7 +3,7 @@ seed_bootstrap_user: "{{ os_distribution if os_distribution == 'ubuntu' else 'cl
 seed_lvm_groups:
   - "{{ stackhpc_lvm_group_rootvg }}"
 
-seed_extra_network_interfaces: "{{ seed_extra_network_interfaces_external + seed_extra_network_interfaces_manila if (kolla_enable_manila | bool and kolla_enable_manila_backend_cephfs_native | bool) else [] }}"
+seed_extra_network_interfaces: "{{ seed_extra_network_interfaces_external + (seed_extra_network_interfaces_manila if (kolla_enable_manila | bool and kolla_enable_manila_backend_cephfs_native | bool) else []) }}"
 
 # Seed has been provided an external interface
 # for tempest tests and SSH access to machines.


### PR DESCRIPTION
If Manila was disabled, `seed_extra_network_interfaces_external` were not applied.