### PR TITLE
Nova bugfix 1805969

### DIFF
--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -17,7 +17,7 @@ caso_tag: yoga-20230315T125157
 grafana_tag: yoga-20230419T085955
 ironic_tag: yoga-20230316T154655
 ironic_dnsmasq_tag: yoga-20230217T135826
-nova_tag: yoga-20230331T102705
+nova_tag: yoga-20230518T105834
 opensearch_tag: yoga-20230324T084510
 prometheus_node_exporter_tag: yoga-20230310T173747
 {% elif kolla_base_distro == 'rocky' %}
@@ -27,7 +27,7 @@ caso_tag: yoga-20230315T130918
 grafana_tag: yoga-20230419T111514
 ironic_tag: yoga-20230316T170311
 ironic_dnsmasq_tag: yoga-20230310T170929
-nova_tag: yoga-20230331T113516
+nova_tag: yoga-20230518T105834
 opensearch_tag: yoga-20230324T090413
 prometheus_node_exporter_tag: yoga-20230315T170614
 {% else %}
@@ -35,7 +35,7 @@ bifrost_tag: yoga-20230220T184947
 blazar_tag: yoga-20230315T125441
 caso_tag: yoga-20230315T125441
 grafana_tag: yoga-20230426T084340
-nova_tag: yoga-20230331T110423
+nova_tag: yoga-20230518T105834
 ironic_tag: yoga-20230316T154704
 ironic_dnsmasq_tag: yoga-20230220T181235
 opensearch_tag: yoga-20230324T090345

--- a/releasenotes/notes/nova-pci-request-resize-a429c115ba2818e8.yaml
+++ b/releasenotes/notes/nova-pci-request-resize-a429c115ba2818e8.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix for nova resize API not parsing the new flavor on resize - bug 1805969.


### PR DESCRIPTION
Fix for nova not parsing RequestSpec.pci_request when resizing.

Quoting upstream change:

> Nova uses the RequestSpec.pci_request in the PciPassthroughFilter to
decide if the PCI devicesm, requested via the pci_alias in the flavor
extra_spec, are available on a potential target host. During resize the
new flavor might contain different pci_alias request than the old flavor
of the instance. In this case Nova should use the pci_alias from the new
flavor to scheduler the destination host of the resize. However this
logic was missing and Nova used the old pci_request value based on the
old flavor. This patch adds the missing logic.

This behaviour resulted in resize not being executed.