### PR TITLE
Refactor tag overrides

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -96,7 +96,7 @@ kolla_docker_registry_password: "{{ stackhpc_docker_registry_password }}"
 
 # Kolla OpenStack release version. This should be a Docker image tag.
 # Default is {{ openstack_release }}.
-kolla_openstack_release: "{% if kolla_base_distro == 'centos' %}yoga-20230217T135826{% elif kolla_base_distro == 'rocky' %}yoga-20230310T170929{% else %}yoga-20230220T181235{% endif %}"
+kolla_openstack_release: "{% raw %}{{ kayobe_image_tags['openstack'][kolla_base_distro] }}{% endraw %}"
 
 # Docker tag applied to built container images. Default is
 # {{ kolla_openstack_release }}.

--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -4,44 +4,62 @@
 # To work around issue of trying to install docker from
 # empty pulp server, use upstream docker dnf repo on
 # non-overcloud hosts
-enable_docker_repo: {% raw %}"{{ 'overcloud' not in group_names or ansible_facts.os_family == 'Debian' }}"{% endraw %}
+enable_docker_repo: "{% raw %}{{ 'overcloud' not in group_names or ansible_facts.os_family == 'Debian' }}{% endraw %}"
+
+kolla_base_distro: "{% raw %}{{ ansible_facts.distribution | lower }}{% endraw %}"
 
 neutron_tag: yoga-20230515T150233
+nova_tag: yoga-20230518T105834
 octavia_tag: yoga-20230523T110936
 openvswitch_tag: yoga-20230515T150233
 ovn_tag: yoga-20230515T150233
 
-{% if kolla_base_distro == 'centos' %}
-bifrost_tag: yoga-20230217T160618
-blazar_tag: yoga-20230315T125157
-caso_tag: yoga-20230315T125157
-grafana_tag: yoga-20230419T085955
-ironic_tag: yoga-20230316T154655
-ironic_dnsmasq_tag: yoga-20230217T135826
-nova_tag: yoga-20230518T105834
-opensearch_tag: yoga-20230324T084510
-prometheus_node_exporter_tag: yoga-20230310T173747
-{% elif kolla_base_distro == 'rocky' %}
-bifrost_tag: yoga-20230310T194732
-blazar_tag: yoga-20230315T130918
-caso_tag: yoga-20230315T130918
-grafana_tag: yoga-20230419T111514
-ironic_tag: yoga-20230316T170311
-ironic_dnsmasq_tag: yoga-20230310T170929
-nova_tag: yoga-20230518T105834
-opensearch_tag: yoga-20230324T090413
-prometheus_node_exporter_tag: yoga-20230315T170614
-{% else %}
-bifrost_tag: yoga-20230220T184947
-blazar_tag: yoga-20230315T125441
-caso_tag: yoga-20230315T125441
-grafana_tag: yoga-20230426T084340
-nova_tag: yoga-20230518T105834
-ironic_tag: yoga-20230316T154704
-ironic_dnsmasq_tag: yoga-20230220T181235
-opensearch_tag: yoga-20230324T090345
-prometheus_node_exporter_tag: yoga-20230315T170541
-{% endif %}
+kayobe_image_tags:
+  openstack:
+    centos: yoga-20230217T135826
+    rocky: yoga-20230310T170929
+    ubuntu: yoga-20230220T181235
+  bifrost:
+    centos: yoga-20230217T160618
+    rocky: yoga-20230310T194732
+    ubuntu: yoga-20230220T184947
+  blazar:
+    centos: yoga-20230315T125157
+    rocky: yoga-20230315T130918
+    ubuntu: yoga-20230315T125441
+  caso:
+    centos: yoga-20230315T125157
+    rocky: yoga-20230315T130918
+    ubuntu: yoga-20230315T125441
+  grafana:
+    centos: yoga-20230419T085955
+    rocky: yoga-20230419T111514
+    ubuntu: yoga-20230426T084340
+  ironic:
+    centos: yoga-20230316T154655
+    rocky: yoga-20230316T170311
+    ubuntu: yoga-20230316T154704
+  ironic_dnsmasq:
+    centos: yoga-20230217T135826
+    rocky: yoga-20230310T170929
+    ubuntu: yoga-20230220T181235
+  opensearch:
+    centos: yoga-20230324T084510
+    rocky: yoga-20230324T090413
+    ubuntu: yoga-20230324T090345
+  prometheus_node_exporter:
+    centos: yoga-20230310T173747
+    rocky: yoga-20230315T170614
+    ubuntu: yoga-20230315T170541
+
+bifrost_tag: "{% raw %}{{ kayobe_image_tags['bifrost'][kolla_base_distro] | default(openstack_tag) }}{% endraw %}"
+blazar_tag: "{% raw %}{{ kayobe_image_tags['blazar'][kolla_base_distro] | default(openstack_tag) }}{% endraw %}"
+caso_tag: "{% raw %}{{ kayobe_image_tags['caso'][kolla_base_distro] | default(openstack_tag) }}{% endraw %}"
+grafana_tag: "{% raw %}{{ kayobe_image_tags['grafana'][kolla_base_distro] | default(openstack_tag) }}{% endraw %}"
+ironic_tag: "{% raw %}{{ kayobe_image_tags['ironic'][kolla_base_distro] | default(openstack_tag) }}{% endraw %}"
+ironic_dnsmasq_tag: "{% raw %}{{ kayobe_image_tags['ironic_dnsmasq'][kolla_base_distro] | default(openstack_tag) }}{% endraw %}"
+opensearch_tag: "{% raw %}{{ kayobe_image_tags['opensearch'][kolla_base_distro] | default(openstack_tag) }}{% endraw %}"
+prometheus_node_exporter_tag: "{% raw %}{{ kayobe_image_tags['prometheus_node_exporter'][kolla_base_distro] | default(openstack_tag) }}{% endraw %}"
 
 glance_tls_proxy_tag: "{% raw %}{{ haproxy_tag | default(openstack_tag) }}{% endraw %}"
 neutron_tls_proxy_tag: "{% raw %}{{ haproxy_tag | default(openstack_tag) }}{% endraw %}"

--- a/releasenotes/notes/refactor-tag-overrides-1ad66680fd801345.yaml
+++ b/releasenotes/notes/refactor-tag-overrides-1ad66680fd801345.yaml
@@ -1,0 +1,6 @@
+---
+upgrade:
+  - |
+    Kolla tag overrides have been refactored to allow kolla-ansible to
+    resolve them individually by host. This means that mixed clouds can be
+    deployed which allows for migration between distributions.


### PR DESCRIPTION
This refactor includes two changes

The first sets kolla_base_distro according to ansible facts, and is resolved by kolla-ansible on a host by host basis.

The second reformats the existing structure for override tags, again allowing kolla-ansible to resolve them on a host by host basis.

The result of these two changes is that clouds with with mixed host distributions can be deployed.

This is relevant when performing a rolling migration between two distributions.