### PR TITLE
Remove host image build option to skip SMS push

### DIFF
--- a/.github/workflows/overcloud-host-image-build.yml
+++ b/.github/workflows/overcloud-host-image-build.yml
@@ -23,10 +23,6 @@ on:
         description: Build Ubuntu 22.04 Jammy
         type: boolean
         default: true
-      SMS:
-        description: Push images to SMS
-        type: boolean
-        default: true
     secrets:
       KAYOBE_VAULT_PASSWORD:
         required: true
@@ -187,7 +183,7 @@ jobs:
         env:
           OS_APPLICATION_CREDENTIAL_ID: ${{ secrets.OS_APPLICATION_CREDENTIAL_ID }}
           OS_APPLICATION_CREDENTIAL_SECRET: ${{ secrets.OS_APPLICATION_CREDENTIAL_SECRET }}
-        if: inputs.centos && steps.build_centos_stream_8.outcome == 'success' && inputs.sms
+        if: inputs.centos && steps.build_centos_stream_8.outcome == 'success'
 
       - name: Build a Rocky Linux 8 overcloud host image
         id: build_rocky_8
@@ -231,7 +227,7 @@ jobs:
         env:
           OS_APPLICATION_CREDENTIAL_ID: ${{ secrets.OS_APPLICATION_CREDENTIAL_ID }}
           OS_APPLICATION_CREDENTIAL_SECRET: ${{ secrets.OS_APPLICATION_CREDENTIAL_SECRET }}
-        if: inputs.rocky8 && steps.build_rocky_8.outcome == 'success' && inputs.sms
+        if: inputs.rocky8 && steps.build_rocky_8.outcome == 'success'
 
       - name: Build a Rocky Linux 9 overcloud host image
         id: build_rocky_9
@@ -275,7 +271,7 @@ jobs:
         env:
           OS_APPLICATION_CREDENTIAL_ID: ${{ secrets.OS_APPLICATION_CREDENTIAL_ID }}
           OS_APPLICATION_CREDENTIAL_SECRET: ${{ secrets.OS_APPLICATION_CREDENTIAL_SECRET }}
-        if: inputs.rocky9 && steps.build_rocky_9.outcome == 'success' && inputs.sms
+        if: inputs.rocky9 && steps.build_rocky_9.outcome == 'success'
 
       - name: Build an Ubuntu Focal 20.04 overcloud host image
         id: build_ubuntu_focal
@@ -319,7 +315,7 @@ jobs:
         env:
           OS_APPLICATION_CREDENTIAL_ID: ${{ secrets.OS_APPLICATION_CREDENTIAL_ID }}
           OS_APPLICATION_CREDENTIAL_SECRET: ${{ secrets.OS_APPLICATION_CREDENTIAL_SECRET }}
-        if: inputs.ubuntu-focal && steps.build_ubuntu_focal.outcome == 'success' && inputs.sms
+        if: inputs.ubuntu-focal && steps.build_ubuntu_focal.outcome == 'success'
 
       - name: Build an Ubuntu Jammy 22.04 overcloud host image
         id: build_ubuntu_jammy
@@ -363,7 +359,7 @@ jobs:
         env:
           OS_APPLICATION_CREDENTIAL_ID: ${{ secrets.OS_APPLICATION_CREDENTIAL_ID }}
           OS_APPLICATION_CREDENTIAL_SECRET: ${{ secrets.OS_APPLICATION_CREDENTIAL_SECRET }}
-        if: inputs.ubuntu-jammy && steps.build_ubuntu_jammy.outcome == 'success' && inputs.sms
+        if: inputs.ubuntu-jammy && steps.build_ubuntu_jammy.outcome == 'success'
 
       - name: Upload updated images artifact
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
This change removes an input option on the overcloud host image build workflow that allowed the user to not push the built image to SMS. This function was useful in testing but in practice serves little use. Images that are not in SMS cannot be used in the default stackhpc kayobe configuration because they are used in CI.

All it does is create confusion and make people manually upload images.