### PR TITLE
Escape wildcard character in custom build command

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,7 +13,7 @@ build:
     python: "3.7"
   jobs:
     post_checkout:
-      - git remote set-branches origin '*' || true
+      - git remote set-branches origin '\*' || true
       - git fetch --unshallow || true
 
 # Build documentation in the doc/source/ directory with Sphinx


### PR DESCRIPTION
The wildcard glob matched files in the current directory which resulted in `git fetch` failing with:

    fatal: couldn't find remote ref refs/heads/LICENSE