### PR TITLE
Work around Read the Docs wildcard escaping issues

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,8 +13,8 @@ build:
     python: "3.7"
   jobs:
     post_checkout:
-      - git remote set-branches origin '\*' || true
-      - git fetch --unshallow || true
+      - git remote set-branches origin master stackhpc/yoga stackhpc/xena stackhpc/wallaby
+      - git fetch --unshallow
 
 # Build documentation in the doc/source/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
Use an explicit list of remote branches with release notes instead of a wildcard which is behaving differently on Read the Docs than locally.

Also remove true fallback to fail early.