### PR TITLE
xena: wallaby merge

### DIFF
--- a/etc/kayobe/ansible/requirements.yml
+++ b/etc/kayobe/ansible/requirements.yml
@@ -1,4 +1,8 @@
 ---
 collections:
+  # NOTE: Pinning pulp.squeezer to 0.0.13 because 0.0.14+ depends on the
+  # pulp_glue Python library being installed.
+  - name: pulp.squeezer
+    version: 0.0.13
   - name: stackhpc.pulp
     version: 0.4.1

--- a/releasenotes/notes/pin-pulp-squeezer-bd3a3c53d9804010.yaml
+++ b/releasenotes/notes/pin-pulp-squeezer-bd3a3c53d9804010.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes an issue with Ansible Pulp modules depending on the ``pulp_glue``
+    Python library since the ``pulp.squeezer`` 0.0.14 release.


### PR DESCRIPTION
From 0.0.14 pulp.squeezer requires the pulp_glue Python library to be installed.

Pin to 0.0.13 until we have a solution for installing pulp_glue.
