### PR TITLE
Rocky9: Add section on routing rules

### DIFF
--- a/doc/source/operations/rocky-linux-9.rst
+++ b/doc/source/operations/rocky-linux-9.rst
@@ -82,6 +82,30 @@ Make the following changes to your Kayobe configuration:
   This change does not need to be applied before migrating to Rocky Linux 9, but it should cause no harm to do so.
   Note that this will not affect existing VMs, only newly created VMs.
 
+Routing rules
+-------------
+
+Routing rules referencing tables by name may need adapting to be compatible with NetworkManager
+e.g:
+
+  .. code-block:: yaml
+
+      undercloud_prov_rules:
+        - from {{ internal_net_name | net_cidr }} table ironic-api
+
+will need to be updated to use numeric IDs:
+
+  .. code-block:: yaml
+
+      undercloud_prov_rules:
+        - from {{ internal_net_name | net_cidr }} table 1
+
+The error from NetworkManager was:
+
+  .. code-block:: shell
+
+      [1697192659.9611] keyfile: ipv4.routing-rules: invalid value for "routing-rule1": invalid value for "table"
+
 Prerequisites
 =============
 


### PR DESCRIPTION
Unsure if this is version specific as I asked on Slack and @cityofships said he didn't see similar issues on SMS

```
Last metadata expiration check: 21:25:18 ago on Thu Oct 12 14:41:23 2023.
Installed Packages
Name         : NetworkManager
Epoch        : 1
Version      : 1.42.2
Release      : 8.el9_2
Architecture : x86_64
Size         : 6.0 M
Source       : NetworkManager-1.42.2-8.el9_2.src.rpm
Repository   : @System
From repo    : baseos
Summary      : Network connection manager and user applications
URL          : https://networkmanager.dev/
License      : GPLv2+ and LGPLv2+
Description  : NetworkManager is a system service that manages network interfaces and
             : connections based on user or automatic configuration. It supports
             : Ethernet, Bridge, Bond, VLAN, Team, InfiniBand, Wi-Fi, mobile broadband
             : (WWAN), PPPoE and other devices, and supports a variety of different VPN
             : services.
```