### PR TITLE
feat: set `3.24.0` for `pulp/pulp`

### DIFF
--- a/etc/kayobe/seed.yml
+++ b/etc/kayobe/seed.yml
@@ -106,7 +106,7 @@ seed_pulp_container:
     image: pulp/pulp
     pre: "{{ kayobe_config_path }}/containers/pulp/pre.yml"
     post: "{{ kayobe_config_path }}/containers/pulp/post.yml"
-    tag: "3.24"
+    tag: "3.24.0"
     network_mode: host
     # Override deploy_containers_defaults.init == true to ensure
     # s6-overlay-suexec starts as pid 1


### PR DESCRIPTION
Issue has been identified in later version of `3.24` that has not been experienced when using `3.24.0`

```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: Exception: Task failed to complete. (failed; 406, message='Not Acceptable', url=URL('https://ark.stackhpc.com/v2/stackhpc/ubuntu-source-bifrost-deploy/tags/list'))
failed: [localhost] (item=stackhpc/ubuntu-source-bifrost-deploy) => changed=false
  ansible_index_var: repository_index
  ansible_loop_var: item
  item: stackhpc/ubuntu-source-bifrost-deploy
  msg: Task failed to complete. (failed; 406, message='Not Acceptable', url=URL('https://ark.stackhpc.com/v2/stackhpc/ubuntu-source-bifrost-deploy/tags/list'))
  repository_index: 0
```