### PR TITLE
Fix overcloud host image promotion workflow

### DIFF
--- a/.github/workflows/overcloud-host-image-promote.yml
+++ b/.github/workflows/overcloud-host-image-promote.yml
@@ -3,17 +3,26 @@ name: Promote overcloud host image
 on:
   workflow_dispatch:
     inputs:
-      os_image:
-        description: Image to promote
-        type: choice
-        required: true
-        default: 'CentOS Stream 8'
-        options:
-          - 'CentOS Stream 8'
-          - 'Rocky Linux 8'
-          - 'Rocky Linux 9'
-          - 'Ubuntu Focal 20.04'
-          - 'Ubuntu Jammy 22.04'
+      centos:
+        description: Promote CentOS Stream 8
+        type: boolean
+        default: true
+      rocky8:
+        description: Promote Rocky Linux 8
+        type: boolean
+        default: true
+      rocky9:
+        description: Promote Rocky Linux 9
+        type: boolean
+        default: true
+      ubuntu-focal:
+        description: Promote Ubuntu 20.04 Focal
+        type: boolean
+        default: true
+      ubuntu-jammy:
+        description: Promote Ubuntu 22.04 Jammy
+        type: boolean
+        default: true
       image_tag:
         description: Tag to promote
         type: string
@@ -78,14 +87,6 @@ jobs:
           source src/kayobe-config/kayobe-env --environment ci-builder &&
           kayobe control host bootstrap
 
-      - name: Configure the seed host
-        run: |
-          source venvs/kayobe/bin/activate &&
-          source src/kayobe-config/kayobe-env --environment ci-builder &&
-          kayobe seed host configure
-        env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
-
       - name: Promote CentOS Stream 8 overcloud host image artifact
         run: |
           source venvs/kayobe/bin/activate &&
@@ -98,7 +99,7 @@ jobs:
         env:
           OVERCLOUD_HOST_IMAGE_TAG: ${{ inputs.image_tag }}
           KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
-        if: os_image == 'CentOS Stream 8'
+        if: inputs.centos
 
       - name: Promote Rocky Linux 8 overcloud host image artifact
         run: |
@@ -112,7 +113,7 @@ jobs:
         env:
           OVERCLOUD_HOST_IMAGE_TAG: ${{ inputs.image_tag }}
           KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
-        if: os_image == 'Rocky Linux 8'
+        if: inputs.rocky8
 
       - name: Promote Rocky Linux 9 overcloud host image artifact
         run: |
@@ -126,7 +127,7 @@ jobs:
         env:
           OVERCLOUD_HOST_IMAGE_TAG: ${{ inputs.image_tag }}
           KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
-        if: os_image == 'Rocky Linux 9'
+        if: inputs.rocky9
 
       - name: Promote Ubuntu Focal 20.04 overcloud host image artifact
         run: |
@@ -140,7 +141,7 @@ jobs:
         env:
           OVERCLOUD_HOST_IMAGE_TAG: ${{ inputs.image_tag }}
           KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
-        if: os_image == 'Ubuntu Focal 20.04'
+        if: inputs.ubuntu-focal
 
       - name: Promote Ubuntu Jammy 22.04 overcloud host image artifact
         run: |
@@ -154,4 +155,4 @@ jobs:
         env:
           OVERCLOUD_HOST_IMAGE_TAG: ${{ inputs.image_tag }}
           KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
-        if: os_image == 'Ubuntu Jammy 22.04'
+        if: inputs.ubuntu-jammy


### PR DESCRIPTION
Allows parallel promotion now that the images can be built with the same tags, fixes a problem with the OS selection, and removes the host configure to speed up the process by a fair margin.