### PR TITLE
Bump Zed container image tags

### DIFF
--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -12,8 +12,8 @@ kolla_base_distro: "{% raw %}{{ ansible_facts.distribution | lower }}{% endraw %
 
 kayobe_image_tags:
   openstack:
-    rocky: zed-rocky-9-20230821T155947
-    ubuntu: zed-ubuntu-jammy-20230821T155947
+    rocky: zed-rocky-9-20230921T153510
+    ubuntu: zed-ubuntu-jammy-20230921T153510
   bifrost:
     rocky: zed-rocky-9-20230927T142529
     ubuntu: zed-ubuntu-jammy-20230927T154443


### PR DESCRIPTION
I'm not quite sure where these tags got lost but they should've been merged in a while ago. We ran a full rebuild to bring in vulnerability mitigations to the base images. 