### PR TITLE
Use upper constraints to install openstackclient

### DIFF
--- a/.github/workflows/overcloud-host-image-build.yml
+++ b/.github/workflows/overcloud-host-image-build.yml
@@ -143,7 +143,7 @@ jobs:
       - name: Install OpenStack client
         run: |
           source venvs/kayobe/bin/activate &&
-          pip install python-openstackclient
+          pip install python-openstackclient -c https://opendev.org/openstack/requirements/raw/branch/stable/${{ steps.openstack_release.outputs.openstack_release }}/upper-constraints.txt
 
       - name: Build a CentOS Stream 8 overcloud host image
         id: build_centos_stream_8


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/cloud-user/actions-runner/_work/stackhpc-kayobe-config/stackhpc-kayobe-config/venvs/kayobe/bin/openstack", line 5, in <module>
    from openstackclient.shell import main
  File "/home/cloud-user/actions-runner/_work/stackhpc-kayobe-config/stackhpc-kayobe-config/venvs/kayobe/lib64/python3.6/site-packages/openstackclient/shell.py", line 23, in <module>
    from osc_lib import shell
  File "/home/cloud-user/actions-runner/_work/stackhpc-kayobe-config/stackhpc-kayobe-config/venvs/kayobe/lib64/python3.6/site-packages/osc_lib/shell.py", line 32, in <module>
    from osc_lib.cli import client_config as cloud_config
  File "/home/cloud-user/actions-runner/_work/stackhpc-kayobe-config/stackhpc-kayobe-config/venvs/kayobe/lib64/python3.6/site-packages/osc_lib/cli/client_config.py", line 18, in <module>
    from openstack.config import exceptions as sdk_exceptions
  File "/home/cloud-user/actions-runner/_work/stackhpc-kayobe-config/stackhpc-kayobe-config/venvs/kayobe/lib64/python3.6/site-packages/openstack/__init__.py", line 58, in <module>
    import openstack.connection
  File "/home/cloud-user/actions-runner/_work/stackhpc-kayobe-config/stackhpc-kayobe-config/venvs/kayobe/lib64/python3.6/site-packages/openstack/connection.py", line 217, in <module>
    from openstack import _services_mixin
  File "/home/cloud-user/actions-runner/_work/stackhpc-kayobe-config/stackhpc-kayobe-config/venvs/kayobe/lib64/python3.6/site-packages/openstack/_services_mixin.py", line 6, in <module>
    from openstack.block_storage import block_storage_service
  File "/home/cloud-user/actions-runner/_work/stackhpc-kayobe-config/stackhpc-kayobe-config/venvs/kayobe/lib64/python3.6/site-packages/openstack/block_storage/block_storage_service.py", line 14, in <module>
    from openstack.block_storage.v3 import _proxy as _v3_proxy
  File "/home/cloud-user/actions-runner/_work/stackhpc-kayobe-config/stackhpc-kayobe-config/venvs/kayobe/lib64/python3.6/site-packages/openstack/block_storage/v3/_proxy.py", line 37, in <module>
    class Proxy(_base_proxy.BaseBlockStorageProxy):
  File "/home/cloud-user/actions-runner/_work/stackhpc-kayobe-config/stackhpc-kayobe-config/venvs/kayobe/lib64/python3.6/site-packages/openstack/block_storage/v3/_proxy.py", line 1592, in Proxy
    ignore_missing: ty.Literal[True] = True,
AttributeError: module 'typing' has no attribute 'Literal'
```

See: https://github.com/stackhpc/stackhpc-kayobe-config/actions/runs/6341830858/job/17226310409