### PR TITLE
Use q35 machine type by default

### DIFF
--- a/etc/kayobe/kolla/config/nova.conf
+++ b/etc/kayobe/kolla/config/nova.conf
@@ -1,0 +1,3 @@
+[libvirt]
+hw_machine_type = q35
+num_pcie_ports = 16

--- a/releasenotes/notes/nova-machine-type-q35-ab363c5f7f3f9807.yaml
+++ b/releasenotes/notes/nova-machine-type-q35-ab363c5f7f3f9807.yaml
@@ -1,0 +1,13 @@
+---
+upgrade:
+  - |
+    Configure Nova to use more modern 'q35' libvirt machine type rather than
+		'pc' which is considered legacy.
+  - |
+    Configure Nova libvirt.num_pcie_ports to 16 by default. Nova currently
+    sets 'num_pcie_ports' to "0" (defaults to libvirt's "1"), which is
+    not sufficient for hotplug use with 'q35' machine type.
+fixes:
+  - |
+    Fixes an issue where 'q35' libvirt machine type VM could not hotplug
+    more than one PCIe device at a time.


### PR DESCRIPTION
Changed nova.conf machine type to q35, along with pcie devices to 16