### PR TITLE
CloudKitty fix for ES->OS migration

### DIFF
--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -20,6 +20,7 @@ kayobe_image_tags:
     # with signature: `Missing section footer for 0000:00:01.3/piix4_pm`. Test carefully before bumping.
     centos: yoga-20230718T112646
 
+cloudkitty_tag: yoga-20231107T165648
 nova_tag: yoga-20231103T161400
 nova_libvirt_tag: "{% raw %}{{ kayobe_image_tags['nova_libvirt'][kolla_base_distro] | default(nova_tag) }}{% endraw %}"
 

--- a/releasenotes/notes/cloudkitty-fix-es-to-os-migration-b0efd2626f59d977.yaml
+++ b/releasenotes/notes/cloudkitty-fix-es-to-os-migration-b0efd2626f59d977.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes the bulk API of CloudKitty so that it now supports the migration
+    from Elasticsearch to OpenSearch.


### PR DESCRIPTION
Built here: https://github.com/stackhpc/stackhpc-kayobe-config/actions/runs/6787765347
Promoted here: https://github.com/stackhpc/stackhpc-release-train/actions/runs/6796023400


Marked WIP. Needs a final test to make sure this doesn't break existing ElasticSearch-backed CloudKitty deployments