### PR TITLE
CI: Only sync old images after build

### DIFF
--- a/.github/workflows/stackhpc-container-image-build.yml
+++ b/.github/workflows/stackhpc-container-image-build.yml
@@ -221,7 +221,8 @@ jobs:
           container-sync.yml \
           --repo stackhpc/stackhpc-release-train \
           --ref main \
-          -f filter="$filter"
+          -f filter="$filter" \
+          -f sync-new-images=false
         env:
           GITHUB_TOKEN: ${{ secrets.STACKHPC_RELEASE_TRAIN_TOKEN }}
 


### PR DESCRIPTION
The new format (without distro & type in the name) is only used from Zed.
