### PR TITLE
Config for pulling Ark overcloud host images

### DIFF
--- a/.github/workflows/overcloud-host-image-promote.yml
+++ b/.github/workflows/overcloud-host-image-promote.yml
@@ -150,8 +150,8 @@ jobs:
           kayobe playbook run \
           src/kayobe-config/etc/kayobe/ansible/pulp-host-image-promote.yml \
           -e image_path='/opt/kayobe/images/overcloud-ubuntu-jammy' \
-          -e os_distribution='jammy' \
-          -e os_release='focal'
+          -e os_distribution='ubuntu' \
+          -e os_release='jammy'
         env:
           OVERCLOUD_HOST_IMAGE_TAG: ${{ inputs.image_tag }}
           KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}

--- a/.github/workflows/stackhpc-all-in-one.yml
+++ b/.github/workflows/stackhpc-all-in-one.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Output image tag
         id: image_tag
         run: |
-          echo image_tag=$(grep stackhpc_${{ inputs.os_distribution }}_$(sed s/-/_/ <(echo "${{ inputs.os_release }}"))_overcloud_host_image_version etc/kayobe/stackhpc-overcloud-host-images.yml | awk '{print $2}') >> $GITHUB_OUTPUT
+          echo image_tag=$(grep stackhpc_${{ inputs.os_distribution }}_$(sed s/-/_/ <(echo "${{ inputs.os_release }}"))_overcloud_host_image_version: etc/kayobe/stackhpc-overcloud-host-images.yml | awk '{print $2}') >> $GITHUB_OUTPUT
 
       # Use the image override if set, otherwise use overcloud-os_distribution-os_release-tag
       - name: Output image name

--- a/.github/workflows/stackhpc-all-in-one.yml
+++ b/.github/workflows/stackhpc-all-in-one.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Output image tag
         id: image_tag
         run: |
-          echo image_tag=$(grep stackhpc_${{ inputs.os_distribution }}_$(sed s/-/_/ <(echo "${{ inputs.os_release }}"))_overcloud_host_image_version: etc/kayobe/stackhpc-overcloud-host-images.yml | awk '{print $2}') >> $GITHUB_OUTPUT
+          echo image_tag=$(grep stackhpc_${{ inputs.os_distribution }}_$(sed s/-/_/ <(echo "${{ inputs.os_release }}"))_overcloud_host_image_version: etc/kayobe/pulp-host-image-versions.yml | awk '{print $2}') >> $GITHUB_OUTPUT
 
       # Use the image override if set, otherwise use overcloud-os_distribution-os_release-tag
       - name: Output image name

--- a/.github/workflows/stackhpc-all-in-one.yml
+++ b/.github/workflows/stackhpc-all-in-one.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Output image tag
         id: image_tag
         run: |
-          echo image_tag=$(grep stackhpc_${{ inputs.os_distribution }}_${{ inputs.os_release }}_overcloud_host_image_version etc/kayobe/environments/ci-aio/stackhpc-ci.yml | awk '{print $2}') >> $GITHUB_OUTPUT
+          echo image_tag=$(grep stackhpc_${{ inputs.os_distribution }}_$(sed s/-/_/ <(echo "${{ inputs.os_release }}"))_overcloud_host_image_version etc/kayobe/stackhpc-overcloud-host-images.yml | awk '{print $2}') >> $GITHUB_OUTPUT
 
       # Use the image override if set, otherwise use overcloud-os_distribution-os_release-tag
       - name: Output image name

--- a/doc/source/configuration/host-images.rst
+++ b/doc/source/configuration/host-images.rst
@@ -26,7 +26,8 @@ Currently, images exist for the following operating systems:
 * Ubuntu Jammy 22.04
 
 The image to download is selected automatically using the ``os_distribution``
-and ``os_release`` variables.
+and ``os_release`` variables. These images are versioned and a variable for
+each OS is stored in ``pulp-host-image-versions.yml``.
 
 This content requires the same set of credentials as is used for other
 release train content.

--- a/doc/source/configuration/host-images.rst
+++ b/doc/source/configuration/host-images.rst
@@ -4,6 +4,44 @@
 Host Images
 ===========
 
+Pulling host images
+===================
+
+StackHPC provides pre-built overcloud host images through Ark, which can be
+consumed using the configuration provided by this repository.
+
+When configured, an image will be downloaded to the seed during the
+``kayobe seed service deploy`` step, and subsequently deployed using bifrost
+with ``kayobe overcloud provision``.
+
+To use these images, set ``stackhpc_download_overcloud_host_images`` to true
+in ``etc/kayobe/stackhpc-overcloud-host-images.yml``.
+
+Currently, images exist for the following operating systems:
+
+* CentOS 8 Stream
+* Rocky Linux 8
+* Rocky Linux 9
+* Ubuntu Focal 20.04
+* Ubuntu Jammy 22.04
+
+The image to download is selected automatically using the ``os_distribution``
+and ``os_release`` variables.
+
+This content requires the same set of credentials as is used for other
+release train content.
+
+The Ark pulp credentials issued by StackHPC should be configured in
+``etc/kayobe/pulp.yml``, using Ansible Vault to encrypt the password:
+
+.. code-block:: yaml
+
+   stackhpc_release_pulp_username: <username>
+   stackhpc_release_pulp_password: <password>
+
+Building host images
+====================
+
 StackHPC Kayobe configuration provides configuration for some standard
 overcloud host images, built using the :kayobe-doc:`overcloud DIB
 <configuration/reference/overcloud-dib.html>` functionality of Kayobe.

--- a/doc/source/configuration/release-train.rst
+++ b/doc/source/configuration/release-train.rst
@@ -38,7 +38,7 @@ This configuration provides the following:
 
 * Configuration to deploy a local Pulp service as a container on the seed
 * Pulp repository definitions for CentOS Stream 8, Rocky Linux 8/9 and Ubuntu
-  Jammy
+  Focal
 * Playbooks to synchronise a local Pulp service with Ark
 * Configuration to use the local Pulp repository mirrors on control plane hosts
 * Configuration to use the local Pulp container registry on control plane hosts

--- a/doc/source/configuration/release-train.rst
+++ b/doc/source/configuration/release-train.rst
@@ -2,9 +2,9 @@
 StackHPC Release Train
 ======================
 
-StackHPC provides packages and container images for OpenStack via `Ark
-<https://ark.stackhpc.com>`__. These artifacts are built and released using a
-process known as the `Release Train
+StackHPC provides packages, container images, and host images for OpenStack via
+`Ark <https://ark.stackhpc.com>`__. These artifacts are built and released using
+a process known as the `Release Train
 <https://stackhpc.github.io/stackhpc-release-train/>`__.
 
 Deployments should use a local `Pulp <https://pulpproject.org/>`__ repository
@@ -37,10 +37,12 @@ Configuration
 This configuration provides the following:
 
 * Configuration to deploy a local Pulp service as a container on the seed
-* Pulp repository definitions for CentOS Stream 8 and Rocky Linux 8
+* Pulp repository definitions for CentOS Stream 8, Rocky Linux 8/9 and Ubuntu
+  Jammy
 * Playbooks to synchronise a local Pulp service with Ark
 * Configuration to use the local Pulp repository mirrors on control plane hosts
 * Configuration to use the local Pulp container registry on control plane hosts
+* Configuration to deploy pre-built OS images to overcloud hosts using Bifrost
 
 Local Pulp server
 -----------------
@@ -60,6 +62,10 @@ Pulp startup.
 If a proxy is required to access the Internet from the seed, ``pulp_proxy_url``
 may be used.
 
+Host images are not synchronised to the local Pulp server, since they should
+only be pulled to the seed node once. More information on host images can be
+found :ref:`here <host-images>`.
+
 StackHPC Ark
 ------------
 
@@ -74,12 +80,12 @@ The Ark pulp credentials issued by StackHPC should be configured in
 Package repositories
 --------------------
 
-Currently, Ark does not provide package repositories for Ubuntu - only
-container images. For this reason, ``stackhpc_pulp_sync_ubuntu_focal`` in
-``etc/kayobe/pulp.yml`` is set to ``false`` by default.
+Currently, Ark does not provide package repositories for Ubuntu Jammy 22.04 -
+only container images.
 
-CentOS Stream 8 and Rocky Linux 8/9 package repositories are synced based on the
-value of ``os_distribution``. If you need to sync multiple distributions,
+CentOS Stream 8, Rocky Linux 8/9, and Ubuntu Focal package repositories are
+synced based on the value of ``os_distribution`` and ``os_release`` . If you
+need to sync multiple RHEL-like distributions,
 ``stackhpc_pulp_sync_centos_stream8``, ``stackhpc_pulp_sync_rocky_8`` and
 ``stackhpc_pulp_sync_rocky_9`` in ``etc/kayobe/pulp.yml`` may be set to
 ``true``.
@@ -93,8 +99,15 @@ repository.
 Package managers
 ----------------
 
-No configuration is provided for APT, since Ark does not currently provide
-package repositories for Ubuntu - only container images.
+For Ubuntu Focal systems, the package manager configuration is provided by
+``stackhpc_apt_repositories`` in ``etc/kayobe/apt.yml``.
+
+The configuration is applied by default to all Ubuntu Focal hosts. The
+configuration can be overridden by changing the repository definitions in
+``apt_repositories`` or toggling ``apt_disable_sources_list`` to use the default
+apt repositories. This can be done on a host-by host basis by defining the
+variables as host or group vars under ``etc/kayobe/inventory/host_vars`` or
+``etc/kayobe/inventory/group_vars``.
 
 For CentOS and Rocky Linux based systems, package manager configuration is
 provided by ``stackhpc_dnf_repos`` in ``etc/kayobe/dnf.yml``, which points to
@@ -104,6 +117,9 @@ package repositories on the local Pulp server. To use this configuration, the
 ``etc/kayobe/inventory/group_vars/overcloud/stackhpc-dnf-repos``. Similar
 configuration may be added for other groups, however there may be ordering
 issues during initial deployment when Pulp has not yet been deployed.
+
+In both instances, the configuration points to package repositories on the
+local Pulp server.
 
 The distribution name for the environment should be configured as either
 ``development`` or ``production`` via ``stackhpc_repo_distribution`` in
@@ -149,7 +165,7 @@ See the Kayobe :kayobe-doc:`custom playbook documentation
   these are new container image repositories, then the new image tags will not
   be available to cloud nodes until they have been published.
 * ``pulp-container-publish.yml``: Publish synchronised container images in the
-  local Pulp. This will make synchonised container images available to cloud
+  local Pulp. This will make synchronised container images available to cloud
   nodes.
 
 Syncing content
@@ -267,4 +283,4 @@ you will see a 404 error during ``pulp-repo-sync.yml``:
       msg: Task failed to complete. (failed; 404, message='Not Found', url=URL('https://ark.stackhpc.com/pulp/content/centos/8-stream/BaseOS/x86_64/os/20211122T102435')) '''
 
 The issue can be rectified by updating the ``stackhpc_release_pulp_username``
-and ``stackhpc_release_pulp_password`` variables
+and ``stackhpc_release_pulp_password`` variables.

--- a/etc/kayobe/environments/ci-aio/stackhpc-ci.yml
+++ b/etc/kayobe/environments/ci-aio/stackhpc-ci.yml
@@ -80,10 +80,3 @@ stackhpc_docker_registry_password: !vault |
   38333133393730633666613965653364316162353337313330346164303631313731646461363461
   3963323635373866630a633533376339363734626664333765313665623662613764363038383735
   38646138376438643533376161376634653439386230353365316239613430363338
-
-# Overcloud host image tags
-stackhpc_centos_8-stream_overcloud_host_image_version: "yoga-20230525T095243"
-stackhpc_rocky_8_overcloud_host_image_version: "yoga-20230629T135322"
-stackhpc_rocky_9_overcloud_host_image_version: "yoga-20230515T145140"
-stackhpc_ubuntu_focal_overcloud_host_image_version: "yoga-20230609T120720"
-stackhpc_ubuntu_jammy_overcloud_host_image_version: "yoga-20230609T120720"

--- a/etc/kayobe/kolla/config/bifrost.yml
+++ b/etc/kayobe/kolla/config/bifrost.yml
@@ -2,7 +2,6 @@
 ---
 # Use prebuilt release train images from Ark.
 {% if stackhpc_download_overcloud_host_images | bool %}
-overcloud_dib_build_host_images: false
 use_cirros: true
 cirros_deploy_image_upstream_url: "{{ stackhpc_overcloud_host_image_url }}"
 {% endif %}

--- a/etc/kayobe/kolla/config/bifrost.yml
+++ b/etc/kayobe/kolla/config/bifrost.yml
@@ -1,0 +1,8 @@
+# yamllint disable-file
+---
+# Use prebuilt release train images from Ark.
+{% if stackhpc_download_overcloud_host_images | bool %}
+overcloud_dib_build_host_images: false
+use_cirros: true
+cirros_deploy_image_upstream_url: "{{ stackhpc_overcloud_host_image_url }}"
+{% endif %}

--- a/etc/kayobe/overcloud-dib.yml
+++ b/etc/kayobe/overcloud-dib.yml
@@ -8,7 +8,7 @@
 # Bifrost. Setting it to true disables Bifrost image build and allows images to
 # be built with the `kayobe overcloud host image build` command. Default value
 # is {{ os_distribution == 'rocky' }}. This will change in a future release.
-#overcloud_dib_build_host_images:
+overcloud_dib_build_host_images: "{{ os_distribution == 'rocky' and not stackhpc_download_overcloud_host_images | bool }}"
 
 # List of additional host packages to install.
 overcloud_dib_host_packages_extra:

--- a/etc/kayobe/pulp-host-image-versions.yml
+++ b/etc/kayobe/pulp-host-image-versions.yml
@@ -1,0 +1,8 @@
+---
+# Overcloud host image versioning tags
+# These images must be in SMS, since they are used by our AIO CI runners
+stackhpc_centos_8_stream_overcloud_host_image_version: "yoga-20230525T095243"
+stackhpc_rocky_8_overcloud_host_image_version: "yoga-20230629T135322"
+stackhpc_rocky_9_overcloud_host_image_version: "yoga-20230515T145140"
+stackhpc_ubuntu_focal_overcloud_host_image_version: "yoga-20230609T120720"
+stackhpc_ubuntu_jammy_overcloud_host_image_version: "yoga-20230609T120720"

--- a/etc/kayobe/pulp.yml
+++ b/etc/kayobe/pulp.yml
@@ -32,8 +32,14 @@ pulp_proxy_url: "{{ omit }}"
 ###############################################################################
 # StackHPC Pulp server
 
+# The scheme - http/https of the StackHPC Pulp service.
+stackhpc_release_pulp_scheme: "https://"
+
+# The domain of the StackHPC Pulp service.
+stackhpc_release_pulp_domain: "ark.stackhpc.com"
+
 # Base URL of the StackHPC Pulp service.
-stackhpc_release_pulp_url: "https://ark.stackhpc.com"
+stackhpc_release_pulp_url: "{{ stackhpc_release_pulp_scheme }}{{ stackhpc_release_pulp_domain }}"
 
 # Credentials used to access the StackHPC Pulp service.
 stackhpc_release_pulp_username:
@@ -41,6 +47,11 @@ stackhpc_release_pulp_password:
 
 # Content URL of the StackHPC Pulp service.
 stackhpc_release_pulp_content_url: "{{ stackhpc_release_pulp_url }}/pulp/content"
+
+# Content URL of the StackHPC Pulp service, with basic auth.
+# NOTE(Alex-Welsh): This may need reworking if it reveals the credentials
+# at runtime in the ansible output
+stackhpc_release_pulp_content_url_with_auth: "{{ stackhpc_release_pulp_scheme }}{{ stackhpc_release_pulp_username }}:{{ stackhpc_release_pulp_password }}@{{ stackhpc_release_pulp_domain }}/pulp/content"
 
 # Sync all repositories required for building Kolla images from the
 # StackHPC Ark Pulp service to local Pulp.

--- a/etc/kayobe/pulp.yml
+++ b/etc/kayobe/pulp.yml
@@ -32,14 +32,14 @@ pulp_proxy_url: "{{ omit }}"
 ###############################################################################
 # StackHPC Pulp server
 
-# The scheme - http/https of the StackHPC Pulp service.
-stackhpc_release_pulp_scheme: "https://"
+# The scheme of the StackHPC Pulp service (http or https)
+stackhpc_release_pulp_scheme: "https"
 
 # The domain of the StackHPC Pulp service.
 stackhpc_release_pulp_domain: "ark.stackhpc.com"
 
 # Base URL of the StackHPC Pulp service.
-stackhpc_release_pulp_url: "{{ stackhpc_release_pulp_scheme }}{{ stackhpc_release_pulp_domain }}"
+stackhpc_release_pulp_url: "{{ stackhpc_release_pulp_scheme }}://{{ stackhpc_release_pulp_domain }}"
 
 # Credentials used to access the StackHPC Pulp service.
 stackhpc_release_pulp_username:
@@ -51,7 +51,7 @@ stackhpc_release_pulp_content_url: "{{ stackhpc_release_pulp_url }}/pulp/content
 # Content URL of the StackHPC Pulp service, with basic auth.
 # NOTE(Alex-Welsh): This may need reworking if it reveals the credentials
 # at runtime in the ansible output
-stackhpc_release_pulp_content_url_with_auth: "{{ stackhpc_release_pulp_scheme }}{{ stackhpc_release_pulp_username }}:{{ stackhpc_release_pulp_password }}@{{ stackhpc_release_pulp_domain }}/pulp/content"
+stackhpc_release_pulp_content_url_with_auth: "{{ stackhpc_release_pulp_scheme }}://{{ stackhpc_release_pulp_username }}:{{ stackhpc_release_pulp_password }}@{{ stackhpc_release_pulp_domain }}/pulp/content"
 
 # Sync all repositories required for building Kolla images from the
 # StackHPC Ark Pulp service to local Pulp.

--- a/etc/kayobe/stackhpc-overcloud-host-images.yml
+++ b/etc/kayobe/stackhpc-overcloud-host-images.yml
@@ -1,0 +1,36 @@
+---
+##############################
+# Release train overcloud host image sources
+
+# Whether or not to download overcloud host images from Ark
+stackhpc_download_overcloud_host_images: false
+
+# Whether or not to use images with MLNX_OFED installed (for deployment using
+# mellanox/Nvidia NICs). Only available for Ubuntu Jammy and Rocky Linux 9
+# OFED images are currently WIP and this variable is a placeholder
+stackhpc_overcloud_host_image_is_ofed: false
+
+# The overcloud host image source, defined by os_distribution, os_release,
+# stackhpc_overcloud_host_image_is_ofed, and the current stable version.
+stackhpc_overcloud_host_image_url: "{{ stackhpc_release_pulp_content_url_with_auth }}/kayobe-images/\
+                                    {{ openstack_release }}/{{ os_distribution }}/{{ os_release }}/\
+                                    {{ 'ofed/' if stackhpc_overcloud_host_image_is_ofed else '' }}\
+                                    {{ stackhpc_overcloud_host_image_version }}/\
+                                    overcloud-{{ os_distribution }}-{{ os_release }}\
+                                    {{ '-ofed' if stackhpc_overcloud_host_image_is_ofed else '' }}.qcow2"
+
+# Overcloud host image versioning tags
+# These images must be in SMS, since they are used by our AIO CI runners
+stackhpc_centos_8_stream_overcloud_host_image_version: "yoga-20230525T095243"
+stackhpc_rocky_8_overcloud_host_image_version: "yoga-20230629T135322"
+stackhpc_rocky_9_overcloud_host_image_version: "yoga-20230515T145140"
+stackhpc_ubuntu_focal_overcloud_host_image_version: "yoga-20230609T120720"
+stackhpc_ubuntu_jammy_overcloud_host_image_version: "yoga-20230609T120720"
+
+# Overcloud host image version tag selection
+stackhpc_overcloud_host_image_version: >-
+  {{ stackhpc_centos_8_stream_overcloud_host_image_version if os_distribution == 'centos' and os_release == '8-stream' else
+  stackhpc_rocky_8_overcloud_host_image_version if os_distribution == 'rocky' and os_release == '8' else
+  stackhpc_rocky_9_overcloud_host_image_version if os_distribution == 'rocky' and os_release == '9' else
+  stackhpc_ubuntu_focal_overcloud_host_image_version if os_distribution == 'ubuntu' and os_release == 'focal' else
+  stackhpc_ubuntu_jammy_overcloud_host_image_version if os_distribution == 'ubuntu' and os_release == 'jammy' }}

--- a/etc/kayobe/stackhpc-overcloud-host-images.yml
+++ b/etc/kayobe/stackhpc-overcloud-host-images.yml
@@ -19,14 +19,6 @@ stackhpc_overcloud_host_image_url: "{{ stackhpc_release_pulp_content_url_with_au
                                     overcloud-{{ os_distribution }}-{{ os_release }}\
                                     {{ '-ofed' if stackhpc_overcloud_host_image_is_ofed else '' }}.qcow2"
 
-# Overcloud host image versioning tags
-# These images must be in SMS, since they are used by our AIO CI runners
-stackhpc_centos_8_stream_overcloud_host_image_version: "yoga-20230525T095243"
-stackhpc_rocky_8_overcloud_host_image_version: "yoga-20230629T135322"
-stackhpc_rocky_9_overcloud_host_image_version: "yoga-20230515T145140"
-stackhpc_ubuntu_focal_overcloud_host_image_version: "yoga-20230609T120720"
-stackhpc_ubuntu_jammy_overcloud_host_image_version: "yoga-20230609T120720"
-
 # Overcloud host image version tag selection
 stackhpc_overcloud_host_image_version: >-
   {{ stackhpc_centos_8_stream_overcloud_host_image_version if os_distribution == 'centos' and os_release == '8-stream' else

--- a/releasenotes/notes/pull-stackhpc-host-images-a623e4ab2d2a9e5b.yaml
+++ b/releasenotes/notes/pull-stackhpc-host-images-a623e4ab2d2a9e5b.yaml
@@ -1,6 +1,6 @@
 ---
 features:
   - |
-    Prebuild overcloud host images can now be pulled from Ark using the
+    Prebuilt overcloud host images can now be pulled from Ark using the
     `stackhpc_download_overcloud_host_images` variable. The image is selected
     based on `os_distribution` and `os_release`. 

--- a/releasenotes/notes/pull-stackhpc-host-images-a623e4ab2d2a9e5b.yaml
+++ b/releasenotes/notes/pull-stackhpc-host-images-a623e4ab2d2a9e5b.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Prebuild overcloud host images can now be pulled from Ark using the
+    `stackhpc_download_overcloud_host_images` variable. The image is selected
+    based on `os_distribution` and `os_release`. 


### PR DESCRIPTION
Updated the Bifrost and pulp config to easily use the overcloud host images stored in Ark.

Currently untested. If CI works with the new image definition, I'll run it through an AUFN