### PR TITLE
Avoid facts for purge-command-not-found.yml

### DIFF
--- a/etc/kayobe/ansible/purge-command-not-found.yml
+++ b/etc/kayobe/ansible/purge-command-not-found.yml
@@ -30,4 +30,4 @@
       become: true
       failed_when: false
       ignore_unreachable: true
-      when: ansible_facts.os_family == "Debian"
+      when: os_distribution == "ubuntu"


### PR DESCRIPTION
Gather facts was false but facts are used in the playbook.