### PR TITLE
Improve multinode

### DIFF
--- a/etc/kayobe/environments/ci-multinode/globals.yml
+++ b/etc/kayobe/environments/ci-multinode/globals.yml
@@ -51,8 +51,10 @@ os_distribution: "{{ lookup('pipe', '. /etc/os-release && echo $ID') | trim }}"
 
 # OS release. Valid options are "8-stream" when os_distribution is "centos", or
 # "focal" when os_distribution is "ubuntu".
-#os_release:
-
+os_release: >-
+          {{ (lookup('pipe', '. /etc/os-release && echo $VERSION_CODENAME') | trim) if os_distribution == 'ubuntu' else
+             (lookup('pipe', '. /etc/os-release && echo $VERSION_ID') | trim | split('.') | first) if os_distribution == 'rocky' else
+             'stream-8' }}
 ###############################################################################
 
 # Avoid a reboot.

--- a/etc/kayobe/environments/ci-multinode/networks.yml
+++ b/etc/kayobe/environments/ci-multinode/networks.yml
@@ -81,7 +81,7 @@ internal_vlan: 101
 
 # External network
 external_cidr: 192.168.38.0/24
-external_mtu: 1450
+external_mtu: "{{ ansible_facts.default_ipv4.mtu - 50 }}"
 external_allocation_pool_start: 192.168.38.3
 external_allocation_pool_end: 192.168.38.128
 external_vlan: 102


### PR DESCRIPTION
This change includes two QOL improvements to the multinode environment.

The first corrects the MTU definition on the external network.

The second sets os_release automatically based on the contents of /etc/os-release