### PR TITLE
Restore flavor_id on openstack_nova_server_status metrics

### DIFF
--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -48,3 +48,8 @@ prometheus_ceph_mgr_exporter_endpoints:
 
 # Use inventory hostnames as labels
 prometheus_instance_label: "{% raw %}{{ ansible_facts.hostname }}{% endraw %}"
+
+# Make openstack-exporter use Nova API version 2.1 to keep metrics the same as
+# in Yoga. This is required to include a valid value for the flavor_id label on
+# openstack_nova_server_status metrics.
+prometheus_openstack_exporter_compute_api_version: "2.1"

--- a/releasenotes/notes/openstack-exporter-nova-api-fa5c2a9663bc97e2.yaml
+++ b/releasenotes/notes/openstack-exporter-nova-api-fa5c2a9663bc97e2.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Restores valid value for the ``flavor_id`` label on
+    ``openstack_nova_server_status`` Prometheus metrics.


### PR DESCRIPTION
The openstack-exporter version used in Zed started to use the latest
Nova API microversion, which produces an invalid flavor_id label on
openstack_nova_server_status metrics.

Force the use of the 2.1 API until we upgrade to a version of
openstack-exporter that can handle the latest API microversion.
