### PR TITLE
Configure SELinux in permissive mode on RL9 hosts

### DIFF
--- a/etc/kayobe/inventory/group_vars/all/selinux
+++ b/etc/kayobe/inventory/group_vars/all/selinux
@@ -1,0 +1,9 @@
+---
+# Configure SELinux in permissive mode when configuring a Rocky Linux 9 host.
+selinux_state: "{{ 'permissive' if ansible_facts.os_family == 'RedHat' and ansible_facts.distribution_major_version == '9' else 'disabled' }}"
+
+# Do NOT reboot Rocky Linux 9 hosts to apply SELinux config changes. Operators
+# must opt-in by changing this variable when applying host configuration. This
+# is to avoid automatically rebooting hosts originally deployed with SELinux
+# disabled and which now need to be changed to permissive.
+disable_selinux_do_reboot: "{{ not (ansible_facts.os_family == 'RedHat' and ansible_facts.distribution_major_version == '9') }}"

--- a/releasenotes/notes/selinux-permissive-bb953d2cdcd7a545.yaml
+++ b/releasenotes/notes/selinux-permissive-bb953d2cdcd7a545.yaml
@@ -1,0 +1,7 @@
+---
+upgrade:
+  - |
+    SELinux mode is now set to permissive when configuring Rocky Linux 9 hosts,
+    to match the default mode in the Zed release. If SELinux is disabled on
+    these hosts, a reboot is required and will only be performed by Ansible if
+    ``disable_selinux_do_reboot`` is changed to ``true``.


### PR DESCRIPTION
This makes the host match the target configuration in Zed and avoids a
later reboot to change the SELinux mode.

Hosts that have SELinux disabled are rebooted only if
disable_selinux_do_reboot is changed to true.
