### PR TITLE
Disable custom apt config for non-overcloud hosts

### DIFF
--- a/etc/kayobe/apt.yml
+++ b/etc/kayobe/apt.yml
@@ -62,12 +62,18 @@ stackhpc_apt_repositories:
     signed_by: docker.asc
     architecture: amd64
 
-apt_repositories: "{{ stackhpc_apt_repositories }}"
+# Do not replace apt configuration for non-overcloud hosts. This can result in
+# errors if apt reconfiguration is performed before local repository mirrors
+# are deployed.
+apt_repositories: "{{ stackhpc_apt_repositories if 'overcloud' in group_names else [] }}"
 
 # Whether to disable repositories in /etc/apt/sources.list. This may be used
 # when replacing the distribution repositories via apt_repositories.
 # Default is false.
-apt_disable_sources_list: true
+# Do not disable the default apt configuration for non-overcloud hosts. This
+# can result in errors if apt reconfiguration is performed before local
+# repository mirrors are deployed.
+apt_disable_sources_list: "{{ 'overcloud' in group_names }}"
 
 ###############################################################################
 # Dummy variable to allow Ansible to accept this file.

--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -4,7 +4,7 @@
 # To work around issue of trying to install docker from
 # empty pulp server, use upstream docker dnf repo on
 # non-overcloud hosts
-enable_docker_repo: "{% raw %}{{ 'overcloud' not in group_names or ansible_facts.os_family == 'Debian' }}{% endraw %}"
+enable_docker_repo: "{% raw %}{{ 'overcloud' not in group_names }}{% endraw %}"
 
 # kolla_base_distro must be set here to be resolvable on a per-host basis
 # This is necessary for os migrations where mixed clouds might be deployed

--- a/releasenotes/notes/disable-non-overcloud-apt-config-5b79b5b63c78779c.yaml
+++ b/releasenotes/notes/disable-non-overcloud-apt-config-5b79b5b63c78779c.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Disabled custom APT configuration for non-overcloud hosts (Ubuntu Only).
+    This resolves the issue of the seed hypervisor attempting to pull packages
+    from the repository on the seed before it has been deployed.


### PR DESCRIPTION
non-overcloud hosts e.g. the seed hypervisor are configured before the seed and its services are deployed. This means that they will look for the local package repo mirrors before they exist.