### PR TITLE
Bump microversion for antelope release

### DIFF
--- a/.automation.conf/tempest/tempest-ci-multinode.overrides.conf
+++ b/.automation.conf/tempest/tempest-ci-multinode.overrides.conf
@@ -10,7 +10,7 @@ v3_endpoint_type = publicURL
 [compute]
 min_compute_nodes = 2
 min_microversion = 2.1
-max_microversion = 2.93
+max_microversion = 2.95
 
 [service-clients]
 http_timeout = 600


### PR DESCRIPTION
See: https://docs.openstack.org/nova/latest/reference/api-microversion-history.html#maximum-in-2023-1-antelope-and-2023-2-bobcat