### PR TITLE
zed: remove symlinks

### DIFF
--- a/etc/kayobe/ansible/filter_plugins
+++ b/etc/kayobe/ansible/filter_plugins
@@ -1,1 +1,0 @@
-../../../../kayobe/ansible/filter_plugins/

--- a/etc/kayobe/ansible/group_vars
+++ b/etc/kayobe/ansible/group_vars
@@ -1,1 +1,0 @@
-../../../../kayobe/ansible/group_vars/

--- a/etc/kayobe/ansible/test_plugins
+++ b/etc/kayobe/ansible/test_plugins
@@ -1,1 +1,0 @@
-../../../../kayobe/ansible/test_plugins/


### PR DESCRIPTION
Remove plugins and group_vars symlinks. These are no longer required in Zed.