### PR TITLE
Fix nova_libvirt pin

### DIFF
--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -73,7 +73,7 @@ kibana_tag: "{% raw %}{{ kayobe_image_tags['kibana'][kolla_base_distro] | defaul
 magnum_tag: "{% raw %}{{ kayobe_image_tags['magnum'][kolla_base_distro] | default(openstack_tag) }}{% endraw %}"
 neutron_tag: "{% raw %}{{ kayobe_image_tags['neutron'][kolla_base_distro] | default(openstack_tag) }}{% endraw %}"
 nova_tag: "{% raw %}{{ kayobe_image_tags['nova'][kolla_base_distro] | default(openstack_tag) }}{% endraw %}"
-nova_libvirt_tag: "{% raw %}{{ kayobe_image_tags['nova_libvirt'][kolla_base_distro] | default(openstack_tag) }}{% endraw %}"
+nova_libvirt_tag: "{% raw %}{{ kayobe_image_tags['nova_libvirt'][kolla_base_distro] | default(nova_tag) }}{% endraw %}"
 octavia_tag: "{% raw %}{{ kayobe_image_tags['octavia'][kolla_base_distro] | default(openstack_tag) }}{% endraw %}"
 openvswitch_tag: "{% raw %}{{ kayobe_image_tags['openvswitch'][kolla_base_distro] | default(openstack_tag) }}{% endraw %}"
 ovn_tag: "{% raw %}{{ kayobe_image_tags['ovn'][kolla_base_distro] | default(openstack_tag) }}{% endraw %}"


### PR DESCRIPTION
This caused an accidential downgrade of libvirt on Rocky 9.

```
[root@kef1p-phyhyp0025 libvirt]# grep "libvirt version" libvirtd.log
2023-09-07 10:27:20.926+0000: 3216: info : libvirt version: 9.0.0, package: 10.2.el9_2 (Rocky Linux Build System (Peridot) <releng@rockylinux.org>, 2023-06-23-14:20:12, )
2023-09-12 12:21:34.102+0000: 2184950: info : libvirt version: 8.5.0, package: 7.3.el9_1 (Rocky Linux Build System (Peridot) <releng@rockylinux.org>, 2023-01-24-00:38:15, )
```