### PR TITLE
Bump Rocky 9 host image to 9.2

### DIFF
--- a/etc/kayobe/pulp-host-image-versions.yml
+++ b/etc/kayobe/pulp-host-image-versions.yml
@@ -3,6 +3,6 @@
 # These images must be in SMS, since they are used by our AIO CI runners
 stackhpc_centos_8_stream_overcloud_host_image_version: "yoga-20230525T095243"
 stackhpc_rocky_8_overcloud_host_image_version: "yoga-20230629T135322"
-stackhpc_rocky_9_overcloud_host_image_version: "yoga-20230929T080356"
+stackhpc_rocky_9_overcloud_host_image_version: "yoga-20230929T133006"
 stackhpc_ubuntu_focal_overcloud_host_image_version: "yoga-20230609T120720"
 stackhpc_ubuntu_jammy_overcloud_host_image_version: "yoga-20230609T120720"

--- a/etc/kayobe/pulp-host-image-versions.yml
+++ b/etc/kayobe/pulp-host-image-versions.yml
@@ -3,6 +3,6 @@
 # These images must be in SMS, since they are used by our AIO CI runners
 stackhpc_centos_8_stream_overcloud_host_image_version: "yoga-20230525T095243"
 stackhpc_rocky_8_overcloud_host_image_version: "yoga-20230629T135322"
-stackhpc_rocky_9_overcloud_host_image_version: "yoga-20230515T145140"
+stackhpc_rocky_9_overcloud_host_image_version: "yoga-20230929T080356"
 stackhpc_ubuntu_focal_overcloud_host_image_version: "yoga-20230609T120720"
 stackhpc_ubuntu_jammy_overcloud_host_image_version: "yoga-20230609T120720"


### PR DESCRIPTION
Hitting this issue with cloud-init in 9.1: 

```
Unable to find a system nic for <MAC_ADDRESS> from cloud-init
```

This means that network interfaces are not configured properly. Newer cloud-init seems to fix the issue.

See: https://askubuntu.com/questions/1400527/unable-to-find-a-system-nic-while-running-cloud-init