### PR TITLE
Check if repos backup exists in kolla footer

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -353,17 +353,17 @@ kolla_build_blocks:
     {% if kolla_base_distro in ['centos', 'rocky'] %}
     RUN \
         if [ -f /etc/yum.repos.d.backup/repos.tar.gz ]; then \
-          tar -xzf /etc/yum.repos.d.backup/repos.tar.gz -C /etc/yum.repos.d
-          rm -rf /etc/yum.repos.d.backup/
+          tar -xzf /etc/yum.repos.d.backup/repos.tar.gz -C /etc/yum.repos.d && \
+          rm -rf /etc/yum.repos.d.backup/ \
         fi && \
         if grep -r '{{ stackhpc_repo_mirror_url }}' /etc/yum.repos.d; then \
           echo "Found repository mirror in Yum repositories"; \
           exit 1; \
-        fi && \
+        fi
     {% else %}
     RUN \
         if [ -f /etc/apt/sources.list.backup ]; then \
-          mv /etc/apt/sources.list.backup /etc/apt/sources.list
+          mv /etc/apt/sources.list.backup /etc/apt/sources.list \
         fi && \
         if grep -r '{{ stackhpc_repo_mirror_url }}' /etc/apt/sources.list; then \
           echo "Found repository mirror in APT repositories"; \

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -352,18 +352,22 @@ kolla_build_blocks:
     {% if stackhpc_kolla_clean_up_repo_mirrors | bool %}
     {% if kolla_base_distro in ['centos', 'rocky'] %}
     RUN \
-        tar -xzf /etc/yum.repos.d.backup/repos.tar.gz -C /etc/yum.repos.d && \
-        if grep -r '{{ stackhpc_repo_mirror_url }}' /etc/yum.repos.d; then \
-           echo "Found repository mirror in Yum repositories"; \
-           exit 1; \
-        fi && \
-        rm -rf /etc/yum.repos.d.backup/
+        if [ -f /etc/yum.repos.d.backup/repos.tar.gz ]; then \
+          tar -xzf /etc/yum.repos.d.backup/repos.tar.gz -C /etc/yum.repos.d && \
+          if grep -r '{{ stackhpc_repo_mirror_url }}' /etc/yum.repos.d; then \
+            echo "Found repository mirror in Yum repositories"; \
+            exit 1; \
+          fi && \
+          rm -rf /etc/yum.repos.d.backup/
+        fi
     {% else %}
     RUN \
-        mv /etc/apt/sources.list.backup /etc/apt/sources.list && \
-        if grep -r '{{ stackhpc_repo_mirror_url }}' /etc/apt/sources.list; then \
-           echo "Found repository mirror in APT repositories"; \
-           exit 1; \
+        if [ -f /etc/apt/sources.list.backup ]; then \
+          mv /etc/apt/sources.list.backup /etc/apt/sources.list && \
+          if grep -r '{{ stackhpc_repo_mirror_url }}' /etc/apt/sources.list; then \
+            echo "Found repository mirror in APT repositories"; \
+            exit 1; \
+          fi
         fi
     {% endif %}
     {% endif %}

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -353,21 +353,21 @@ kolla_build_blocks:
     {% if kolla_base_distro in ['centos', 'rocky'] %}
     RUN \
         if [ -f /etc/yum.repos.d.backup/repos.tar.gz ]; then \
-          tar -xzf /etc/yum.repos.d.backup/repos.tar.gz -C /etc/yum.repos.d && \
-          if grep -r '{{ stackhpc_repo_mirror_url }}' /etc/yum.repos.d; then \
-            echo "Found repository mirror in Yum repositories"; \
-            exit 1; \
-          fi && \
+          tar -xzf /etc/yum.repos.d.backup/repos.tar.gz -C /etc/yum.repos.d
           rm -rf /etc/yum.repos.d.backup/
-        fi
+        fi && \
+        if grep -r '{{ stackhpc_repo_mirror_url }}' /etc/yum.repos.d; then \
+          echo "Found repository mirror in Yum repositories"; \
+          exit 1; \
+        fi && \
     {% else %}
     RUN \
         if [ -f /etc/apt/sources.list.backup ]; then \
-          mv /etc/apt/sources.list.backup /etc/apt/sources.list && \
-          if grep -r '{{ stackhpc_repo_mirror_url }}' /etc/apt/sources.list; then \
-            echo "Found repository mirror in APT repositories"; \
-            exit 1; \
-          fi
+          mv /etc/apt/sources.list.backup /etc/apt/sources.list
+        fi && \
+        if grep -r '{{ stackhpc_repo_mirror_url }}' /etc/apt/sources.list; then \
+          echo "Found repository mirror in APT repositories"; \
+          exit 1; \
         fi
     {% endif %}
     {% endif %}

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -354,7 +354,7 @@ kolla_build_blocks:
     RUN \
         if [ -f /etc/yum.repos.d.backup/repos.tar.gz ]; then \
           tar -xzf /etc/yum.repos.d.backup/repos.tar.gz -C /etc/yum.repos.d && \
-          rm -rf /etc/yum.repos.d.backup/ \
+          rm -rf /etc/yum.repos.d.backup/; \
         fi && \
         if grep -r '{{ stackhpc_repo_mirror_url }}' /etc/yum.repos.d; then \
           echo "Found repository mirror in Yum repositories"; \
@@ -363,7 +363,7 @@ kolla_build_blocks:
     {% else %}
     RUN \
         if [ -f /etc/apt/sources.list.backup ]; then \
-          mv /etc/apt/sources.list.backup /etc/apt/sources.list \
+          mv /etc/apt/sources.list.backup /etc/apt/sources.list; \
         fi && \
         if grep -r '{{ stackhpc_repo_mirror_url }}' /etc/apt/sources.list; then \
           echo "Found repository mirror in APT repositories"; \


### PR DESCRIPTION
When a child service is build, such as neutron-infoblox-ipam-agent being a child of neutron-server, the fotoer is ran twice.

This means it fails as the repo backup has already been moved.