### PR TITLE
Restore default Git fetch configuration on RTD

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,6 +13,7 @@ build:
     python: "3.7"
   jobs:
     post_checkout:
+      - git remote set-branches origin '*' || true
       - git fetch --unshallow || true
 
 # Build documentation in the doc/source/ directory with Sphinx


### PR DESCRIPTION
The Git shallow clone used on Read the Docs is configured to only fetch a specific Git branch:

[remote "origin"]
	url = https://github.com/stackhpc/stackhpc-kayobe-config.git
	fetch = +refs/heads/stackhpc/yoga:refs/remotes/origin/stackhpc/yoga

This prevents subsequent `git fetch` commands from fetching all remote branches. Use `git remote set-branches origin '*'` to revert to the default Git fetch configuration.