### PR TITLE
 Disable ignore_null_merges for release notes

### DIFF
--- a/releasenotes/config.yaml
+++ b/releasenotes/config.yaml
@@ -1,3 +1,4 @@
 ---
 # This needs to be updated to the latest release.
 release_tag_re: stackhpc/11\.\d+\.\d+\.\d
+ignore_null_merges: false


### PR DESCRIPTION
This allows reno to find additional release notes.