### PR TITLE
Unshallow Read the Docs git clone

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,6 +11,9 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.7"
+  jobs:
+    post_checkout:
+      - git fetch --unshallow || true
 
 # Build documentation in the doc/source/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
Read the Docs does not perform a full clone on checkout job to reduce network data and speed up the build process. Because of this, extensions that depend on the full Git history will fail [1].

This breaks build of release notes, since reno needs Git history access.

[1] https://docs.readthedocs.io/en/stable/build-customization.html#unshallow-git-clone