### PR TITLE
Fix Growroot Playbook

### DIFF
--- a/etc/kayobe/ansible/growroot.yml
+++ b/etc/kayobe/ansible/growroot.yml
@@ -77,7 +77,7 @@
           vars:
             pv: "{{ pvs.stdout | from_json }}"
             disk_tmp: "{{ pv.report[0].pv[0].pv_name[:-1] }}"
-            disk: "{{ disk_tmp[:-1] if disk_tmp[-1] == 'p' else disk_tmp }}"
+            disk: "{{ disk_tmp[:-1] if disk_tmp[-1] == 'p' and disk_tmp[:4] == 'nvme' else disk_tmp }}"
             part_num: "{{ pv.report[0].pv[0].pv_name[-1] }}"
           become: true
           failed_when: "growpart.rc != 0 and 'NOCHANGE' not in growpart.stdout"

--- a/releasenotes/notes/fix-growroot-playbook-6a8ee02d7c0fbcb3.yaml
+++ b/releasenotes/notes/fix-growroot-playbook-6a8ee02d7c0fbcb3.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixes an issue with the growroot playbook where disks such as 'sdp' would
+    become 'sd' due to the removal of the trailing 'p' when dealing with nvme
+    devices.


### PR DESCRIPTION
Fixes an issue with the growroot playbook where disks such as 'sdp' would become 'sd' due to the removal of the trailing 'p' when dealing with nvme devices.