### PR TITLE
zed: small fixes

### DIFF
--- a/.automation.conf/tempest/tempest-ci-multinode.overrides.conf
+++ b/.automation.conf/tempest/tempest-ci-multinode.overrides.conf
@@ -10,7 +10,7 @@ v3_endpoint_type = publicURL
 [compute]
 min_compute_nodes = 2
 min_microversion = 2.1
-max_microversion = 2.88
+max_microversion = 2.93
 
 [service-clients]
 http_timeout = 600
@@ -26,7 +26,7 @@ console_output = true
 storage_protocol = ceph
 build_timeout = 600
 min_microversion = 3.0
-max_microversion = 3.66
+max_microversion = 3.70
 
 [image]
 build_timeout = 600

--- a/.github/workflows/stackhpc-all-in-one.yml
+++ b/.github/workflows/stackhpc-all-in-one.yml
@@ -254,7 +254,7 @@ jobs:
             -v $(pwd)/tempest-artifacts:/stack/tempest-artifacts \
             -e KAYOBE_ENVIRONMENT -e KAYOBE_VAULT_PASSWORD -e KAYOBE_AUTOMATION_SSH_PRIVATE_KEY \
             $KAYOBE_IMAGE \
-            /stack/kayobe-automation-env/src/kayobe-config/.automation/pipeline/tempest.sh -e ansible_user=stack
+            /stack/kayobe-automation-env/src/kayobe-config/.automation/pipeline/tempest.sh -e ansible_user=stack -e rally_no_sensitive_log=false
         env:
           KAYOBE_AUTOMATION_SSH_PRIVATE_KEY: ${{ steps.ssh_key.outputs.ssh_key }}
 

--- a/doc/source/configuration/swap.rst
+++ b/doc/source/configuration/swap.rst
@@ -2,6 +2,11 @@
 Swap
 ====
 
+Support for :kayobe-doc:`managing swap files and devices
+<configuration/reference/hosts.html#swap>` was added to Kayobe in the Zed
+release. The custom playbook described below is retained for backwards
+compatibility but may be removed in a future release.
+
 StackHPC Kayobe configuration provides a ``swap.yml`` custom playbook that may
 be used to configure a swap device.
 

--- a/etc/kayobe/ansible/requirements.yml
+++ b/etc/kayobe/ansible/requirements.yml
@@ -3,7 +3,7 @@ collections:
   - name: stackhpc.cephadm
     version: 1.14.0
   - name: stackhpc.pulp
-    version: 0.4.1
+    version: 0.5.2
   - name: stackhpc.hashicorp
     version: 2.4.0
 roles:

--- a/etc/kayobe/ansible/swap.yml
+++ b/etc/kayobe/ansible/swap.yml
@@ -1,4 +1,8 @@
 ---
+# NOTE: Kayobe provides support for managing swap devices and files since the
+# Zed release. This playbook is retained for backwards compatibility but will
+# be removed in a future release.
+
 # Custom playbook to configure a swap device. This may be used as a
 # post-overcloud host configure hook.
 #

--- a/etc/kayobe/cephadm.yml
+++ b/etc/kayobe/cephadm.yml
@@ -3,7 +3,7 @@
 # Cephadm deployment configuration.
 
 # Ceph release name.
-cephadm_ceph_release: "{{ 'quincy' }}"
+cephadm_ceph_release: "quincy"
 
 # Ceph FSID.
 #cephadm_fsid:
@@ -12,7 +12,7 @@ cephadm_ceph_release: "{{ 'quincy' }}"
 cephadm_image: "{{ stackhpc_docker_registry if stackhpc_sync_ceph_images | bool else 'quay.io' }}/ceph/ceph:{{ cephadm_image_tag }}"
 
 # Ceph container image tag.
-cephadm_image_tag: "{{ 'v17.2.6' }}"
+cephadm_image_tag: "v17.2.6"
 
 # Ceph custom repo workaround for Ubuntu Jammy as there are no official ceph repos for jammy.
 cephadm_custom_repos: "{{ ansible_facts['distribution_release'] == 'jammy' }}"

--- a/etc/kayobe/environments/aufn-ceph/a-universe-from-nothing.sh
+++ b/etc/kayobe/environments/aufn-ceph/a-universe-from-nothing.sh
@@ -10,8 +10,8 @@
 set -eu
 
 BASE_PATH=~
-KAYOBE_BRANCH=stackhpc/yoga
-KAYOBE_CONFIG_BRANCH=stackhpc/yoga
+KAYOBE_BRANCH=stackhpc/zed
+KAYOBE_CONFIG_BRANCH=stackhpc/zed
 KAYOBE_ENVIRONMENT=aufn-ceph
 
 PELICAN_HOST="10.0.0.34 pelican pelican.service.compute.sms-lab.cloud"

--- a/etc/kayobe/environments/aufn-ceph/cephadm.yml
+++ b/etc/kayobe/environments/aufn-ceph/cephadm.yml
@@ -2,9 +2,6 @@
 ###############################################################################
 # Cephadm deployment configuration.
 
-# Ceph container image.
-cephadm_image: "quay.io/ceph/ceph:v16.2.5"
-
 # List of additional cephadm commands to run before deployment
 # cephadm_commands:
 #   - "config set global osd_pool_default_size {{ [3, groups['osds'] | length] | min }}"

--- a/etc/kayobe/environments/aufn-ceph/kolla/inventory/overcloud-services.j2
+++ b/etc/kayobe/environments/aufn-ceph/kolla/inventory/overcloud-services.j2
@@ -24,6 +24,17 @@ common
 [kolla-toolbox:children]
 common
 
+[opensearch:children]
+control
+
+# TODO: This is used for cleanup and can be removed in the Antelope cycle.
+[elasticsearch-curator:children]
+opensearch
+
+# Opensearch dashboards
+[opensearch-dashboards:children]
+opensearch
+
 # Glance
 [glance-api:children]
 glance
@@ -475,9 +486,8 @@ monitoring
 [prometheus-openstack-exporter:children]
 monitoring
 
-# NOTE(Alex-Welsh): This might need removing, since we have moved to opensearch
 [prometheus-elasticsearch-exporter:children]
-elasticsearch
+opensearch
 
 [prometheus-blackbox-exporter:children]
 monitoring

--- a/etc/kayobe/pulp.yml
+++ b/etc/kayobe/pulp.yml
@@ -497,7 +497,6 @@ stackhpc_pulp_images_kolla:
   - prometheus-blackbox-exporter
   - prometheus-cadvisor
   - prometheus-haproxy-exporter
-  - prometheus-jiralert
   - prometheus-libvirt-exporter
   - prometheus-memcached-exporter
   - prometheus-msteams

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 kayobe@git+https://github.com/stackhpc/kayobe@stackhpc/zed
-ansible-modules-hashivault;python_version >= "3.8"
+ansible-modules-hashivault


### PR DESCRIPTION
- CI: Only sync new images after build
- swap: Note that Kayobe supports swap in Zed
- tempest: update max microversions for Cinder & Nova
- Update stackhpc.pulp to 0.5.2
- ceph: remove unnecesary Jinja braces
- aufn-ceph: Use stackhpc/zed branch in script
- requirements.txt: drop version specifier
- pulp: Stop syncing prometheus-jiralert image
- aufn-ceph: Drop cephadm_image override
- aufn-ceph: Sync inventory with kolla-ansible
