### PR TITLE
Update kolla image build config and release note changes part 1

### DIFF
--- a/etc/kayobe/environments/aufn-ceph/kolla/inventory/overcloud-services.j2
+++ b/etc/kayobe/environments/aufn-ceph/kolla/inventory/overcloud-services.j2
@@ -404,14 +404,6 @@ compute
 [zun-cni-daemon:children]
 compute
 
-# Skydive
-[skydive-analyzer:children]
-skydive
-
-[skydive-agent:children]
-compute
-network
-
 # Tacker
 [tacker-server:children]
 tacker

--- a/etc/kayobe/environments/ci-aio/kolla/config/grafana
+++ b/etc/kayobe/environments/ci-aio/kolla/config/grafana
@@ -1,1 +1,0 @@
-../../../../kolla/config/grafana/

--- a/etc/kayobe/environments/ci-aio/kolla/config/prometheus
+++ b/etc/kayobe/environments/ci-aio/kolla/config/prometheus
@@ -1,1 +1,0 @@
-../../../../kolla/config/prometheus/

--- a/etc/kayobe/environments/ci-builder/stackhpc-ci.yml
+++ b/etc/kayobe/environments/ci-builder/stackhpc-ci.yml
@@ -26,7 +26,6 @@ kolla_enable_opensearch: true
 kolla_enable_ovn: true
 kolla_enable_prometheus: true
 kolla_enable_redis: true
-kolla_enable_skydive: true
 
 ###############################################################################
 # Network configuration.

--- a/etc/kayobe/environments/ci-multinode/kolla/config/grafana
+++ b/etc/kayobe/environments/ci-multinode/kolla/config/grafana
@@ -1,1 +1,0 @@
-../../../../kolla/config/grafana/

--- a/etc/kayobe/environments/ci-multinode/kolla/config/prometheus
+++ b/etc/kayobe/environments/ci-multinode/kolla/config/prometheus
@@ -1,1 +1,0 @@
-../../../../kolla/config/prometheus/

--- a/etc/kayobe/inventory/group_vars/overcloud/stackhpc-repos
+++ b/etc/kayobe/inventory/group_vars/overcloud/stackhpc-repos
@@ -3,3 +3,5 @@
 # tries to use a local pulp repo on the seed VM
 # before the seed vm has been provisioned
 dnf_custom_repos: "{{ stackhpc_dnf_repos }}"
+
+enable_docker_repo: false

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -115,7 +115,7 @@ kolla_docker_registry_password: "{{ stackhpc_docker_registry_password }}"
 # 'stackhpc/{{ openstack_release }}' which would keep the branch up to date
 # for the current release. This is nice in theory but in practice, the stackhpc
 # forks change with every release and the elements in this list change with
-# them. Explicitly using /zed makes it more intuitive to find and edit these
+# them. Explicitly using /2021.3 makes it more intuitive to find and edit these
 # entries.
 kolla_sources:
   bifrost-base-additions-stackhpc-inspector-plugins:
@@ -126,11 +126,11 @@ kolla_sources:
   cloudkitty-base:
     type: git
     location: https://github.com/stackhpc/cloudkitty.git
-    reference: stackhpc/zed
+    reference: stackhpc/2023.1
   horizon-plugin-cloudkitty-dashboard:
     type: git
     location: https://github.com/stackhpc/cloudkitty-dashboard.git
-    reference: stackhpc/zed
+    reference: stackhpc/2023.1
   ironic-inspector-additions-stackhpc-inspector-plugins:
     # Install our custom inspector plugins.
     type: git
@@ -140,11 +140,11 @@ kolla_sources:
   magnum-base:
     type: git
     location: https://github.com/stackhpc/magnum.git
-    reference: stackhpc/zed
+    reference: stackhpc/2023.1
   neutron-base-plugin-networking-generic-switch:
     type: git
     location: https://github.com/stackhpc/networking-generic-switch.git
-    reference: stackhpc/zed
+    reference: stackhpc/2023.1
 
 ###############################################################################
 # Kolla image build configuration.

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -641,7 +641,6 @@ kolla_enable_prometheus: true
 #kolla_enable_redis:
 #kolla_enable_sahara:
 #kolla_enable_senlin:
-#kolla_enable_skydive:
 #kolla_enable_solum:
 #kolla_enable_swift:
 #kolla_enable_swift_recon:

--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -1,11 +1,6 @@
 # yamllint disable-file
 ---
 
-# To work around issue of trying to install docker from
-# empty pulp server, use upstream docker dnf repo on
-# non-overcloud hosts
-enable_docker_repo: "{% raw %}{{ 'overcloud' not in group_names or ansible_facts.os_family == 'Debian' }}{% endraw %}"
-
 # kolla_base_distro must be set here to be resolvable on a per-host basis
 # This is necessary for os migrations where mixed clouds might be deployed
 kolla_base_distro: "{% raw %}{{ ansible_facts.distribution | lower }}{% endraw %}"

--- a/etc/kayobe/pulp.yml
+++ b/etc/kayobe/pulp.yml
@@ -510,8 +510,6 @@ stackhpc_pulp_images_kolla:
   - rabbitmq
   - redis
   - redis-sentinel
-  - skydive-agent
-  - skydive-analyzer
 
 # List of images for each base distribution which should not/cannot be built.
 stackhpc_kolla_unbuildable_images:


### PR DESCRIPTION
This PR includes changes to kolla.yml for container image builds and changes to the config as a whole to account for changes in kolla/kolla-ansible/kayobe upstream, as determined by the antelope release notes for each project.

There will likely be more changes needed but fewer commits per PR makes it easier to review.

Initially making this PR a draft as it's dependent on https://github.com/stackhpc/stackhpc-kayobe-config/pull/634