### PR TITLE
Fix Pulp container deployment with HTTPS enabled

### DIFF
--- a/etc/kayobe/seed.yml
+++ b/etc/kayobe/seed.yml
@@ -106,7 +106,7 @@ seed_pulp_container:
     image: pulp/pulp
     pre: "{{ kayobe_config_path }}/containers/pulp/pre.yml"
     post: "{{ kayobe_config_path }}/containers/pulp/post.yml"
-    tag: "{{ '3.23-https' if pulp_enable_tls | bool else '3.23' }}"
+    tag: "3.23"
     network_mode: host
     # Override deploy_containers_defaults.init == true to ensure
     # s6-overlay-suexec starts as pid 1
@@ -114,6 +114,7 @@ seed_pulp_container:
     env:
       PULP_CONTENT_WORKERS: "{{ ansible_facts.processor_vcpus * 2 + 1 }}"
       PULP_API_WORKERS: "{{ ansible_facts.processor_vcpus * 2 + 1 }}"
+      PULP_HTTPS: "{{ 'true' if pulp_enable_tls | bool else 'false' }}"
     volumes:
       - /opt/kayobe/containers/pulp:/etc/pulp
       - pulp_storage:/var/lib/pulp


### PR DESCRIPTION
The Pulp project has stopped maintaining separate https images and there is no pulp/pulp image tagged as 3.23-https. The PULP_HTTPS variable should be set to ``true`` instead [1].

[1] https://github.com/pulp/pulp-oci-images/pull/426