### PR TITLE
Add missing proxy_url to Pulp repositories

### DIFF
--- a/etc/kayobe/pulp.yml
+++ b/etc/kayobe/pulp.yml
@@ -257,6 +257,7 @@ stackhpc_pulp_repository_rpm_repos:
     client_cert: ""
     client_key: ""
     policy: on_demand
+    proxy_url: "{{ pulp_proxy_url }}"
     sync_policy: mirror_complete
     state: present
     required: "{{ stackhpc_pulp_sync_rocky_8 | bool }}"
@@ -267,6 +268,7 @@ stackhpc_pulp_repository_rpm_repos:
     client_cert: ""
     client_key: ""
     policy: on_demand
+    proxy_url: "{{ pulp_proxy_url }}"
     sync_policy: mirror_complete
     state: present
     required: "{{ stackhpc_pulp_sync_rocky_8 | bool }}"
@@ -277,6 +279,7 @@ stackhpc_pulp_repository_rpm_repos:
     client_cert: ""
     client_key: ""
     policy: on_demand
+    proxy_url: "{{ pulp_proxy_url }}"
     sync_policy: mirror_complete
     state: present
     required: "{{ stackhpc_pulp_sync_rocky_8 | bool }}"
@@ -287,6 +290,7 @@ stackhpc_pulp_repository_rpm_repos:
     client_cert: ""
     client_key: ""
     policy: on_demand
+    proxy_url: "{{ pulp_proxy_url }}"
     sync_policy: mirror_complete
     state: present
     required: "{{ stackhpc_pulp_sync_rocky_8 | bool }}"
@@ -297,6 +301,7 @@ stackhpc_pulp_repository_rpm_repos:
     client_cert: ""
     client_key: ""
     policy: on_demand
+    proxy_url: "{{ pulp_proxy_url }}"
     sync_policy: mirror_complete
     state: present
     required: "{{ stackhpc_pulp_sync_rocky_8 | bool }}"
@@ -346,6 +351,7 @@ stackhpc_pulp_repository_rpm_repos:
     client_cert: ""
     client_key: ""
     policy: on_demand
+    proxy_url: "{{ pulp_proxy_url }}"
     sync_policy: mirror_complete
     state: present
     required: "{{ stackhpc_pulp_sync_for_local_container_build | bool and stackhpc_pulp_sync_el_8 | bool }}"
@@ -357,6 +363,7 @@ stackhpc_pulp_repository_rpm_repos:
     client_cert: ""
     client_key: ""
     policy: on_demand
+    proxy_url: "{{ pulp_proxy_url }}"
     sync_policy: mirror_complete
     state: present
     required: "{{ stackhpc_pulp_sync_for_local_container_build | bool and stackhpc_pulp_sync_el_8 | bool }}"
@@ -368,6 +375,7 @@ stackhpc_pulp_repository_rpm_repos:
     client_cert: ""
     client_key: ""
     policy: on_demand
+    proxy_url: "{{ pulp_proxy_url }}"
     sync_policy: mirror_complete
     state: present
     required: "{{ stackhpc_pulp_sync_for_local_container_build | bool and stackhpc_pulp_sync_el_8 | bool }}"
@@ -379,6 +387,7 @@ stackhpc_pulp_repository_rpm_repos:
     client_cert: ""
     client_key: ""
     policy: on_demand
+    proxy_url: "{{ pulp_proxy_url }}"
     sync_policy: mirror_complete
     state: present
     required: "{{ stackhpc_pulp_sync_for_local_container_build | bool and stackhpc_pulp_sync_el_8 | bool }}"
@@ -390,6 +399,7 @@ stackhpc_pulp_repository_rpm_repos:
     client_cert: ""
     client_key: ""
     policy: on_demand
+    proxy_url: "{{ pulp_proxy_url }}"
     sync_policy: mirror_complete
     state: present
     required: "{{ stackhpc_pulp_sync_for_local_container_build | bool and stackhpc_pulp_sync_el_8 | bool }}"
@@ -401,6 +411,7 @@ stackhpc_pulp_repository_rpm_repos:
     client_cert: ""
     client_key: ""
     policy: on_demand
+    proxy_url: "{{ pulp_proxy_url }}"
     sync_policy: mirror_complete
     state: present
     required: "{{ stackhpc_pulp_sync_for_local_container_build | bool and stackhpc_pulp_sync_el_8 | bool }}"
@@ -412,6 +423,7 @@ stackhpc_pulp_repository_rpm_repos:
     client_cert: ""
     client_key: ""
     policy: on_demand
+    proxy_url: "{{ pulp_proxy_url }}"
     sync_policy: mirror_complete
     state: present
     required: "{{ stackhpc_pulp_sync_for_local_container_build | bool and stackhpc_pulp_sync_el_8 | bool }}"
@@ -423,6 +435,7 @@ stackhpc_pulp_repository_rpm_repos:
     client_cert: ""
     client_key: ""
     policy: on_demand
+    proxy_url: "{{ pulp_proxy_url }}"
     sync_policy: mirror_complete
     state: present
     required: "{{ stackhpc_pulp_sync_for_local_container_build | bool and stackhpc_pulp_sync_el_8 | bool }}"
@@ -434,6 +447,7 @@ stackhpc_pulp_repository_rpm_repos:
     client_cert: ""
     client_key: ""
     policy: on_demand
+    proxy_url: "{{ pulp_proxy_url }}"
     sync_policy: mirror_complete
     state: present
     required: "{{ stackhpc_pulp_sync_for_local_container_build | bool and stackhpc_pulp_sync_el_8 | bool }}"
@@ -445,6 +459,7 @@ stackhpc_pulp_repository_rpm_repos:
     client_cert: ""
     client_key: ""
     policy: on_demand
+    proxy_url: "{{ pulp_proxy_url }}"
     sync_policy: mirror_complete
     state: present
     required: "{{ stackhpc_pulp_sync_for_local_container_build | bool and stackhpc_pulp_sync_el_8 | bool }}"
@@ -456,6 +471,7 @@ stackhpc_pulp_repository_rpm_repos:
     client_cert: ""
     client_key: ""
     policy: on_demand
+    proxy_url: "{{ pulp_proxy_url }}"
     sync_policy: mirror_complete
     state: present
     required: "{{ stackhpc_pulp_sync_for_local_container_build | bool and stackhpc_pulp_sync_el_8 | bool }}"
@@ -870,6 +886,7 @@ stackhpc_pulp_repository_container_repos_ceph:
   - name: "ceph/ceph"
     url: "https://quay.io"
     policy: on_demand
+    proxy_url: "{{ pulp_proxy_url }}"
     state: present
     include_tags: "{{ cephadm_image_tag }}"
     required: "{{ stackhpc_sync_ceph_images | bool }}"


### PR DESCRIPTION
This was causing pulp-container-sync to hang on synchronising ceph/ceph in an environment behind an HTTP proxy.