### PR TITLE
Reduce service workers for aufn-ceph & virtualised ci-multinode envs

### DIFF
--- a/etc/kayobe/environments/aufn-ceph/kolla/globals.yml
+++ b/etc/kayobe/environments/aufn-ceph/kolla/globals.yml
@@ -7,6 +7,7 @@ nova_compute_virt_type: qemu
 # Reduce the control plane's memory footprint by limiting the number of worker
 # processes to one per-service.
 openstack_service_workers: "1"
+openstack_service_rpc_workers: "1"
 
 glance_backend_ceph: "yes"
 cinder_backend_ceph: "yes"

--- a/etc/kayobe/environments/ci-multinode/kolla/globals.yml
+++ b/etc/kayobe/environments/ci-multinode/kolla/globals.yml
@@ -1,4 +1,9 @@
 ---
+# Reduce the control plane's memory footprint by limiting the number of worker
+# processes to two per-service when running in a VM.
+openstack_service_workers: "{% raw %}{{ [ansible_facts.processor_vcpus, 2 if ansible_facts.virtualization_role == 'guest' else 5] | min }}{% endraw %}"
+openstack_service_rpc_workers: "{% raw %}{{ [ansible_facts.processor_vcpus, 2 if ansible_facts.virtualization_role == 'guest' else 3] | min }}{% endraw %}"
+
 # Glance Ceph configuration
 glance_backend_ceph: "yes"
 


### PR DESCRIPTION
When running a multinode environment in VMs, we can easily run out of
memory on controllers. Reduce to 2 service/RPC workers in this case.
Also reduce RPC workers to 1 for the aufn-ceph environment.
