### PR TITLE
Fixes various issues with the cis.yml playbook

### DIFF
--- a/doc/source/configuration/security-hardening.rst
+++ b/doc/source/configuration/security-hardening.rst
@@ -33,6 +33,16 @@ about what each variable does. The documentation can be found here:
 Running the playbooks
 ---------------------
 
+.. note:
+
+  On CentOS 8, you must run with `INJECT_FACT_AS_VARS <https://docs.ansible.com/ansible/latest/reference_appendices/config.html#inject-facts-as-vars>`__
+  enabled. To do this you for this playbook only, you can use:
+
+  .. code-block: shell
+
+    ANSIBLE_INJECT_FACT_VARS=true kayobe playbook run $KAYOBE_CONFIG_PATH/ansible/cis.yml
+
+
 As there is potential for unintended side effects when applying the hardening
 playbooks, the playbooks are not currently enabled by default. It is recommended
 that they are first applied to a representative staging environment to determine

--- a/doc/source/configuration/security-hardening.rst
+++ b/doc/source/configuration/security-hardening.rst
@@ -36,7 +36,7 @@ Running the playbooks
 .. note:
 
   On CentOS 8, you must run with `INJECT_FACT_AS_VARS <https://docs.ansible.com/ansible/latest/reference_appendices/config.html#inject-facts-as-vars>`__
-  enabled. To do this you for this playbook only, you can use:
+  enabled. To do this for this playbook only, you can use:
 
   .. code-block: shell
 

--- a/etc/kayobe/ansible/requirements.yml
+++ b/etc/kayobe/ansible/requirements.yml
@@ -16,15 +16,15 @@ roles:
     src: https://github.com/ansible-lockdown/RHEL8-CIS
     version: 1.3.0
   - name: ansible-lockdown.ubuntu22_cis
-    src: https://github.com/ansible-lockdown//UBUNTU22-CIS
-    #FIXME: Waiting for https://github.com/ansible-lockdown/UBUNTU22-CIS/pull/132
+    src: https://github.com/stackhpc/UBUNTU22-CIS
+    #FIXME: https://github.com/ansible-lockdown/UBUNTU22-CIS/pull/174
     # to be in a tagged release
-    version: c91a1038fd218f727075d21b2d0880751322b162
+    version: bugfix/inject-facts
   - name: ansible-lockdown.rhel9_cis
-    src: https://github.com/ansible-lockdown/RHEL9-CIS
-    #FIXME: Waiting for https://github.com/ansible-lockdown/RHEL9-CIS/pull/54
+    src: https://github.com/stackhpc/RHEL9-CIS
+    #FIXME: Waiting for https://github.com/ansible-lockdown/RHEL9-CIS/pull/115
     # to be in a tagged release.
-    version: 3525cb6aab12a3d1e34aa8432ed77dd76be6a44a
+    version: bugfix/inject-facts
   - name: wazuh-ansible
     src: https://github.com/stackhpc/wazuh-ansible
     version: stackhpc

--- a/etc/kayobe/ansible/requirements.yml
+++ b/etc/kayobe/ansible/requirements.yml
@@ -17,7 +17,7 @@ roles:
     version: 1.3.0
   - name: ansible-lockdown.ubuntu22_cis
     src: https://github.com/stackhpc/UBUNTU22-CIS
-    #FIXME: https://github.com/ansible-lockdown/UBUNTU22-CIS/pull/174
+    #FIXME: Waiting for https://github.com/ansible-lockdown/UBUNTU22-CIS/pull/174
     # to be in a tagged release
     version: bugfix/inject-facts
   - name: ansible-lockdown.rhel9_cis

--- a/etc/kayobe/inventory/group_vars/overcloud/cis
+++ b/etc/kayobe/inventory/group_vars/overcloud/cis
@@ -71,6 +71,10 @@ rhel9cis_auditd:
 # Max size of audit logs (MB)
 rhel9cis_max_log_file_size: 1024
 
+# Disable setting of boatloader password. This requires setting the variable
+# `rhel9cis_bootloader_password_hash`
+rhel9cis_set_boot_pass: false
+
 ##############################################################################
 # Ubuntu Jammy CIS Hardening Configuration
 
@@ -106,27 +110,35 @@ ubtu22cis_rule_5_3_4: false
 ubtu22cis_sshd:
   log_level: "INFO"
   max_auth_tries: 4
-  ciphers: "chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr"
-  macs: "hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-256"
-  kex_algorithms: "curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group14-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256"
+  ciphers:
+      - chacha20-poly1305@openssh.com
+      - aes256-gcm@openssh.com
+      - aes128-gcm@openssh.com
+      - aes256-ctr
+      - aes192-ctr
+      - aes128-ctr
+  macs:
+      - hmac-sha2-512-etm@openssh.com
+      - hmac-sha2-256-etm@openssh.com
+      - hmac-sha2-512
+      - hmac-sha2-256
+  kex_algorithms:
+      - curve25519-sha256
+      - curve25519-sha256@libssh.org
+      - diffie-hellman-group14-sha256
+      - diffie-hellman-group16-sha512
+      - diffie-hellman-group18-sha512
+      - ecdh-sha2-nistp521
+      - ecdh-sha2-nistp384
+      - ecdh-sha2-nistp256
+      - diffie-hellman-group-exchange-sha256
   client_alive_interval: 300
   client_alive_count_max: 3
   login_grace_time: 60
-  max_sessions: 10
+  max_sessions: 8
   allow_users: "kolla stack ubuntu"
   allow_groups: "kolla stack ubuntu"
-  # This variable, if specified, configures a list of USER name patterns, separated by spaces, to prevent SSH access
-  # for users whose user name matches one of the patterns. This is done
-  # by setting the value of `DenyUsers` option in `/etc/ssh/sshd_config` file.
-  # If an USER@HOST format will be used, the specified user will be restricted only on that particular host.
-  # The allow/deny directives process order: DenyUsers, AllowUsers, DenyGroups, AllowGroups.
-  # For more info, see https://linux.die.net/man/5/sshd_config
   deny_users: ""
-  # This variable, if specified, configures a list of GROUP name patterns, separated by spaces, to prevent SSH access
-  # for users whose primary group or supplementary group list matches one of the patterns. This is done
-  # by setting the value of `DenyGroups` option in `/etc/ssh/sshd_config` file.
-  # The allow/deny directives process order: DenyUsers, AllowUsers, DenyGroups, AllowGroups.
-  # For more info, see https://linux.die.net/man/5/sshd_config
   deny_groups: ""
 
 # Do not change /var/lib/docker permissions

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 kayobe@git+https://github.com/stackhpc/kayobe@stackhpc/yoga
 ansible-modules-hashivault@git+https://github.com/stackhpc/ansible-modules-hashivault@stackhpc;python_version < "3.8"
 ansible-modules-hashivault;python_version >= "3.8"
+jmespath


### PR DESCRIPTION
Apologies, turns out I should have tested the role bump more thoroughly.

- Format of variable changed: https://github.com/ansible-lockdown/UBUNTU22-CIS/commit/f335da9c707fffea85559881b64931d912f99557
- Regression in support for inject_facts_as_vars=False
- Bootloader password was being set to default value. 