### PR TITLE
Seed image build fix antelope

### DIFF
--- a/.github/workflows/stackhpc-container-image-build.yml
+++ b/.github/workflows/stackhpc-container-image-build.yml
@@ -167,7 +167,7 @@ jobs:
 
       - name: Build and push kolla seed images
         run: |
-          args="kolla_base_distro=${{ matrix.distro }}"
+          args="-e kolla_base_distro=${{ matrix.distro }}"
           args="$args -e kolla_tag=$KOLLA_TAG"
           if ${{ inputs.push }} == 'true'; then
             args="$args --push"

--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -9,8 +9,12 @@ kayobe_image_tags:
   openstack:
     rocky: 2023.1-rocky-9-20231011T200357
     ubuntu: 2023.1-ubuntu-jammy-20231011T200357
+  bifrost:
+    rocky: 2023.1-rocky-9-20231013T151957
+    ubuntu: 2023.1-ubuntu-jammy-20231013T151957
 
 openstack_tag: "{% raw %}{{ kayobe_image_tags['openstack'][kolla_base_distro] }}{% endraw %}"
+bifrost_tag: "{% raw %}{{ kayobe_image_tags['bifrost'][kolla_base_distro] }}{% endraw %}"
 
 om_enable_rabbitmq_high_availability: true
 


### PR DESCRIPTION
Seed image builds were previously failing. This change cherry-picks the fix and adds tags for bifrost with newly built images