### PR TITLE
Become during /opt/kayobe/vault creation

### DIFF
--- a/etc/kayobe/ansible/vault-deploy-overcloud.yml
+++ b/etc/kayobe/ansible/vault-deploy-overcloud.yml
@@ -43,6 +43,7 @@
       file:
         path: /opt/kayobe/vault
         state: directory
+      become: true
 
     - name: Template out TLS key and cert
       copy:


### PR DESCRIPTION
The vault deploy overcloud playbook can fail when trying to create /opt/kayobe/vault without privilege escalation