### PR TITLE
Remove references to undefined Bifrost variables

### DIFF
--- a/etc/kayobe/bifrost.yml
+++ b/etc/kayobe/bifrost.yml
@@ -5,11 +5,11 @@
 # Bifrost installation.
 
 # URL of Bifrost source code repository.
-kolla_bifrost_source_url: "{{ stackhpc_bifrost_source_url }}"
+#kolla_bifrost_source_url:
 
 # Version (branch, tag, etc.) of Bifrost source code repository. Default is
 # {{ openstack_branch }}.
-kolla_bifrost_source_version: "{{ stackhpc_bifrost_source_version }}"
+#kolla_bifrost_source_version:
 
 # Whether Bifrost uses firewalld. Default value is false to avoid conflicting
 # with iptables rules configured on the seed host by Kayobe.


### PR DESCRIPTION
Commit 6c2bcf21d879ee1cf09e5201fa7887cb468b9ec2 removed the definition of these variables but forgot to remove some references.