### PR TITLE
Using venv module explicitly.

### DIFF
--- a/etc/kayobe/ansible/octavia-amphora-image-build.yml
+++ b/etc/kayobe/ansible/octavia-amphora-image-build.yml
@@ -68,6 +68,7 @@
             name: diskimage-builder
             extra_args: "{% if amphora_dib_upper_constraints_file %}-c {{ amphora_dib_upper_constraints_file }}{% endif %}"
             virtualenv: "{{ venv_path }}"
+            virtualenv_command: "python3.{{ ansible_facts.python.version.minor }} -m venv"
 
         - name: Create build log file (/var/log/octavia-amphora-image-build.log)
           file:


### PR DESCRIPTION
Using venv module explicitly, else it can fail with:

" msg: 'Failed to find required executable "virtualenv" in paths: /home/stack/.local/bin:/home/stack/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin'"