### PR TITLE
yoga host image selinux

### DIFF
--- a/etc/kayobe/ansible/pulp-host-image-promote.yml
+++ b/etc/kayobe/ansible/pulp-host-image-promote.yml
@@ -19,6 +19,9 @@
         name: "{{ repository_name }}_{{ promotion_tag }}"
         base_path: "{{ base_path }}/{{ promotion_tag }}"
       register: distribution_details
+      until: distribution_details is success
+      retries: 3
+      delay: 1
 
     - name: Fail if the image does not exist
       fail:
@@ -34,6 +37,10 @@
         base_path: "{{ base_path }}/{{ promotion_tag }}"
         content_guard: release
         state: present
+      register: content_guard_result
+      until: content_guard_result is success
+      retries: 3
+      delay: 1
 
     - name: Print version tag and os
       debug:

--- a/etc/kayobe/ansible/pulp-host-image-upload.yml
+++ b/etc/kayobe/ansible/pulp-host-image-upload.yml
@@ -25,6 +25,10 @@
         password: "{{ remote_pulp_password }}"
         file: "{{ found_files.files[0].path }}"
         state: present
+      register: upload_result
+      until: upload_result is success
+      retries: 3
+      delay: 1
 
     - name: Get sha256 hash
       ansible.builtin.stat:
@@ -40,6 +44,10 @@
         sha256: "{{ file_stats.stat.checksum }}"
         relative_path: "{{ found_files.files[0].path | basename }}"
         state: present
+      register: file_content_result
+      until: file_content_result is success
+      retries: 3
+      delay: 1
 
     - name: Ensure file repo exists
       pulp.squeezer.file_repository:
@@ -48,6 +56,10 @@
         password: "{{ remote_pulp_password }}"
         name: "{{ repository_name }}"
         state: present
+      register: file_repo_result
+      until: file_repo_result is success
+      retries: 3
+      delay: 1
 
     - name: Add content to file repo
       pulp.squeezer.file_repository_content:
@@ -58,6 +70,10 @@
         present_content:
           - relative_path: "{{ found_files.files[0].path | basename }}"
             sha256: "{{ file_stats.stat.checksum }}"
+      register: file_repo_content_result
+      until: file_repo_content_result is success
+      retries: 3
+      delay: 1
 
     - name: Create a new publication to point to this version
       pulp.squeezer.file_publication:
@@ -67,6 +83,9 @@
         repository: "{{ repository_name }}"
         state: present
       register: publication_details
+      until: publication_details is success
+      retries: 3
+      delay: 1
 
     - name: Update distribution for latest version
       pulp.squeezer.file_distribution:
@@ -79,6 +98,9 @@
         content_guard: development
         state: present
       register: latest_distribution_details
+      until: latest_distribution_details is success
+      retries: 3
+      delay: 1
 
     - name: Create distribution for given version
       pulp.squeezer.file_distribution:
@@ -91,6 +113,10 @@
         content_guard: development
         state: present
       when: latest_distribution_details.changed
+      register: distribution_result
+      until: distribution_result is success
+      retries: 3
+      delay: 1
 
     - name: Update new images file with versioned path
       lineinfile:

--- a/etc/kayobe/overcloud-dib.yml
+++ b/etc/kayobe/overcloud-dib.yml
@@ -71,7 +71,7 @@ overcloud_dib_host_packages_extra:
 overcloud_dib_git_elements_extra:
   - repo: "https://github.com/stackhpc/stackhpc-image-elements"
     local: "{{ source_checkout_path }}/stackhpc-image-elements"
-    version: "v1.6.0"
+    version: "rocky_container_pulp"
     elements_path: "elements"
 
 # List of git repositories containing Diskimage Builder (DIB) elements. See

--- a/etc/kayobe/stackhpc-overcloud-dib.yml
+++ b/etc/kayobe/stackhpc-overcloud-dib.yml
@@ -58,10 +58,10 @@ stackhpc_overcloud_dib_env_vars:
   # On Rocky Linux 9, use the host's repo files.
   # These will have been configured to point to Test Pulp repo snapshots during the 'host configure' step.
   # FIXME: This assumes we are building on RL9, which may not be the case.
-  DIB_YUM_MINIMAL_BOOTSTRAP_REPOS: "{% if os_distribution == 'rocky' and os_release == '9' %}/etc/yum.repos.d/{% endif %}"
   YUM: dnf
   # Workaround for stack user home ownership bug
   DIB_IMAGE_CACHE: "/tmp/yum"
+  DIB_CONTAINERFILE_BUILDOPTS: "--add-host pulp-server.internal.sms-cloud:10.205.3.187 --build-arg ROCKY_USE_MIRROR=true --build-arg ROCKY_APPSTREAM_URL={{ stackhpc_repo_rocky_9_appstream_url }} --build-arg ROCKY_BASEOS_URL={{ stackhpc_repo_rocky_9_baseos_url }} --build-arg ROCKY_CRB_URL={{ stackhpc_repo_rocky_9_crb_url }}"
 
 # StackHPC overcloud DIB image packages.
 stackhpc_overcloud_dib_packages:

--- a/etc/kayobe/stackhpc-overcloud-dib.yml
+++ b/etc/kayobe/stackhpc-overcloud-dib.yml
@@ -55,7 +55,10 @@ stackhpc_overcloud_dib_env_vars:
   # Avoid DNS queries during sudo commands, since we might not always have working DNS.
   DIB_SUDOERS_CONFIG: |
     Defaults  !fqdn
-  DIB_YUM_MINIMAL_BOOTSTRAP_REPOS: /etc/yum.repos.d/
+  # On Rocky Linux 9, use the host's repo files.
+  # These will have been configured to point to Test Pulp repo snapshots during the 'host configure' step.
+  # FIXME: This assumes we are building on RL9, which may not be the case.
+  DIB_YUM_MINIMAL_BOOTSTRAP_REPOS: "{% if os_distribution == 'rocky' and os_release == '9' %}/etc/yum.repos.d/{% endif %}"
   YUM: dnf
   # Workaround for stack user home ownership bug
   DIB_IMAGE_CACHE: "/tmp/yum"

--- a/etc/kayobe/stackhpc-overcloud-dib.yml
+++ b/etc/kayobe/stackhpc-overcloud-dib.yml
@@ -23,7 +23,7 @@ stackhpc_overcloud_dib_name: "deployment_image"
 stackhpc_overcloud_dib_elements:
   - "{{ os_distribution }}-{% if os_distribution == 'rocky' %}container-stackhpc{% else %}minimal{% endif %}"
   - "cloud-init-datasources"
-  - "{% if os_distribution in ['centos', 'rocky'] %}disable-selinux{% endif %}"
+  - "{% if os_distribution == 'rocky' and os_release == '9' %}selinux-permissive{% elif os_distribution in ['centos', 'rocky'] %}disable-selinux{% endif %}"
   - "enable-serial-console"
   - "{% if kayobe_environment == 'ci-builder' %}etc-hosts{% endif %}"
   - "vm"
@@ -55,8 +55,7 @@ stackhpc_overcloud_dib_env_vars:
   # Avoid DNS queries during sudo commands, since we might not always have working DNS.
   DIB_SUDOERS_CONFIG: |
     Defaults  !fqdn
-  # FIXME: Support templating repo files.
-  # DIB_YUM_MINIMAL_BOOTSTRAP_REPOS: /path/to/dir/containing/dib-mirror-*.repo
+  DIB_YUM_MINIMAL_BOOTSTRAP_REPOS: /etc/yum.repos.d/
   YUM: dnf
   # Workaround for stack user home ownership bug
   DIB_IMAGE_CACHE: "/tmp/yum"


### PR DESCRIPTION
- RL9: Set SELinux to permissive mode in the standard overcloud host image
- RL9: Use Pulp repo snapshots when building overcloud host image
