### PR TITLE
Change default to reboot one host at a time

### DIFF
--- a/etc/kayobe/ansible/reboot.yml
+++ b/etc/kayobe/ansible/reboot.yml
@@ -1,7 +1,7 @@
 ---
 - name: Reboot the host
   hosts: seed-hypervisor:seed:overcloud:infra-vms
-  serial: "{{ lookup('env', 'ANSIBLE_SERIAL') | default(0, true) }}"
+  serial: "{{ lookup('env', 'ANSIBLE_SERIAL') | default(1, true) }}"
   tags:
     - reboot
   tasks:

--- a/releasenotes/notes/reboot-default-serial-5944a2a648da71c7.yaml
+++ b/releasenotes/notes/reboot-default-serial-5944a2a648da71c7.yaml
@@ -1,0 +1,6 @@
+---
+upgrade:
+  - |
+    The ``reboot.yml`` custom Ansible playbook now defaults to reboot only one
+    host at a time. Existing behaviour can be retained by setting
+    ANSIBLE_SERIAL=0.


### PR DESCRIPTION
This is safer if the playbook is run by accident. Existing behaviour can be retained by setting ANSIBLE_SERIAL=0.