### PR TITLE
fix build of rocky and ubuntu images

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -322,7 +322,7 @@ kolla_build_blocks:
     {% endif %}
   base_ubuntu_package_sources_list: |
     RUN \
-        mv /etc/apt/sources.list{,.backup} && \
+        mv /etc/apt/sources.list /etc/apt/sources.list.backup && \
     {% for repo in stackhpc_ubuntu_focal_repos %}
         echo '{{ repo }}' >> /etc/apt/sources.list {% if not loop.last %} && \
     {% endif %}

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -329,7 +329,7 @@ kolla_build_blocks:
     {% endfor %}
   footer: |
     {% if stackhpc_kolla_clean_up_repo_mirrors | bool %}
-    {% if kolla_base_distro == 'centos' %}
+    {% if kolla_base_distro in ['centos', 'rocky'] %}
     RUN \
         tar -xzf /etc/yum.repos.d.backup/repos.tar.gz -C /etc/yum.repos.d && \
         if grep -r '{{ stackhpc_repo_mirror_url }}' /etc/yum.repos.d; then \


### PR DESCRIPTION
recent commit broke rocky/ubuntu builds:
https://github.com/stackhpc/stackhpc-kayobe-config/commit/908d7513df8eed0cfb0aadced4cc9a34c78c7027#diff-12d955d16a7bd8d6dc7bae8b56c2e485f4445434f0fb67546ea09c9e8b9b504dR332
https://github.com/stackhpc/stackhpc-kayobe-config/blame/stackhpc/yoga/etc/kayobe/kolla.yml#L325C8-L325C46