### PR TITLE
Add opensearch to Rocky AIOs/Multinodes

### DIFF
--- a/etc/kayobe/environments/ci-aio/stackhpc-ci.yml
+++ b/etc/kayobe/environments/ci-aio/stackhpc-ci.yml
@@ -5,9 +5,6 @@
 # Docker namespace to use for Kolla images. Default is 'kolla'.
 kolla_docker_namespace: stackhpc-dev
 
-# Do not enable central logging if using Rocky Linux 9. It does not have elasticsearch
-kolla_enable_central_logging: "{{ os_release != '9' }}"
-
 ###############################################################################
 # Network configuration.
 

--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -45,7 +45,7 @@ kayobe_image_tags:
     ubuntu: yoga-20230220T181235
   opensearch:
     centos: yoga-20230324T084510
-    rocky: yoga-20230324T090413
+    rocky: yoga-20230622T154317
     ubuntu: yoga-20230324T090345
   prometheus_node_exporter:
     centos: yoga-20230310T173747


### PR DESCRIPTION
Updating the Rocky opensearch tag and enabling centralised logging with opensearch in Rocky AIOs.
I haven't included a release note but can do if it's deemed necessary 