### PR TITLE
Fix cephadm image tag conditional error

### DIFF
--- a/etc/kayobe/cephadm.yml
+++ b/etc/kayobe/cephadm.yml
@@ -12,7 +12,7 @@ cephadm_ceph_release: "{{ 'quincy' if (ansible_facts['distribution_release'] == 
 cephadm_image: "{{ stackhpc_docker_registry if stackhpc_sync_ceph_images | bool else 'quay.io' }}/ceph/ceph:{{ cephadm_image_tag }}"
 
 # Ceph container image tag.
-cephadm_image_tag: "{{ 'v17.2.6' if ansible_facts['distribution_release'] == 'jammy' else 'v16.2.11' }}"
+cephadm_image_tag: "{{ 'v17.2.6' if os_release == 'jammy' else 'v16.2.11' }}"
 
 # Ceph custom repo workaround for Ubuntu Jammy as there are no official ceph repos for jammy.
 cephadm_custom_repos: "{{ ansible_facts['distribution_release'] == 'jammy' }}"


### PR DESCRIPTION
This change allows the pulp container/repo playbooks for syncing and publishing to be configured using ansible facts.

Recent changes use facts to set the Ceph images, which therefore fails.

```
   The conditional check 'pulp_repository_container_repos | length > 0' failed. The error was: error while evaluating conditional (pulp_repository_container_repos | length > 0): {{ stackhpc_pulp_repository_container_repos }}:{{(stackhpc_pulp_repository_container_repos_kolla + stackhpc_pulp_repository_container_repos_ceph) | selectattr('required') }}: [AnsibleMapping([('name', 'ceph/ceph'), ('url', 'https://quay.io'), ('policy', 'on_demand'), ('proxy_url', '{{ pulp_proxy_url }}'), ('state', 'present'), ('include_tags', '{{ cephadm_image_tag }}'), ('required', '{{ stackhpc_sync_ceph_images | bool }}')])]: {{'v17.2.6' if ansible_facts['distribution_release'] == 'jammy' else 'v16.2.11' }}: 'dict object' has no attribute 'distribution_release'
```
The alternative would be to replace the `cephadm_image_tag` conditional with something based on `os_release`
