### PR TITLE
Update yamllint file

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -11,3 +11,7 @@ rules:
     require-starting-space: false
   line-length: disable
   truthy: disable
+
+ignore: |
+  *etc/kayobe/environments/ci-multinode/secrets.yml
+  *etc/kayobe/environments/ci-multinode/kolla/globals-tls-config.yml


### PR DESCRIPTION
There are currently a couple of warnings from yamllint about files not starting with `---`. One is encrypted with ansible vault, the other is a placeholder file, which is designed to concantenated onto the end of another configuration file at a later date for automated deployments. 
This change just makes yamllint ignore those files. 