### PR TITLE
Fix loop label syntax in cephadm-gather-keys.yml

### DIFF
--- a/etc/kayobe/ansible/cephadm-gather-keys.yml
+++ b/etc/kayobe/ansible/cephadm-gather-keys.yml
@@ -43,8 +43,7 @@
         path: "{{ kayobe_env_config_path }}/kolla/config/{{ kolla_service_to_key_dir[item.name] }}"
       loop: "{{ kolla_ceph_services | selectattr('required') }}"
       loop_control:
-        label:
-          service: "{{ item.name }}"
+        label: "{{ item.name }}"
       delegate_to: localhost
 
     - name: Save Ceph keys to Kayobe configuration
@@ -59,9 +58,7 @@
         dest: "{{ kayobe_env_config_path }}/kolla/config/{{ kolla_service_to_key_dir[item.0.name] }}/ceph.{{ cephadm_user }}.keyring"
       loop: "{{ query('subelements', kolla_ceph_services | selectattr('required'), 'keys') }}"
       loop_control:
-        label:
-          service: "{{ item.0.name }}"
-          key: "{{ item.1 }}"
+        label: "{{ item.0.name }}: {{ item.1 }}"
       delegate_to: localhost
       notify: Please add and commit the Kayobe configuration
 
@@ -74,9 +71,7 @@
         dest: "{{ kayobe_env_config_path }}/kolla/config/{{ kolla_service_to_conf_dir[item.0.name] }}/ceph.conf"
       loop: "{{ query('subelements', kolla_ceph_services | selectattr('required'), 'keys') }}"
       loop_control:
-        label:
-          service: "{{ item.0.name }}"
-          key: "{{ item.1 }}"
+        label: "{{ item.0.name }}: {{ item.1 }}"
       delegate_to: localhost
       notify: Please add and commit the Kayobe configuration
 


### PR DESCRIPTION
Loop labels are required to be strings. This was not properly enforced in previous versions of Ansible, but starting in ansible-core 2.15 this will cause a parse-time error.

```
ERROR! The field 'label' is supposed to be a string type, however the incoming data structure is a <class 'ansible.parsing.yaml.objects.AnsibleMapping'>

The error appears to be in 'cephadm-gather-keys.yml': line 46, column 9, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

      loop_control:
        label:
        ^ here
```