### PR TITLE
Add LVM config for AIOs

### DIFF
--- a/doc/source/contributor/environments/ci-aio.rst
+++ b/doc/source/contributor/environments/ci-aio.rst
@@ -42,6 +42,11 @@ Run the setup script:
 
    ./automated-setup.sh
 
+Adding the ``--lvm`` flag will also automatically set the LVM configuration,
+which can be modified in
+``etc/kayobe/environments/ci-aio/inventory/group_vars/controllers/lvm.yml``. A
+minimum 30GB root disk is recommended.
+
 The script will pull the current version of Kayobe and this repository, and
 then run the manual setup steps below. The script can be easily edited to use
 a different branch of Kayobe or this repository.

--- a/etc/kayobe/environments/ci-aio/automated-setup.sh
+++ b/etc/kayobe/environments/ci-aio/automated-setup.sh
@@ -6,6 +6,11 @@ cat << EOF | sudo tee -a /etc/hosts
 10.205.3.187 pulp-server pulp-server.internal.sms-cloud
 EOF
 
+if [ "${1-0}" = "--lvm" ]; then
+   sudo lvextend -L 2G /dev/rootvg/lv_home -r || true
+   sudo lvextend -L 2.5G /dev/rootvg/lv_tmp -r || true
+fi
+
 BASE_PATH=~
 KAYOBE_BRANCH=stackhpc/yoga
 KAYOBE_CONFIG_BRANCH=stackhpc/yoga
@@ -61,6 +66,8 @@ pushd $BASE_PATH/src/kayobe-config
 source kayobe-env --environment ci-aio
 
 kayobe control host bootstrap
+
+kayobe playbook run etc/kayobe/ansible/growroot.yml
 
 kayobe overcloud host configure
 

--- a/etc/kayobe/environments/ci-aio/controllers.yml
+++ b/etc/kayobe/environments/ci-aio/controllers.yml
@@ -5,3 +5,8 @@
 # User with which to access the controllers via SSH during bootstrap, in order
 # to setup the Kayobe user account. Default is {{ os_distribution }}.
 controller_bootstrap_user: "{{ os_distribution if os_distribution == 'ubuntu' else 'cloud-user' }}"
+
+# Controller lvm configuration. See intentory/group_vars/controllers/lvm.yml
+# for the exact configuration.
+controller_lvm_groups:
+  - "{{ stackhpc_lvm_group_rootvg }}"

--- a/etc/kayobe/environments/ci-aio/inventory/group_vars/controllers/lvm.yml
+++ b/etc/kayobe/environments/ci-aio/inventory/group_vars/controllers/lvm.yml
@@ -1,0 +1,34 @@
+---
+# List of extra LVs to include in the rootvg VG.
+stackhpc_lvm_group_rootvg_lvs_extra:
+  - "{{ stackhpc_lvm_lv_docker }}"
+
+###############################################################################
+# StackHPC LVM Logical Volume (LV) configuration.
+
+# StackHPC LVM lv_swap LV size.
+stackhpc_lvm_lv_swap_size: 100m
+
+# StackHPC LVM lv_root LV size.
+stackhpc_lvm_lv_root_size: 2g
+
+# StackHPC LVM lv_tmp LV size.
+stackhpc_lvm_lv_tmp_size: 2.5g
+
+# StackHPC LVM lv_var LV size.
+stackhpc_lvm_lv_var_size: 2.5g
+
+# StackHPC LVM lv_var_tmp LV size.
+stackhpc_lvm_lv_var_tmp_size: 0.5g
+
+# StackHPC LVM lv_log LV size.
+stackhpc_lvm_lv_log_size: 4g
+
+# StackHPC LVM lv_audit LV size.
+stackhpc_lvm_lv_audit_size: 100m
+
+# StackHPC LVM lv_home LV size.
+stackhpc_lvm_lv_home_size: 1.5G
+
+# StackHPC LVM lv_docker LV size.
+stackhpc_lvm_lv_docker_size: 100%FREE


### PR DESCRIPTION
Adds an lvm configuration for the ci-aio environment and updates the automated setup script with an --lvm flag for additional configuration.

A minimum 30gb root disk is recommended