### PR TITLE
fix: Sync Grafana RPM repo on RL9

### DIFF
--- a/etc/kayobe/pulp.yml
+++ b/etc/kayobe/pulp.yml
@@ -376,7 +376,7 @@ stackhpc_pulp_rpm_repos:
     url: "{{ stackhpc_release_pulp_content_url }}/grafana/oss/rpm/{{ stackhpc_pulp_repo_grafana_version }}"
     distribution_name: "grafana-"
     base_path: "grafana/oss/rpm/"
-    required: "{{ stackhpc_pulp_sync_for_local_container_build | bool and stackhpc_pulp_sync_el_8 | bool }}"
+    required: "{{ stackhpc_pulp_sync_for_local_container_build | bool and ( stackhpc_pulp_sync_el_8 | bool or stackhpc_pulp_sync_el_9 | bool ) }}"
 
   - name: RabbitMQ - Erlang
     url: "{{ stackhpc_release_pulp_content_url }}/rabbitmq/erlang/el/8/x86_64/{{ stackhpc_pulp_repo_rabbitmq_erlang_version }}"


### PR DESCRIPTION
This was lost during the recent repo refactor.
