### PR TITLE
Revert "Build Neutron from stackhpc fork"

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -140,10 +140,6 @@ kolla_sources:
     type: git
     location: https://github.com/stackhpc/magnum.git
     reference: stackhpc/wallaby
-  neutron-base:
-    type: git
-    location: https://github.com/stackhpc/neutron.git
-    reference: stackhpc/{{ openstack_release }}
   neutron-base-plugin-networking-generic-switch:
     type: git
     location: https://github.com/stackhpc/networking-generic-switch.git


### PR DESCRIPTION
The upstream fix for the IPv6 metadata DAD failure was merged on all
branches up to Victoria [1].

This reverts commit 9df33a626e0d809790d067a05d1e3844cb16e90b.

[1] https://review.opendev.org/q/I6b544c5528cb22e5e8846fc47dfb8b05f70f975c
