### PR TITLE
Fix seed container image build

### DIFF
--- a/.github/workflows/stackhpc-container-image-build.yml
+++ b/.github/workflows/stackhpc-container-image-build.yml
@@ -167,7 +167,7 @@ jobs:
 
       - name: Build and push kolla seed images
         run: |
-          args="kolla_base_distro=${{ matrix.distro }}"
+          args="-e kolla_base_distro=${{ matrix.distro }}"
           args="$args -e kolla_tag=$KOLLA_TAG"
           if ${{ inputs.push }} == 'true'; then
             args="$args --push"


### PR DESCRIPTION
The argument list was missing -e which meant the first argument was interpreted as image regexes.