### PR TITLE
Various os_capacity fixes

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -20,3 +20,4 @@ ignore: |
   .github/
   .gitlab/
   .gitlab-ci.yml
+  etc/kayobe/kolla/config/prometheus/prometheus.yml.d/70-oscapacity.yml

--- a/doc/source/configuration/monitoring.rst
+++ b/doc/source/configuration/monitoring.rst
@@ -140,33 +140,58 @@ enable the ceph mgr exporter.
 OpenStack Capacity
 ==================
 
-OpenStack Capacity allows you to see how much space you have avaliable
-in your cloud. StackHPC Kayobe Config includes this exporter by default
-and it's necessary that some variables are set to allow deployment.
+OpenStack Capacity allows you to see how much space you have available
+in your cloud. StackHPC Kayobe Config includes a playbook for manual
+deployment, and it's necessary that some variables are set before
+running this playbook.
 
 To successfully deploy OpenStack Capacity, you are required to specify
 the OpenStack application credentials in ``kayobe/secrets.yml`` as:
 
 .. code-block:: yaml
 
-    secrets_os_exporter_auth_url: <some_auth_url>
-    secrets_os_exporter_credential_id: <some_credential_id>
-    secrets_os_exporter_credential_secret: <some_credential_secret>
+    secrets_os_capacity_credential_id: <some_credential_id>
+    secrets_os_capacity_credential_secret: <some_credential_secret>
 
-After defining your credentials, You may deploy OpenStack Capacity
+The Keystone authentication URL and OpenStack region can be changed
+from their defaults in ``stackhpc-monitoring.yml`` should you need to
+set a different OpenStack region for your cloud. The authentication
+URL is set to use ``kolla_internal_fqdn`` by default:
+
+.. code-block:: yaml
+
+    stackhpc_os_capacity_auth_url: <some_authentication_url>
+    stackhpc_os_capacity_openstack_region_name: <some_openstack_region>
+
+Additionally, you are required to enable a conditional flag to allow
+HAProxy and Prometheus configuration to be templated during deployment.
+
+.. code-block:: yaml
+
+    stackhpc_enable_os_capacity: true
+
+If you are deploying in a cloud with internal TLS, you may be required
+to disable certificate verification for the OpenStack Capacity exporter
+if your certificate is not signed by a trusted CA.
+
+.. code-block:: yaml
+
+    stackhpc_os_capacity_openstack_verify: false
+
+After defining your credentials, you may deploy OpenStack Capacity
 using the ``ansible/deploy-os-capacity-exporter.yml`` Ansible playbook
 via Kayobe.
 
 .. code-block:: console
 
-    kayobe playbook run ansible/deploy-os-capacity-exporter.yml
+    kayobe playbook run $KAYOBE_CONFIG_PATH/ansible/deploy-os-capacity-exporter.yml
 
 It is required that you re-configure the Prometheus, Grafana and HAProxy
 services following deployment, to do this run the following Kayobe command.
 
 .. code-block:: console
 
-    kayobe overcloud service reconfigure -kt grafana,prometheus,haproxy
+    kayobe overcloud service reconfigure -kt grafana,prometheus,loadbalancer
 
 If you notice ``HaproxyServerDown`` or ``HaproxyBackendDown`` prometheus
 alerts after deployment it's likely the os_exporter secrets have not been

--- a/etc/kayobe/ansible/deploy-os-capacity-exporter.yml
+++ b/etc/kayobe/ansible/deploy-os-capacity-exporter.yml
@@ -3,6 +3,13 @@
   gather_facts: false
 
   tasks:
+    - name: Ensure legacy os_exporter.cfg config file is deleted
+      ansible.builtin.file:
+        path: /etc/kolla/haproxy/services.d/os_exporter.cfg
+        state: absent
+      delegate_to: network
+      become: true
+
     - name: Create os-capacity directory
       ansible.builtin.file:
         path: /opt/kayobe/os-capacity/

--- a/etc/kayobe/ansible/templates/os_capacity-clouds.yml.j2
+++ b/etc/kayobe/ansible/templates/os_capacity-clouds.yml.j2
@@ -1,10 +1,13 @@
 clouds:
   openstack:
     auth:
-      auth_url: "{{ secrets_os_exporter_auth_url }}"
-      application_credential_id: "{{ secrets_os_exporter_credential_id }}"
-      application_credential_secret: "{{ secrets_os_exporter_credential_secret }}"
-    region_name: "RegionOne"
+      auth_url: "{{ stackhpc_os_capacity_auth_url }}"
+      application_credential_id: "{{ secrets_os_capacity_credential_id }}"
+      application_credential_secret: "{{ secrets_os_capacity_credential_secret }}"
+    region_name: "{{ stackhpc_os_capacity_openstack_region_name }}"
     interface: "internal"
     identity_api_version: 3
     auth_type: "v3applicationcredential"
+{% if not stackhpc_os_capacity_openstack_verify | bool %}
+    verify: False
+{% endif %}

--- a/etc/kayobe/kolla/config/grafana/dashboards/openstack/grafana_cloud_dashboard.json
+++ b/etc/kayobe/kolla/config/grafana/dashboards/openstack/grafana_cloud_dashboard.json
@@ -25,7 +25,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 2084495,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -66,7 +65,7 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 2.4,
+        "w": 4.8,
         "x": 0,
         "y": 1
       },
@@ -86,7 +85,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.4.7",
+      "pluginVersion": "10.1.5",
       "repeat": "flavors",
       "repeatDirection": "h",
       "targets": [
@@ -96,7 +95,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "openstack_free_capacity_by_flavor_total{flavor_name=~\"$flavors\"}",
+          "expr": "round(avg_over_time(openstack_free_capacity_by_flavor_total{flavor_name=~\"$flavors\"}[30m]), 1)",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -424,6 +423,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -465,6 +465,7 @@
         "y": 17
       },
       "id": 5,
+      "interval": "10m",
       "options": {
         "legend": {
           "calcs": [
@@ -489,7 +490,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "openstack_project_usage{placement_resource=\"MEMORY_MB\"}",
+          "expr": "avg_over_time(openstack_project_usage{placement_resource=\"MEMORY_MB\"}[30m])",
           "legendFormat": "{{project_name}}",
           "range": true,
           "refId": "A"
@@ -522,6 +523,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -552,7 +554,7 @@
               }
             ]
           },
-          "unit": "decmbytes"
+          "unit": "none"
         },
         "overrides": []
       },
@@ -563,6 +565,7 @@
         "y": 17
       },
       "id": 16,
+      "interval": "10m",
       "options": {
         "legend": {
           "calcs": [
@@ -587,7 +590,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "openstack_project_usage{placement_resource=\"VCPU\"}",
+          "expr": "avg_over_time(openstack_project_usage{placement_resource=\"VCPU\"}[30m])",
           "legendFormat": "VCPU {{project_name}}",
           "range": true,
           "refId": "A"
@@ -598,7 +601,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "openstack_project_usage{placement_resource=\"PCPU\"}",
+          "expr": "avg_over_time(openstack_project_usage{placement_resource=\"PCPU\"}[30m])",
           "hide": false,
           "legendFormat": "PCPU {{project_name}}",
           "range": true,
@@ -646,6 +649,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "smooth",
             "lineStyle": {
               "fill": "solid"
@@ -689,6 +693,7 @@
         "y": 26
       },
       "id": 6,
+      "interval": "10m",
       "options": {
         "legend": {
           "calcs": [
@@ -715,15 +720,15 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "openstack_free_capacity_hypervisor_by_flavor{flavor_name=~\"$flavors\"}",
+          "expr": "avg_over_time(openstack_free_capacity_hypervisor_by_flavor{flavor_name=~\"$flavors\"}[30m])",
           "format": "time_series",
           "instant": false,
           "legendFormat": "{{flavor_name}} on {{hypervisor}}",
           "range": true,
-          "refId": "Avaliable Capacity on Hypervisors"
+          "refId": "Available Capacity on Hypervisors"
         }
       ],
-      "title": "Avaliable Capacity for $flavors",
+      "title": "Available Capacity for $flavors",
       "type": "timeseries"
     },
     {
@@ -750,6 +755,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -791,6 +797,7 @@
         "y": 26
       },
       "id": 4,
+      "interval": "10m",
       "options": {
         "legend": {
           "calcs": [
@@ -814,8 +821,8 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "editorMode": "builder",
-          "expr": "openstack_hypervisor_placement_allocatable_capacity{resource=\"MEMORY_MB\"} - on(hypervisor) openstack_hypervisor_placement_allocated{resource=\"MEMORY_MB\"}",
+          "editorMode": "code",
+          "expr": "avg_over_time(openstack_hypervisor_placement_allocatable_capacity{resource=\"MEMORY_MB\"}[30m]) - on(hypervisor) avg_over_time(openstack_hypervisor_placement_allocated{resource=\"MEMORY_MB\"}[30m])",
           "legendFormat": "{{hypervisor}}",
           "range": true,
           "refId": "A"
@@ -885,7 +892,7 @@
     ]
   },
   "time": {
-    "from": "now-24h",
+    "from": "now-2d",
     "to": "now"
   },
   "timepicker": {},

--- a/etc/kayobe/kolla/config/grafana/dashboards/openstack/grafana_project_dashboard.json
+++ b/etc/kayobe/kolla/config/grafana/dashboards/openstack/grafana_project_dashboard.json
@@ -25,7 +25,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 2084480,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -89,9 +88,10 @@
           "fields": "",
           "values": false
         },
-        "showUnfilled": true
+        "showUnfilled": true,
+        "valueMode": "color"
       },
-      "pluginVersion": "9.4.7",
+      "pluginVersion": "10.1.5",
       "targets": [
         {
           "datasource": {
@@ -134,6 +134,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -175,6 +176,7 @@
         "y": 11
       },
       "id": 5,
+      "interval": "10m",
       "options": {
         "legend": {
           "calcs": [
@@ -199,7 +201,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(openstack_project_usage{project_id=~\"${project_id}\"}) by (placement_resource)",
+          "expr": "sum(avg_over_time(openstack_project_usage{project_id=~\"${project_id}\"}[30m:])) by (placement_resource)",
           "hide": false,
           "legendFormat": "{{placement_resource}}",
           "range": true,
@@ -234,6 +236,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -275,6 +278,7 @@
         "y": 11
       },
       "id": 19,
+      "interval": "10m",
       "options": {
         "legend": {
           "calcs": [
@@ -299,7 +303,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "openstack_project_quota{project_id=~\"${project_id}\"}",
+          "expr": "avg_over_time(openstack_project_quota{project_id=~\"${project_id}\"}[30m:])",
           "hide": false,
           "legendFormat": "{{project_name}}:{{quota_resource}}",
           "range": true,
@@ -333,6 +337,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -433,6 +438,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -474,6 +480,7 @@
         "y": 20
       },
       "id": 20,
+      "interval": "30m",
       "options": {
         "legend": {
           "calcs": [
@@ -498,7 +505,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(irate(libvirt_domain_vcpu_time_seconds_total{}[5m]) / ignoring(instance,vcpu) group_left(domain) libvirt_domain_info_virtual_cpus{}) by (domain) * on(domain) group_left(instance_name,project_name,project_uuid) libvirt_domain_info_meta{project_uuid=~\"${project_id}\"}",
+          "expr": "avg(sum(irate(libvirt_domain_vcpu_time_seconds_total{}[5m]) / ignoring(instance,vcpu) group_left(domain) libvirt_domain_info_virtual_cpus{}) by (domain) * on(domain) group_left(instance_name,project_name,project_uuid) libvirt_domain_info_meta{project_uuid=~\"${project_id}\"}) by (project_name)",
           "hide": false,
           "legendFormat": "{{instance_name}}",
           "range": true,
@@ -532,6 +539,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -598,7 +606,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "libvirt_domain_memory_stats_used_percent * on(domain) group_left(instance_name,project_name,project_uuid) libvirt_domain_info_meta{project_uuid=~\"${project_id}\"}",
+          "expr": "avg(libvirt_domain_memory_stats_used_percent * on(domain) group_left(instance_name,project_name,project_uuid) libvirt_domain_info_meta{project_uuid=~\"${project_id}\"}) by (project_name)",
           "hide": false,
           "legendFormat": "{{instance_name}}",
           "range": true,
@@ -633,6 +641,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -700,9 +709,9 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "rate(libvirt_domain_block_stats_read_time_seconds_total[5m]) * on(domain) group_left(instance_name,project_name,project_uuid) libvirt_domain_info_meta{project_uuid=~\"${project_id}\"}",
+          "expr": "avg(rate(libvirt_domain_block_stats_read_time_seconds_total[5m]) * on(domain) group_left(instance_name,project_name,project_uuid) libvirt_domain_info_meta{project_uuid=~\"${project_id}\"}) by (project_name)",
           "hide": false,
-          "legendFormat": "{{instance_name}} : read {{target_device}}",
+          "legendFormat": "read: {{project_name}}",
           "range": true,
           "refId": "B"
         },
@@ -712,9 +721,9 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "rate(libvirt_domain_block_stats_write_time_seconds_total[5m]) * on(domain) group_left(instance_name,project_name,project_uuid) libvirt_domain_info_meta{project_uuid=~\"${project_id}\"} * -1",
+          "expr": "avg(rate(libvirt_domain_block_stats_write_time_seconds_total[5m]) * on(domain) group_left(instance_name,project_name,project_uuid) libvirt_domain_info_meta{project_uuid=~\"${project_id}\"} * -1) by (project_name)",
           "hide": false,
-          "legendFormat": "{{instance_name}} : write {{target_device}}",
+          "legendFormat": " write: {{project_name}}",
           "range": true,
           "refId": "C"
         }
@@ -732,8 +741,212 @@
       },
       "id": 15,
       "panels": [],
-      "title": "Per Hypervisor Free Capacity",
+      "title": "Per Instance Utilization",
       "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMax": 1,
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 23,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 0,
+        "y": 30
+      },
+      "id": 23,
+      "interval": "30m",
+      "options": {
+        "legend": {
+          "calcs": [
+            "min",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(irate(libvirt_domain_vcpu_time_seconds_total{}[5m]) / ignoring(instance,vcpu) group_left(domain) libvirt_domain_info_virtual_cpus{}) by (domain) * on(domain) group_left(instance_name,project_name,project_uuid) libvirt_domain_info_meta{project_uuid=~\"${project_id}\"}",
+          "hide": false,
+          "legendFormat": "{{instance_name}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "CPU utilization per instance",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 23,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 8,
+        "y": 30
+      },
+      "id": 24,
+      "interval": "30m",
+      "options": {
+        "legend": {
+          "calcs": [
+            "min",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "libvirt_domain_memory_stats_used_percent * on(domain) group_left(instance_name,project_name,project_uuid) libvirt_domain_info_meta{project_uuid=~\"${project_id}\"}",
+          "hide": false,
+          "legendFormat": "{{instance_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Memory utilization per instance",
+      "type": "timeseries"
     },
     {
       "datasource": {
@@ -744,63 +957,111 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "thresholds"
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": true,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 23,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
+          "max": 1,
+          "min": -1,
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "semi-dark-yellow",
+                "color": "green",
                 "value": null
               },
               {
-                "color": "green",
-                "value": 4
+                "color": "red",
+                "value": 80
               }
             ]
-          }
+          },
+          "unit": "percentunit"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 10,
-        "w": 24,
-        "x": 0,
+        "h": 9,
+        "w": 8,
+        "x": 16,
         "y": 30
       },
-      "id": 2,
+      "id": 25,
       "options": {
-        "displayMode": "basic",
-        "minVizHeight": 10,
-        "minVizWidth": 0,
-        "orientation": "horizontal",
-        "reduceOptions": {
+        "legend": {
           "calcs": [
-            "lastNotNull"
+            "min",
+            "max"
           ],
-          "fields": "",
-          "values": false
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
         },
-        "showUnfilled": true
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
       },
-      "pluginVersion": "9.4.7",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "editorMode": "builder",
-          "expr": "openstack_free_capacity_by_flavor_total",
-          "format": "time_series",
-          "legendFormat": "{{flavor_name}}",
+          "editorMode": "code",
+          "expr": "rate(libvirt_domain_block_stats_read_time_seconds_total[5m]) * on(domain) group_left(instance_name,project_name,project_uuid) libvirt_domain_info_meta{project_uuid=~\"${project_id}\"}",
+          "hide": false,
+          "legendFormat": "{{instance_name}} : read {{target_device}}",
           "range": true,
-          "refId": "A"
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "avg(rate(libvirt_domain_block_stats_write_time_seconds_total[5m]) * on(domain) group_left(instance_name,project_name,project_uuid) libvirt_domain_info_meta{project_uuid=~\"${project_id}\"} * -1) by (project_name)",
+          "hide": false,
+          "legendFormat": "{{instance_name}} : write {{target_device}}",
+          "range": true,
+          "refId": "C"
         }
       ],
-      "title": "Free Capacity by Flavor",
-      "type": "bargauge"
+      "title": "Disk utilization per instance",
+      "type": "timeseries"
     }
   ],
   "refresh": "",
@@ -817,7 +1078,7 @@
         "current": {
           "selected": false,
           "text": "Prometheus",
-          "value": "Prometheus"
+          "value": "PBFA97CFB590B2093"
         },
         "description": "The prometheus datasource used for queries.",
         "hide": 0,
@@ -867,14 +1128,14 @@
     ]
   },
   "time": {
-    "from": "now-3h",
+    "from": "now-2d",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "OpenStack Project Metrics",
   "uid": "mXiuBDe7z",
-  "version": 2,
+  "version": 1,
   "weekStart": ""
 }
 {% endraw %}

--- a/etc/kayobe/kolla/config/haproxy/services.d/os_capacity.cfg
+++ b/etc/kayobe/kolla/config/haproxy/services.d/os_capacity.cfg
@@ -6,7 +6,11 @@ frontend os_capacity_frontend
     option httplog
     option forwardfor
     http-request set-header X-Forwarded-Proto https if { ssl_fc }
-    bind {{ kolla_internal_vip_address }}:9000
+{% if kolla_enable_tls_internal | bool %}
+    bind {{ kolla_internal_vip_address }}:9090 ssl crt /etc/haproxy/haproxy-internal.pem
+{% else %}
+    bind {{ kolla_internal_vip_address }}:9090
+{% endif %}
     default_backend os_capacity_backend
 
 backend os_capacity_backend

--- a/etc/kayobe/kolla/config/prometheus/prometheus.yml.d/70-oscapacity.yml
+++ b/etc/kayobe/kolla/config/prometheus/prometheus.yml.d/70-oscapacity.yml
@@ -6,8 +6,11 @@ scrape_configs:
   - job_name: os-capacity
     static_configs:
         - targets:
-          - '{{ kolla_internal_vip_address | put_address_in_context('url') }}:9000'
+          - '{{ kolla_internal_fqdn | put_address_in_context('url') }}:9090'
     scrape_interval: 15m
     scrape_timeout: 10m
+{% if kolla_enable_tls_internal | bool %}
+    scheme: https
+{% endif %}
 {% endraw %}
 {% endif %}

--- a/etc/kayobe/stackhpc-monitoring.yml
+++ b/etc/kayobe/stackhpc-monitoring.yml
@@ -15,3 +15,13 @@ alertmanager_low_memory_threshold_gib: 5
 # Enabling this flag will result in HAProxy configuration and Prometheus scrape
 # targets being templated during deployment.
 stackhpc_enable_os_capacity: false
+
+# Keystone authentication URL for OpenStack Capacity
+stackhpc_os_capacity_auth_url: "http{% if kolla_enable_tls_internal | bool %}s{% endif %}://{{ kolla_internal_fqdn }}:5000"
+
+# OpenStack region for OpenStack Capacity
+stackhpc_os_capacity_openstack_region_name: "{{ openstack_region_name | default(RegionOne) }}"
+
+# Whether TLS certificate verification is enabled for the OpenStack Capacity
+# exporter during Keystone authentication.
+stackhpc_os_capacity_openstack_verify: true

--- a/releasenotes/notes/os-capacity-94006f03f16583e4.yaml
+++ b/releasenotes/notes/os-capacity-94006f03f16583e4.yaml
@@ -9,7 +9,20 @@ upgrade:
   - |
     To deploy the OpenStack Capacity Grafana dashboard, you must
     define OpenStack application credential variables:
-    ``secrets_os_exporter_auth_url``,
-    ``secrets_os_exporter_credential_id`` and
-    ``secrets_os_exporter_credential_secret`` as laid out in the
+    ``secrets_os_capacity_credential_id`` and
+    ``secrets_os_capacity_credential_secret`` as laid out in the
     'Monitoring' documentation.
+
+    You must also enable the ``stackhpc_enable_os_capacity``
+    flag for OpenStack Capacity HAProxy and Prometheus configuration
+    to be templated.
+
+    You may also change the default authentication URL from the
+    kolla_internal_fqdn and change the default OpenStack region
+    from RegionOne with the variables:
+    ``stackhpc_os_capacity_auth_url`` and
+    ``stackhpc_os_capacity_openstack_region_name``.
+
+    To disable certificate verification for the OpenStack Capacity
+    exporter, you can set ``stackhpc_os_capacity_openstack_verify``
+    to false.


### PR DESCRIPTION
- Various typo fixes.
- Renamed `os_exporter` to `os_capacity`.
- Renamed `70-oscapacity.yml.j2` to `70-oscapacity.yml` to ensure correct templating.
- Added `70-oscapacity.yml` to .yamlint ignore list.
- Conditional flag `stackhpc_enable_os_capacity` added to prevent HAProxy config and Prometheus scrape targets being copied in before manual deployment.
- Conditional flag `stackhpc_os_capacity_openstack_verify` added where certificate verification can be overridden.
- Fixed interval errors