### PR TITLE
Pin pulp version to 3.24.0

### DIFF
--- a/etc/kayobe/seed.yml
+++ b/etc/kayobe/seed.yml
@@ -106,7 +106,7 @@ seed_pulp_container:
     image: pulp/pulp
     pre: "{{ kayobe_config_path }}/containers/pulp/pre.yml"
     post: "{{ kayobe_config_path }}/containers/pulp/post.yml"
-    tag: "3.24"
+    tag: "3.24.0"
     network_mode: host
     # Override deploy_containers_defaults.init == true to ensure
     # s6-overlay-suexec starts as pid 1


### PR DESCRIPTION
The 3.24 tag was recently updated to 3.24.1 which includes a version of pulp_container that causes client pulp container syncs to fail.