### PR TITLE
OVN: Disable distributed floating IPs by default

### DIFF
--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -48,7 +48,3 @@ prometheus_ceph_mgr_exporter_endpoints:
 
 # Use inventory hostnames as labels
 prometheus_instance_label: "{% raw %}{{ ansible_facts.hostname }}{% endraw %}"
-
-#############################################################################
-
-neutron_ovn_distributed_fip: true

--- a/releasenotes/notes/enable_ovn-b84974f398242dcb.yaml
+++ b/releasenotes/notes/enable_ovn-b84974f398242dcb.yaml
@@ -1,8 +1,10 @@
 ---
 upgrade:
   - |
-    Enabled ML2/OVN by default as checks preventing accidental migration
-    from ML2/OVS were added in kolla-ansible. If you are using a Neutron
-    plugin other than ML2/OVN, set `kolla_enable_ovn` to `false`.
-    OVN distributed FIP is also enabled, to disable it set
-    `neutron_ovn_distributed_fip` to `false` in `etc/kayobe/kolla/globals.yml`.
+    Enabled ML2/OVN by default. Checks preventing accidental migration
+    from ML2/OVS were added in Kolla Ansible. If you are using a Neutron
+    plugin other than ML2/OVN, set ``kolla_enable_ovn`` to ``false``.
+
+    OVN distributed FIP is disabled, to enable it set
+    ``neutron_ovn_distributed_fip`` to ``true`` in
+    ``etc/kayobe/kolla/globals.yml``.


### PR DESCRIPTION
It could be dangerous to enable distributed floating IPs on an OVN
system already deployed without them.
