### PR TITLE
bump nova tag to fix creation of over 1TB memory vms on AMD with IOMMU on RL9

### DIFF
--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -7,7 +7,7 @@
 enable_docker_repo: "{% raw %}{{ 'overcloud' not in group_names or ansible_facts.os_family == 'Debian' }}{% endraw %}"
 
 neutron_tag: yoga-20230515T150233
-nova_tag: yoga-20230518T105834
+nova_tag: yoga-20230718T112646
 octavia_tag: yoga-20230523T110936
 openvswitch_tag: yoga-20230515T150233
 ovn_tag: yoga-20230515T150233

--- a/releasenotes/notes/fix-over-1TBram-vm-amd-iommu-rl9-6ddb3d7c030a1674.yaml
+++ b/releasenotes/notes/fix-over-1TBram-vm-amd-iommu-rl9-6ddb3d7c030a1674.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes creation of over 1TB memory VMs on AMD with IOMMU enabled on Rocky
+    Linux 9.


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1983208

It is updating QEMU to 7.2

It remains not fixed on C8S and Ubuntu, as it needs QEMU 7.1.

https://bugs.launchpad.net/ubuntu/+source/qemu/+bug/2009048.

adding the same tag for all distros to have common nova version everywhere.