### PR TITLE
Reduce ESP partition size in deployment image

### DIFF
--- a/etc/kayobe/pulp-host-image-versions.yml
+++ b/etc/kayobe/pulp-host-image-versions.yml
@@ -3,6 +3,6 @@
 # These images must be in SMS, since they are used by our AIO CI runners
 stackhpc_centos_8_stream_overcloud_host_image_version: "yoga-20230525T095243"
 stackhpc_rocky_8_overcloud_host_image_version: "yoga-20230629T135322"
-stackhpc_rocky_9_overcloud_host_image_version: "yoga-20230929T133006"
+stackhpc_rocky_9_overcloud_host_image_version: "yoga-20231012T121552"
 stackhpc_ubuntu_focal_overcloud_host_image_version: "yoga-20230609T120720"
-stackhpc_ubuntu_jammy_overcloud_host_image_version: "yoga-20230609T120720"
+stackhpc_ubuntu_jammy_overcloud_host_image_version: "yoga-20231012T121552"

--- a/etc/kayobe/stackhpc-overcloud-dib.yml
+++ b/etc/kayobe/stackhpc-overcloud-dib.yml
@@ -102,7 +102,7 @@ stackhpc_overcloud_dib_block_device_config_uefi_lvm: |
       partitions:
         - name: ESP
           type: 'EF00'
-          size: 550MiB
+          size: 500MiB
           mkfs:
             type: vfat
             mount:


### PR DESCRIPTION
It does not fit into 550MiB partition created by Ironic Python Agent. This is relevant when provisioning software RAID UEFI enabled servers.

https://github.com/openstack/ironic-python-agent/blob/stable/yoga/ironic_python_agent/raid_utils.py#L30