### PR TITLE
DNM: CloudKitty  for fresh OpenSearch deployments

### DIFF
--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -10,6 +10,7 @@ enable_docker_repo: "{% raw %}{{ 'overcloud' not in group_names or ansible_facts
 # This is necessary for os migrations where mixed clouds might be deployed
 kolla_base_distro: "{% raw %}{{ 'centos' if ansible_facts.distribution == 'Rocky' and ansible_facts.distribution_major_version == '8' else ansible_facts.distribution | lower }}{% endraw %}"
 
+cloudkitty_tag: yoga-20231009T094403
 opensearch_tag: yoga-20230904T121340
 octavia_tag: yoga-20230921T074238
 


### PR DESCRIPTION
This container tag brings in the fixes from this PR: https://github.com/stackhpc/cloudkitty/pull/57 which allows CloudKitty with the elasticsearch backend to be used with fresh OpenSearch. i.e for new deployments (Habrok, AZ Moldnal, etc.)

This PR should not be merged until we are happy with using the same patch for existing deployments after an ES->OS migration. (Or ideally, never at all if we want to integrate the proper opensearch v2 storage driver)