### PR TITLE
Fixes for Barbican with Vault plugin

### DIFF
--- a/doc/source/configuration/vault.rst
+++ b/doc/source/configuration/vault.rst
@@ -296,6 +296,7 @@ Configure Barbican
       [vault_plugin]
       vault_url = https://{{ kolla_internal_vip_address }}:8200
       use_ssl = True
+      ssl_ca_crt_file = /etc/ssl/certs/ca-bundle.trust.crt
       approle_role_id = {{ secrets_barbican_approle_role_id }}
       approle_secret_id = {{ secrets_barbican_approle_secret_id }}
       kv_mountpoint = barbican

--- a/doc/source/configuration/vault.rst
+++ b/doc/source/configuration/vault.rst
@@ -296,7 +296,7 @@ Configure Barbican
       [vault_plugin]
       vault_url = https://{{ kolla_internal_vip_address }}:8200
       use_ssl = True
-      ssl_ca_crt_file = /etc/ssl/certs/ca-bundle.trust.crt
+      ssl_ca_crt_file = {% raw %}{{ openstack_cacert }}{% endraw %}
       approle_role_id = {{ secrets_barbican_approle_role_id }}
       approle_secret_id = {{ secrets_barbican_approle_secret_id }}
       kv_mountpoint = barbican

--- a/etc/kayobe/ansible/vault-deploy-barbican.yml
+++ b/etc/kayobe/ansible/vault-deploy-barbican.yml
@@ -85,12 +85,13 @@
       when: stackhpc_write_barbican_role_id_to_file | default(false) | bool
 
     - name: Check if barbican Approle Secret ID is defined
-      hashivault_approle_role_secret_list:
+      hashivault_approle_role_secret_get:
         url: "{{ vault_api_addr }}"
         ca_cert: "{{ vault_ca_cert }}"
         token: "{{ vault_keys.root_token }}"
+        secret: "{{ secrets_barbican_approle_secret_id }}"
         name: barbican
-      register: barbican_approle_secret_list
+      register: barbican_approle_secret_get
 
     - name: Ensure barbican AppRole Secret ID is defined
       hashivault_approle_role_secret:
@@ -99,4 +100,4 @@
         token: "{{ vault_keys.root_token }}"
         secret: "{{ secrets_barbican_approle_secret_id }}"
         name: barbican
-      when: barbican_approle_secret_list.secrets is match(secrets_barbican_approle_secret_id)
+      when: barbican_approle_secret_get.status == "absent"

--- a/etc/kayobe/ansible/vault-deploy-barbican.yml
+++ b/etc/kayobe/ansible/vault-deploy-barbican.yml
@@ -82,7 +82,7 @@
       copy:
         content: "{{ barbican_role_id.id }}"
         dest: "{{ stackhpc_barbican_role_id_file_path | default('~/barbican-role-id') }}"
-      when: stackhpc_write_barbican_role_id_to_file | bool | default(false)
+      when: stackhpc_write_barbican_role_id_to_file | default(false) | bool
 
     - name: Check if barbican Approle Secret ID is defined
       hashivault_approle_role_secret_list:

--- a/etc/kayobe/environments/ci-multinode/kolla/config/barbican.conf
+++ b/etc/kayobe/environments/ci-multinode/kolla/config/barbican.conf
@@ -7,6 +7,7 @@ enabled_secretstore_plugins=vault_plugin
 [vault_plugin]
 vault_url = https://{{ kolla_internal_vip_address }}:8200
 use_ssl = True
+ssl_ca_crt_file = /etc/ssl/certs/ca-bundle.trust.crt
 approle_role_id = {{ secrets_barbican_approle_role_id }}
 approle_secret_id = {{ secrets_barbican_approle_secret_id }}
 kv_mountpoint = barbican

--- a/etc/kayobe/environments/ci-multinode/kolla/config/barbican.conf
+++ b/etc/kayobe/environments/ci-multinode/kolla/config/barbican.conf
@@ -7,7 +7,7 @@ enabled_secretstore_plugins=vault_plugin
 [vault_plugin]
 vault_url = https://{{ kolla_internal_vip_address }}:8200
 use_ssl = True
-ssl_ca_crt_file = /etc/ssl/certs/ca-bundle.trust.crt
+ssl_ca_crt_file = {% raw %}{{ openstack_cacert }}{% endraw %}
 approle_role_id = {{ secrets_barbican_approle_role_id }}
 approle_secret_id = {{ secrets_barbican_approle_secret_id }}
 kv_mountpoint = barbican


### PR DESCRIPTION
Currently gives the error below, as the default field is not being applied to the varriable.

```
TASK [Write barbican Approle ID to file if requested] *************************************************************************
Monday 30 October 2023  09:57:48 +0000 (0:00:00.075)       0:00:07.517 ********
fatal: [controller01 -> localhost]: FAILED! =>
  msg: |-
    The conditional check 'stackhpc_write_barbican_role_id_to_file | bool | default(false)' failed. The error was: error while evaluating conditional (stackhpc_write_barbican_role_id_to_file | bool | default(false)): 'stackhpc_write_barbican_role_id_to_file' is undefined

    The error appears to be in '/var/lib/home/stackhpc/mattc/src/kayobe-config/etc/kayobe/ansible/vault-deploy-barbican.yml': line 80, column 7, but may
    be elsewhere in the file depending on the exact syntax problem.

    The offending line appears to be:

        - name: Write barbican Approle ID to file if requested
          ^ here
```