### PR TITLE
Handle undefined Ansible variable

### DIFF
--- a/etc/kayobe/cephadm.yml
+++ b/etc/kayobe/cephadm.yml
@@ -92,7 +92,7 @@ cephadm_commands_post: "{{ cephadm_commands_post_default + cephadm_commands_post
 cephadm_commands_pre_default: []
 cephadm_commands_pre_extra: []
 
-cephadm_commands_post_default: "{{ ['mgr module enable prometheus'] if kolla_enable_prometheus_ceph_mgr_exporter | bool else [] }}"
+cephadm_commands_post_default: "{{ ['mgr module enable prometheus'] if kolla_enable_prometheus_ceph_mgr_exporter | default(False) | bool else [] }}"
 cephadm_commands_post_extra: []
 
 ###############################################################################


### PR DESCRIPTION
The variable kolla_enable_prometheus_ceph_mgr_exporter can be undefined,
leading to an error running the cephadm-commands-post.yml playbook.
