### PR TITLE
Add magnum container footer

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -339,7 +339,8 @@ kolla_build_blocks:
     RUN sed -i 's/"pc-q35-rhel8.5.0"/"pc-q35-*"/' /usr/share/qemu/firmware/50-edk2-ovmf-cc.json
     {% endif %}
     {% endraw %}
-
+  magnum_base_footer: |
+    RUN curl -fsL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | head -n -1 | bash
 # Dict mapping image customization variable names to their values.
 # Each variable takes the form:
 # <image name>_<customization>_<operation>

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -340,7 +340,7 @@ kolla_build_blocks:
     {% endif %}
     {% endraw %}
   magnum_base_footer: |
-    RUN curl -fsL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | head -n -1 | bash
+    RUN curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | head -n -1 | bash
 # Dict mapping image customization variable names to their values.
 # Each variable takes the form:
 # <image name>_<customization>_<operation>

--- a/releasenotes/notes/magnum-container-footer-dcf6dca0667bcb94.yaml
+++ b/releasenotes/notes/magnum-container-footer-dcf6dca0667bcb94.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    adds helm client into magnum container


### PR DESCRIPTION
the new cluster api driver requires helm to be installed in the containers. this is a temporary place for it to be installed until it is added to upstream kolla containers