### PR TITLE
Re-add prometheus elasticsearch exporter

### DIFF
--- a/etc/kayobe/pulp.yml
+++ b/etc/kayobe/pulp.yml
@@ -504,6 +504,7 @@ stackhpc_pulp_images_kolla:
   - prometheus-alertmanager
   - prometheus-blackbox-exporter
   - prometheus-cadvisor
+  - prometheus-elasticsearch-exporter
   - prometheus-haproxy-exporter
   - prometheus-libvirt-exporter
   - prometheus-memcached-exporter


### PR DESCRIPTION
Prometheus elasticsearch exporter was accidentally removed when purging elasticsearch references from Zed and Antelope. It is still being used for OpenSearch