### PR TITLE
Correct release notes for Inception vulnerability

### DIFF
--- a/releasenotes/notes/bump-centos8-stream-snapshots-2023-09-04-a473edfd3f3b2298.yaml
+++ b/releasenotes/notes/bump-centos8-stream-snapshots-2023-09-04-a473edfd3f3b2298.yaml
@@ -2,9 +2,8 @@
 security:
   - |
     Bumps CentOS Stream 8 snapshots to include fixes for Zenbleed
-    (CVE-2023-20593), Downfall (CVE-2022-40982) and Inception (CVE-2023-20569).
-    It is recommended that you update your OS packages and reboot into the kernel
-    as soon as possible.
+    (CVE-2023-20593), Downfall (CVE-2022-40982). It is recommended that you
+    update your OS packages and reboot into the kernel as soon as possible.
 upgrade:
   - |
     CentOS Stream 8 snapshots have been bumped and new container images are

--- a/releasenotes/notes/bump-centos8-stream-snapshots-2023-09-04-a473edfd3f3b2298.yaml
+++ b/releasenotes/notes/bump-centos8-stream-snapshots-2023-09-04-a473edfd3f3b2298.yaml
@@ -2,7 +2,7 @@
 security:
   - |
     Bumps CentOS Stream 8 snapshots to include fixes for Zenbleed
-    (CVE-2023-20593), Downfall (CVE-2022-40982). It is recommended that you
+    (CVE-2023-20593) and Downfall (CVE-2022-40982). It is recommended that you
     update your OS packages and reboot into the kernel as soon as possible.
 upgrade:
   - |

--- a/releasenotes/notes/bump-ubuntu-snapshots-2023-09-15-22ca5250d40bd5b6.yaml
+++ b/releasenotes/notes/bump-ubuntu-snapshots-2023-09-15-22ca5250d40bd5b6.yaml
@@ -3,6 +3,6 @@ security:
   - |
     Bumps Ubuntu repository snapshots and container images to bring in latest
     security patches. This includes the microcode to patch Downfall
-    (CVE-2022-40982).  Zenbleed (CVE-2023-20593) was patched in the previous
+    (CVE-2022-40982). Zenbleed (CVE-2023-20593) was patched in the previous
     snapshot bump. To apply the microcode updates, it is recommended to reboot
     each host after upgrading all of the packages.

--- a/releasenotes/notes/bump-ubuntu-snapshots-2023-09-15-22ca5250d40bd5b6.yaml
+++ b/releasenotes/notes/bump-ubuntu-snapshots-2023-09-15-22ca5250d40bd5b6.yaml
@@ -2,7 +2,7 @@
 security:
   - |
     Bumps Ubuntu repository snapshots and container images to bring in latest
-    security patches. This includes the microcode to patch Inception
-    (CVE-2023-20569) and Downfall (CVE-2022-40982). Zenbleed (CVE-2023-20593)
-    was patched in the previous snapshot bump. To apply the microcode updates,
-    it is recommended to reboot each host after upgrading all of the packages.
+    security patches. This includes the microcode to patch Downfall
+    (CVE-2022-40982).  Zenbleed (CVE-2023-20593) was patched in the previous
+    snapshot bump. To apply the microcode updates, it is recommended to reboot
+    each host after upgrading all of the packages.


### PR DESCRIPTION
Missing the kernel mitigation. This is required in addition to the microcode, see: https://docs.kernel.org/admin-guide/hw-vuln/srso.html.