### PR TITLE
Cap number of Pulp workers

### DIFF
--- a/etc/kayobe/seed.yml
+++ b/etc/kayobe/seed.yml
@@ -112,8 +112,8 @@ seed_pulp_container:
     # s6-overlay-suexec starts as pid 1
     init: false
     env:
-      PULP_CONTENT_WORKERS: "{{ ansible_facts.processor_vcpus * 2 + 1 }}"
-      PULP_API_WORKERS: "{{ ansible_facts.processor_vcpus * 2 + 1 }}"
+      PULP_CONTENT_WORKERS: "{{ [ansible_facts.processor_vcpus * 2 + 1, 32] | min }}"
+      PULP_API_WORKERS: "{{ [ansible_facts.processor_vcpus * 2 + 1, 32] | min }}"
       PULP_HTTPS: "{{ 'true' if pulp_enable_tls | bool else 'false' }}"
     volumes:
       - /opt/kayobe/containers/pulp:/etc/pulp

--- a/releasenotes/notes/cap-pulp-workers-e0f12c0b67d3d0bf.yaml
+++ b/releasenotes/notes/cap-pulp-workers-e0f12c0b67d3d0bf.yaml
@@ -1,0 +1,4 @@
+fixes:
+  - |
+    Caps the number of Pulp API and content workers to 32 each to avoid errors
+    on hosts with many CPUs.


### PR DESCRIPTION
Running Pulp with a number of workers based on CPUs can cause errors such as PostgreSQL connection limits on hosts with many cores:

    psycopg.OperationalError: connection failed: FATAL:  remaining connection slots are reserved for non-replication superuser connections

Cap workers to 32 until large scale testing can identify a more suitable limit.