### PR TITLE
OVN packages version bump to 22.12

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -415,15 +415,15 @@ kolla_build_customizations_centos:
     - openvswitch2.17
     - python3-openvswitch2.17
   ovn_base_packages_override:
-    - ovn22.09
+    - ovn22.12
   ovn_controller_packages_override:
-    - ovn22.09-host
+    - ovn22.12-host
   ovn_nb_db_server_packages_override:
-    - ovn22.09-central
+    - ovn22.12-central
   ovn_northd_packages_override:
-    - ovn22.09-central
+    - ovn22.12-central
   ovn_sb_db_server_packages_override:
-    - ovn22.09-central
+    - ovn22.12-central
   openvswitch_base_packages_remove:
     - openvswitch
     - python3-openvswitch

--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -41,9 +41,11 @@ kayobe_image_tags:
     # with signature: `Missing section footer for 0000:00:01.3/piix4_pm`. Test carefully before bumping.
     centos: yoga-20230718T112646
   openvswitch:
-    rocky: yoga-20230515T150233
+    centos: yoga-20231019T102525
+    rocky: yoga-20231019T102525
   ovn:
-    rocky: yoga-20230515T150233
+    centos: yoga-20231019T102525
+    rocky: yoga-20231019T102525
   prometheus_node_exporter:
     rocky: yoga-20230315T170614
 


### PR DESCRIPTION
Need to bump to 22.12 to get to the same level as already deployed on many customers yoga-20231019T102525.