### PR TITLE
Add caso to pulp.yml

### DIFF
--- a/etc/kayobe/pulp.yml
+++ b/etc/kayobe/pulp.yml
@@ -574,6 +574,7 @@ stackhpc_pulp_images_kolla:
   - bifrost-deploy
   - blazar-api
   - blazar-manager
+  - caso
   - cinder-api
   - cinder-backup
   - cinder-scheduler


### PR DESCRIPTION
This change adds caso to the main list of containers in pulp.yml, allowing it to be pulled with a pulp container image sync.