### PR TITLE
Revert changes to use cloud-user

### DIFF
--- a/etc/kayobe/environments/aufn-ceph/compute.yml
+++ b/etc/kayobe/environments/aufn-ceph/compute.yml
@@ -1,2 +1,0 @@
----
-compute_bootstrap_user: "{{ 'cloud-user' if os_distribution == 'centos' else os_distribution }}"

--- a/etc/kayobe/environments/aufn-ceph/controllers.yml
+++ b/etc/kayobe/environments/aufn-ceph/controllers.yml
@@ -1,2 +1,0 @@
----
-controller_bootstrap_user: "{{ 'cloud-user' if os_distribution == 'centos' else os_distribution }}"

--- a/etc/kayobe/environments/aufn-ceph/seed.yml
+++ b/etc/kayobe/environments/aufn-ceph/seed.yml
@@ -1,2 +1,0 @@
----
-seed_bootstrap_user: "{{ 'cloud-user' if os_distribution == 'centos' else os_distribution }}"

--- a/etc/kayobe/environments/aufn-ceph/storage.yml
+++ b/etc/kayobe/environments/aufn-ceph/storage.yml
@@ -1,6 +1,4 @@
 ---
-storage_bootstrap_user: "{{ 'cloud-user' if os_distribution == 'centos' else os_distribution }}"
-
 ###############################################################################
 # Storage node LVM configuration.
 


### PR DESCRIPTION
The upstream CentOS image uses centos as the user, not `cloud-user`. Reverting recent changes