### PR TITLE
Extend the cephadm commands to allow defaults and extras

### DIFF
--- a/etc/kayobe/cephadm.yml
+++ b/etc/kayobe/cephadm.yml
@@ -89,14 +89,14 @@ cephadm_cluster_network: "{{ storage_mgmt_net_name | net_cidr }}"
 cephadm_commands_pre: "{{ cephadm_commands_pre_default + cephadm_commands_pre_extra }}"
 cephadm_commands_post: "{{ cephadm_commands_post_default + cephadm_commands_post_extra }}"
 
-cephadm_commands_pre_default:
+cephadm_commands_pre_default: []
 cephadm_commands_post_default:
 {% if kolla_enable_prometheus_ceph_mgr_exporter %}
   - "mgr module enable prometheus"
 {% endif %}
 
-cephadm_commands_pre_extra:
-cephadm_commands_post_extra:
+cephadm_commands_pre_extra: []
+cephadm_commands_post_extra: []
 
 ###############################################################################
 # Kolla Ceph auto-configuration.

--- a/etc/kayobe/cephadm.yml
+++ b/etc/kayobe/cephadm.yml
@@ -90,12 +90,7 @@ cephadm_commands_pre: "{{ cephadm_commands_pre_default + cephadm_commands_pre_ex
 cephadm_commands_post: "{{ cephadm_commands_post_default + cephadm_commands_post_extra }}"
 
 cephadm_commands_pre_default: []
-{% if kolla_enable_prometheus_ceph_mgr_exporter %}
-cephadm_commands_post_default:
-  - "mgr module enable prometheus"
-{% else %}
-cephadm_commands_post_default: []
-{% endif %}
+cephadm_commands_post_default: "{{ ['mgr module enable prometheus'] if kolla_enable_prometheus_ceph_mgr_exporter else [] }}"
 
 cephadm_commands_pre_extra: []
 cephadm_commands_post_extra: []

--- a/etc/kayobe/cephadm.yml
+++ b/etc/kayobe/cephadm.yml
@@ -91,6 +91,9 @@ cephadm_commands_post: "{{ cephadm_commands_post_default + cephadm_commands_post
 
 cephadm_commands_pre_default:
 cephadm_commands_post_default:
+{% if kolla_enable_prometheus_ceph_mgr_exporter %}
+  - "mgr module enable prometheus"
+{% endif %}
 
 cephadm_commands_pre_extra:
 cephadm_commands_post_extra:

--- a/etc/kayobe/cephadm.yml
+++ b/etc/kayobe/cephadm.yml
@@ -90,9 +90,11 @@ cephadm_commands_pre: "{{ cephadm_commands_pre_default + cephadm_commands_pre_ex
 cephadm_commands_post: "{{ cephadm_commands_post_default + cephadm_commands_post_extra }}"
 
 cephadm_commands_pre_default: []
-cephadm_commands_post_default:
 {% if kolla_enable_prometheus_ceph_mgr_exporter %}
+cephadm_commands_post_default:
   - "mgr module enable prometheus"
+{% else %}
+cephadm_commands_post_default: []
 {% endif %}
 
 cephadm_commands_pre_extra: []

--- a/etc/kayobe/cephadm.yml
+++ b/etc/kayobe/cephadm.yml
@@ -86,8 +86,14 @@ cephadm_cluster_network: "{{ storage_mgmt_net_name | net_cidr }}"
 # stackhpc.cephadm.commands for format. Pre commands run before the rest of the
 # post-deployment configuration, post commands run after the rest of the
 # post-deployment configuration.
-#cephadm_commands_pre:
-#cephadm_commands_post:
+cephadm_commands_pre: "{{ cephadm_commands_pre_default + cephadm_commands_pre_extra }}"
+cephadm_commands_post: "{{ cephadm_commands_post_default + cephadm_commands_post_extra }}"
+
+cephadm_commands_pre_default:
+cephadm_commands_post_default:
+
+cephadm_commands_pre_extra:
+cephadm_commands_post_extra:
 
 ###############################################################################
 # Kolla Ceph auto-configuration.

--- a/etc/kayobe/cephadm.yml
+++ b/etc/kayobe/cephadm.yml
@@ -90,9 +90,9 @@ cephadm_commands_pre: "{{ cephadm_commands_pre_default + cephadm_commands_pre_ex
 cephadm_commands_post: "{{ cephadm_commands_post_default + cephadm_commands_post_extra }}"
 
 cephadm_commands_pre_default: []
-cephadm_commands_post_default: "{{ ['mgr module enable prometheus'] if kolla_enable_prometheus_ceph_mgr_exporter else [] }}"
-
 cephadm_commands_pre_extra: []
+
+cephadm_commands_post_default: "{{ ['mgr module enable prometheus'] if kolla_enable_prometheus_ceph_mgr_exporter else [] }}"
 cephadm_commands_post_extra: []
 
 ###############################################################################

--- a/etc/kayobe/cephadm.yml
+++ b/etc/kayobe/cephadm.yml
@@ -92,7 +92,7 @@ cephadm_commands_post: "{{ cephadm_commands_post_default + cephadm_commands_post
 cephadm_commands_pre_default: []
 cephadm_commands_pre_extra: []
 
-cephadm_commands_post_default: "{{ ['mgr module enable prometheus'] if kolla_enable_prometheus_ceph_mgr_exporter else [] }}"
+cephadm_commands_post_default: "{{ ['mgr module enable prometheus'] if kolla_enable_prometheus_ceph_mgr_exporter | bool else [] }}"
 cephadm_commands_post_extra: []
 
 ###############################################################################

--- a/releasenotes/notes/cephadm-pre-post-commands-now-have-defaults-b42ce9b13fa6d63b.yaml
+++ b/releasenotes/notes/cephadm-pre-post-commands-now-have-defaults-b42ce9b13fa6d63b.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    The Cephadm pre and post commands now support default commands with the
+    variables ``cephadm_commands_pre_default`` and
+    ``cephadm_commands_post_default``. As such, any extra commands should be
+    added to the variables ``cephadm_commands_pre_extra`` and
+    ``cephadm_commands_post_extra``.


### PR DESCRIPTION
Seems that in a couple of deployments this was just set by hand. Let's get it automated instead.