### PR TITLE
Fix value of libvirt.hw_machine_type

### DIFF
--- a/etc/kayobe/kolla/config/nova.conf
+++ b/etc/kayobe/kolla/config/nova.conf
@@ -1,2 +1,2 @@
 [libvirt]
-hw_machine_type = q35
+hw_machine_type = x86_64=q35


### PR DESCRIPTION
We are seeing the following entries in nova-compute.log:

    WARNING nova.virt.libvirt.utils [-] Invalid hw_machine_type config value q35

The format for this config option is `host-arch=machine-type`. For example: `x86_64=machinetype1,armv7l=machinetype2`.