### PR TITLE
Support Ceph ingress images stored in Pulp

### DIFF
--- a/etc/kayobe/ansible/requirements.yml
+++ b/etc/kayobe/ansible/requirements.yml
@@ -1,7 +1,7 @@
 ---
 collections:
   - name: stackhpc.cephadm
-    version: 1.13.2
+    version: 1.14.0
   - name: stackhpc.pulp
     version: 0.4.1
   - name: stackhpc.hashicorp

--- a/etc/kayobe/cephadm.yml
+++ b/etc/kayobe/cephadm.yml
@@ -17,6 +17,18 @@ cephadm_image_tag: "{{ 'v17.2.6' if os_release == 'jammy' else 'v16.2.11' }}"
 # Ceph custom repo workaround for Ubuntu Jammy as there are no official ceph repos for jammy.
 cephadm_custom_repos: "{{ ansible_facts['distribution_release'] == 'jammy' }}"
 
+# HAProxy container image.
+cephadm_haproxy_image: "{{ stackhpc_docker_registry if stackhpc_sync_ceph_images | bool else 'quay.io' }}/ceph/haproxy:{{ cephadm_haproxy_image_tag }}"
+
+# HAProxy container image tag.
+cephadm_haproxy_image_tag: "2.3"
+
+# Keepalived container image.
+cephadm_keepalived_image: "{{ stackhpc_docker_registry if stackhpc_sync_ceph_images | bool else 'quay.io' }}/ceph/keepalived:{{ cephadm_keepalived_image_tag }}"
+
+# Keepalived container image tag.
+cephadm_keepalived_image_tag: "2.1.5"
+
 # Ceph container image registry URL.
 cephadm_registry_url: "{{ stackhpc_docker_registry }}"
 

--- a/etc/kayobe/pulp.yml
+++ b/etc/kayobe/pulp.yml
@@ -728,12 +728,36 @@ stackhpc_pulp_repository_container_repos_ceph:
     state: present
     include_tags: "{{ cephadm_image_tag }}"
     required: "{{ stackhpc_sync_ceph_images | bool }}"
+  - name: "ceph/haproxy"
+    url: "https://quay.io"
+    policy: on_demand
+    proxy_url: "{{ pulp_proxy_url }}"
+    state: present
+    include_tags: "{{ cephadm_haproxy_image_tag }}"
+    required: "{{ stackhpc_sync_ceph_images | bool }}"
+  - name: "ceph/keepalived"
+    url: "https://quay.io"
+    policy: on_demand
+    proxy_url: "{{ pulp_proxy_url }}"
+    state: present
+    include_tags: "{{ cephadm_keepalived_image_tag }}"
+    required: "{{ stackhpc_sync_ceph_images | bool }}"
 
 # List of Ceph container image distributions.
 stackhpc_pulp_distribution_container_ceph:
   - name: ceph
     repository: ceph/ceph
     base_path: ceph/ceph
+    state: present
+    required: "{{ stackhpc_sync_ceph_images | bool }}"
+  - name: ceph/haproxy
+    repository: ceph/haproxy
+    base_path: ceph/haproxy
+    state: present
+    required: "{{ stackhpc_sync_ceph_images | bool }}"
+  - name: ceph/keepalived
+    repository: ceph/keepalived
+    base_path: ceph/keepalived
     state: present
     required: "{{ stackhpc_sync_ceph_images | bool }}"
 

--- a/releasenotes/notes/ceph-ingress-images-e756bde5087460ad.yaml
+++ b/releasenotes/notes/ceph-ingress-images-e756bde5087460ad.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Adds support for using Ceph HAProxy and Keepalived images stored in Pulp.
+    This is enabled automatically if ``stackhpc_sync_ceph_images`` is set to
+    ``true``.


### PR DESCRIPTION
This requires stackhpc.cephadm 1.14.0 (now available).