### PR TITLE
Keep 10percentOSDsDown alert pending for 15 minutes

### DIFF
--- a/etc/kayobe/kolla/config/prometheus/ceph.rules
+++ b/etc/kayobe/kolla/config/prometheus/ceph.rules
@@ -46,6 +46,7 @@ groups:
   rules:
   - alert: 10percentOSDsDown
     expr: count(ceph_osd_up == 0) / count(ceph_osd_up) * 100 >= 10
+    for: 15m
     labels:
       severity: critical
     annotations:


### PR DESCRIPTION
This should allow enough time for rebooting a Ceph OSD host without firing the alert.