### PR TITLE
Bump stackhpc.cephadm collection to 1.13.2

### DIFF
--- a/etc/kayobe/ansible/requirements.yml
+++ b/etc/kayobe/ansible/requirements.yml
@@ -1,7 +1,7 @@
 ---
 collections:
   - name: stackhpc.cephadm
-    version: 1.13.1
+    version: 1.13.2
   - name: stackhpc.pulp
     version: 0.4.1
   - name: stackhpc.hashicorp


### PR DESCRIPTION
This release fixes Ceph deployment with FQDN hostnames.