### PR TITLE
Hostnames in prometheus

### DIFF
--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -103,5 +103,8 @@ prometheus_ceph_mgr_exporter_endpoints:
 {% endfor %}
 {% endif %}
 
+# Use inventory hostnames as labels
+prometheus_instance_label: "{% raw %}{{ ansible_facts.hostname }}{% endraw %}"
+
 #############################################################################
 

--- a/releasenotes/notes/prometheus-labels-1aebdfd8631a3406.yaml
+++ b/releasenotes/notes/prometheus-labels-1aebdfd8631a3406.yaml
@@ -1,0 +1,4 @@
+---
+upgrade:
+  - |
+    Instance labels in prometheus now use inventory hostnames rather than IPs.


### PR DESCRIPTION
use prometheus_instance_label to have nice hostnames rather than IPs