### PR TITLE
Lookup os_release for appropriate distros in AIO and AUFN-Ceph

### DIFF
--- a/etc/kayobe/environments/aufn-ceph/globals.yml
+++ b/etc/kayobe/environments/aufn-ceph/globals.yml
@@ -10,4 +10,7 @@ os_distribution: "{{ lookup('pipe', '. /etc/os-release && echo $ID') | trim }}"
 
 # OS release. Valid options are "8-stream" when os_distribution is "centos", or
 # "focal" when os_distribution is "ubuntu".
-#os_release:
+os_release: >-
+          {{ (lookup('pipe', '. /etc/os-release && echo $VERSION_CODENAME') | trim) if os_distribution == 'ubuntu' else
+             (lookup('pipe', '. /etc/os-release && echo $VERSION_ID') | trim | split('.') | first) if os_distribution == 'rocky' else
+             'stream-8' }}

--- a/etc/kayobe/environments/ci-aio/globals.yml
+++ b/etc/kayobe/environments/ci-aio/globals.yml
@@ -51,7 +51,10 @@ os_distribution: "{{ lookup('pipe', '. /etc/os-release && echo $ID') | trim }}"
 
 # OS release. Valid options are "8-stream" when os_distribution is "centos", or
 # "focal" when os_distribution is "ubuntu".
-#os_release:
+os_release: >-
+          {{ (lookup('pipe', '. /etc/os-release && echo $VERSION_CODENAME') | trim) if os_distribution == 'ubuntu' else
+             (lookup('pipe', '. /etc/os-release && echo $VERSION_ID') | trim | split('.') | first) if os_distribution == 'rocky' else
+             'stream-8' }}
 
 ###############################################################################
 


### PR DESCRIPTION
Uses the same os_release template as the ci-multinode environment.

I (and others) keep forgetting to set os_release when creating a Rocky 9 aio. This templates the variable for us.