### PR TITLE
Attempt to fix RTD failures using Python 3.7

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,7 +10,7 @@ build:
     - tox
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.7"
 
 # Build documentation in the doc/source/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
The default Python version has changed from 3.7 to 3.11 when updating Read the Docs configuration. See the announcement of configuration file version 2 for more details [1].

[1] https://blog.readthedocs.com/migrate-configuration-v2/