### PR TITLE
apply fix for nova only on centos

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -332,6 +332,7 @@ kolla_build_blocks:
     {% endif %}
     {% endraw %}
   nova_base_footer: |
+    {% if kolla_base_distro == 'centos' %}
     # Fix for https://bugs.launchpad.net/nova/+bug/1955035, i.e.
     # https://bugzilla.redhat.com/show_bug.cgi?id=2090752 on c8s
     {% raw %}
@@ -339,6 +340,7 @@ kolla_build_blocks:
     RUN sed -i 's/"pc-q35-rhel8.5.0"/"pc-q35-*"/' /usr/share/qemu/firmware/50-edk2-ovmf-cc.json
     {% endif %}
     {% endraw %}
+    {% endif %}
   magnum_base_footer: |
     RUN curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | head -n -1 | bash
 # Dict mapping image customization variable names to their values.


### PR DESCRIPTION
error log:
`ERROR:kolla.common.utils.nova-base:The command '/bin/sh -c sed -i 's/"pc-q35-rhel8.5.0"/"pc-q35-*"/' /usr/share/qemu/firmware/50-edk2-ovmf-cc.json' returned a non-zero code: 2`


This fix is not applicable to RL9.2:

RL9.2:
edk2-ovmf-20221207gitfff6d81270b5-9.el9_2.noarch

```
# grep -irn pc-q35 /usr/share/qemu/firmware
/usr/share/qemu/firmware/40-edk2-ovmf-x64-sb.json:21:                "pc-q35-*"
/usr/share/qemu/firmware/60-edk2-ovmf-x64-inteltdx.json:18:                "pc-q35-*"
/usr/share/qemu/firmware/30-edk2-ovmf-x64-sb-enrolled.json:21:                "pc-q35-*"
/usr/share/qemu/firmware/50-edk2-ovmf-x64-nosb.json:21:                "pc-q35-*"
/usr/share/qemu/firmware/60-edk2-ovmf-x64-amdsev.json:18:                "pc-q35-*"

```
C8S:
edk2-ovmf-20220126gitbb1bba3d77-5.el8.noarch

```
# grep -irn pc-q35 /usr/share/qemu/firmware
/usr/share/qemu/firmware/40-edk2-ovmf-sb.json:21:                "pc-q35-*"
/usr/share/qemu/firmware/50-edk2-ovmf-cc.json:21:                "pc-q35-rhel8.5.0"
/usr/share/qemu/firmware/50-edk2-ovmf.json:21:                "pc-q35-*"
```
