### PR TITLE
Xena: Bump nova images

### DIFF
--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -28,6 +28,7 @@ prometheus_node_exporter_tag: xena-20230315T164024
 
 glance_tls_proxy_tag: "{% raw %}{{ haproxy_tag | default(openstack_tag) }}{% endraw %}"
 neutron_tls_proxy_tag: "{% raw %}{{ haproxy_tag | default(openstack_tag) }}{% endraw %}"
+nova_tag: xena-20231110T095551
 
 om_enable_rabbitmq_high_availability: true
 

--- a/releasenotes/notes/fix-libvirt-mdev-issue-55b3f501a436c3be.yaml
+++ b/releasenotes/notes/fix-libvirt-mdev-issue-55b3f501a436c3be.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes an `issue where Nova failed to parse the mdev device format
+    <https://bugs.launchpad.net/nova/+bug/1951656>`__.


### PR DESCRIPTION
Nova hasn't been rebuilt since:

https://github.com/stackhpc/stackhpc-kayobe-config/commit/1cfefbd1a12f18c414546f957b9afb43fb1aa18d

So this switches back to the upstream code.