### PR TITLE
Add more services to the rabbitmq-reset playbook

### DIFF
--- a/etc/kayobe/ansible/rabbitmq-reset.yml
+++ b/etc/kayobe/ansible/rabbitmq-reset.yml
@@ -1,6 +1,6 @@
 ---
 # Reset a broken RabbitMQ cluster.
-# Also restarts OpenStack services which may be broken.
+# Also restarts all OpenStack services using RabbitMQ.
 
 - name: Reset RabbitMQ
   hosts: controllers
@@ -66,7 +66,7 @@
   tags:
     - restart-openstack
   tasks:
-    # The following services can have problems if the cluster gets broken.
+    # The following services use RabbitMQ.
     - name: Restart OpenStack services
       shell: >-
-        docker ps -a | egrep '(cinder|heat|ironic|keystone|magnum|neutron|nova)' | awk '{ print $NF }' | xargs docker restart
+        docker ps -a | egrep '(barbican|blazar|cinder|cloudkitty|designate|heat|ironic|keystone|magnum|manila|neutron|nova|octavia)' | awk '{ print $NF }' | xargs docker restart


### PR DESCRIPTION
This change adds services that we often deploy: Barbican, Blazar, CloudKitty, Designate, Manila and Octavia.