### PR TITLE
feat: add pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+  - repo: https://github.com/sirwart/ripsecrets
+    rev: v0.1.7
+    hooks:
+      - id: ripsecrets

--- a/doc/source/contributor/index.rst
+++ b/doc/source/contributor/index.rst
@@ -11,3 +11,4 @@ This guide is for contributors of the StackHPC Kayobe configuration project.
    release-notes
    environments/index
    package-updates
+   pre-commit

--- a/doc/source/contributor/pre-commit.rst
+++ b/doc/source/contributor/pre-commit.rst
@@ -1,0 +1,38 @@
+================
+Pre-commit Hooks
+================
+
+StackHPC Kayobe configuration carries support for
+`pre-commit hooks <https://pre-commit.com/>`_ which simplify the use of git
+hooks enabling the identification and repairing of broken or poor code
+before committing.
+These hooks are designed to make working within SKC easier and less error prone.
+
+Currently the following hooks are provided:
+
+- ``check-yaml``: perform basic yaml syntax linting
+- ``end-of-file-fixer``: identify and automatically fix missing newline
+- ``trailing-whitespace``: identify and automatically fix excessive white space
+- ``ripsecrets``: identify and prevent secrets from being committed to the branch
+
+.. warning::
+   The hook ``ripsecrets`` is capable of preventing the accidental leaking of secrets
+   such as those found within `secrets.yml` or `passwords.yml`.
+   However if the secret is contained within a file on it's own and lacks a certain level
+   of entropy then the secret will not be identified as such as and maybe leaked as a result.
+
+Installation of `pre-commit` hooks is handled via the `install-pre-commit-hooks` playbook
+found within the Ansible directory.
+Either use `kayobe playbook run` or add the playbook as a hook within Kayobe config such as
+within `control-host-bootstrap/post.d`.
+Once done you should find `pre-commit` is available within the `kayobe` virtualenv.
+
+All that remains is the installation of the hooks themselves which can be accomplished either by
+running `pre-commit run` or using `git commit` when you have changes that need to be committed.
+This will trigger a brief installation process of the hooks which may take a few minutes.
+This a one time process and will not be required again unless new hooks are added or existing ones are updated.
+
+.. note::
+   Currently if you run ``pre-commit run --all-files`` it will make a series of changes to
+   release notes that lack new lines as well configuration files that ``check-yaml`` does not
+   approve of.

--- a/doc/source/contributor/pre-commit.rst
+++ b/doc/source/contributor/pre-commit.rst
@@ -23,9 +23,18 @@ Currently the following hooks are provided:
 
 Installation of `pre-commit` hooks is handled via the `install-pre-commit-hooks` playbook
 found within the Ansible directory.
-Either use `kayobe playbook run` or add the playbook as a hook within Kayobe config such as
+Either run the playbook manually or add the playbook as a hook within Kayobe config such as
 within `control-host-bootstrap/post.d`.
 Once done you should find `pre-commit` is available within the `kayobe` virtualenv.
+
+To run the playbook using the following command
+
+- ``kayobe playbook run ${KAYOBE_CONFIG_PATH}/ansible/install-pre-commit-hooks.yml``
+
+Whereas to run the playbook when control host bootstrap runs ensure it registered as symlink using the following command
+
+- ``mkdir -p ${KAYOBE_CONFIG_PATH}/hooks/control-host-bootstrap/post.d``
+- ``ln -s ${KAYOBE_CONFIG_PATH}/ansible/install-pre-commit-hooks.yml ${KAYOBE_CONFIG_PATH}/hooks/control-host-bootstrap/post.d/install-pre-commit-hooks.yml``
 
 All that remains is the installation of the hooks themselves which can be accomplished either by
 running `pre-commit run` or using `git commit` when you have changes that need to be committed.

--- a/etc/kayobe/ansible/install-pre-commit-hooks.yml
+++ b/etc/kayobe/ansible/install-pre-commit-hooks.yml
@@ -2,13 +2,15 @@
 - name: Install pre-commit hooks
   hosts: localhost
   gather_facts: false
+  vars:
+    pre_commit_version: 3.5.0
   tasks:
     - name: Install pre-commit hooks
       block:
         - name: Install pre-commit hooks into kayobe virtual env
           ansible.builtin.pip:
             name: pre-commit
-            version: 3.5.0
+            version: "{{ pre_commit_version  }}"
             virtualenv: "{{ lookup('ansible.builtin.env', 'VIRTUAL_ENV') }}"
           register: pip_install
 

--- a/etc/kayobe/ansible/install-pre-commit-hooks.yml
+++ b/etc/kayobe/ansible/install-pre-commit-hooks.yml
@@ -19,4 +19,3 @@
             creates: "{{ lookup('ansible.builtin.env', 'KAYOBE_CONFIG_PATH') }}/../../.git/hooks/pre-commit"
           args:
             chdir: "{{ lookup('ansible.builtin.env', 'KAYOBE_CONFIG_PATH') }}"
-      when: enable_pre_commit_hooks | default(false)

--- a/etc/kayobe/ansible/install-pre-commit-hooks.yml
+++ b/etc/kayobe/ansible/install-pre-commit-hooks.yml
@@ -10,10 +10,11 @@
             name: pre-commit
             version: 3.5.0
             virtualenv: "{{ lookup('ansible.builtin.env', 'VIRTUAL_ENV') }}"
+          register: pip_install
 
         - name: Register pre-commit hooks with git
           ansible.builtin.command:
             cmd: "{{ lookup('ansible.builtin.env', 'VIRTUAL_ENV') }}/bin/pre-commit install"
-            creates: "{{ lookup('ansible.builtin.env', 'KAYOBE_CONFIG_PATH') }}/../../.git/hooks/pre-commit"
           args:
             chdir: "{{ lookup('ansible.builtin.env', 'KAYOBE_CONFIG_PATH') }}"
+          when: pip_install is changed

--- a/etc/kayobe/ansible/install-pre-commit-hooks.yml
+++ b/etc/kayobe/ansible/install-pre-commit-hooks.yml
@@ -11,12 +11,11 @@
           ansible.builtin.pip:
             name: pre-commit
             version: "{{ pre_commit_version  }}"
-            virtualenv: "{{ lookup('ansible.builtin.env', 'VIRTUAL_ENV') }}"
+            virtualenv: "{{ lookup('ansible.builtin.env', 'VIRTUAL_ENV') | default(omit, true) }}"
           register: pip_install
 
         - name: Register pre-commit hooks with git
           ansible.builtin.command:
-            cmd: "{{ lookup('ansible.builtin.env', 'VIRTUAL_ENV') }}/bin/pre-commit install"
+            cmd: "{{ lookup('ansible.builtin.env', 'VIRTUAL_ENV') | default(lookup('ansible.builtin.env', 'HOME') ~ '/.local', true) }}/bin/pre-commit install"
           args:
-            chdir: "{{ lookup('ansible.builtin.env', 'KAYOBE_CONFIG_PATH') }}"
-          when: pip_install is changed
+            chdir: "{{ playbook_dir | dirname | dirname | dirname }}"

--- a/etc/kayobe/ansible/install-pre-commit-hooks.yml
+++ b/etc/kayobe/ansible/install-pre-commit-hooks.yml
@@ -2,16 +2,21 @@
 - name: Install pre-commit hooks
   hosts: localhost
   gather_facts: false
+  vars:
+    enable_pre_commit_hooks: false
   tasks:
-    - name: Install pre-commit hooks into kayobe virtual env
-      ansible.builtin.pip:
-        name: pre-commit
-        version: 3.5.0
-        virtualenv: "{{ lookup('ansible.builtin.env', 'VIRTUAL_ENV') }}"
+    - name: Install pre-commit hooks
+      block:
+        - name: Install pre-commit hooks into kayobe virtual env
+          ansible.builtin.pip:
+            name: pre-commit
+            version: 3.5.0
+            virtualenv: "{{ lookup('ansible.builtin.env', 'VIRTUAL_ENV') }}"
 
-    - name: Register pre-commit hooks with git
-      ansible.builtin.command:
-        cmd: "{{ lookup('ansible.builtin.env', 'VIRTUAL_ENV') }}/bin/pre-commit install"
-        creates: "{{ lookup('ansible.builtin.env', 'KAYOBE_CONFIG_PATH') }}/../../.git/hooks/pre-commit"
-      args:
-        chdir: "{{ lookup('ansible.builtin.env', 'KAYOBE_CONFIG_PATH') }}"
+        - name: Register pre-commit hooks with git
+          ansible.builtin.command:
+            cmd: "{{ lookup('ansible.builtin.env', 'VIRTUAL_ENV') }}/bin/pre-commit install"
+            creates: "{{ lookup('ansible.builtin.env', 'KAYOBE_CONFIG_PATH') }}/../../.git/hooks/pre-commit"
+          args:
+            chdir: "{{ lookup('ansible.builtin.env', 'KAYOBE_CONFIG_PATH') }}"
+      when: enable_pre_commit_hooks | default(false)

--- a/etc/kayobe/ansible/install-pre-commit-hooks.yml
+++ b/etc/kayobe/ansible/install-pre-commit-hooks.yml
@@ -1,0 +1,11 @@
+---
+- name: Install pre-commit hooks
+  hosts: localhost
+  become: true
+  gather_facts: false
+  tasks:
+    - name: Install pre-commit hooks into kayobe virtual env
+      ansible.builtin.pip:
+        name: pre-commit
+        version: 3.5.0
+        virtualenv: "{{ lookup('ansible.builtin.env', 'VIRTUAL_ENV') }}"

--- a/etc/kayobe/ansible/install-pre-commit-hooks.yml
+++ b/etc/kayobe/ansible/install-pre-commit-hooks.yml
@@ -2,8 +2,6 @@
 - name: Install pre-commit hooks
   hosts: localhost
   gather_facts: false
-  vars:
-    enable_pre_commit_hooks: false
   tasks:
     - name: Install pre-commit hooks
       block:

--- a/etc/kayobe/ansible/install-pre-commit-hooks.yml
+++ b/etc/kayobe/ansible/install-pre-commit-hooks.yml
@@ -1,7 +1,6 @@
 ---
 - name: Install pre-commit hooks
   hosts: localhost
-  become: true
   gather_facts: false
   tasks:
     - name: Install pre-commit hooks into kayobe virtual env
@@ -9,3 +8,10 @@
         name: pre-commit
         version: 3.5.0
         virtualenv: "{{ lookup('ansible.builtin.env', 'VIRTUAL_ENV') }}"
+
+    - name: Register pre-commit hooks with git
+      ansible.builtin.command:
+        cmd: "{{ lookup('ansible.builtin.env', 'VIRTUAL_ENV') }}/bin/pre-commit install"
+        creates: "{{ lookup('ansible.builtin.env', 'KAYOBE_CONFIG_PATH') }}/../../.git/hooks/pre-commit"
+      args:
+        chdir: "{{ lookup('ansible.builtin.env', 'KAYOBE_CONFIG_PATH') }}"

--- a/etc/kayobe/hooks/control-host-bootstrap/post.d/50-install-pre-commit-hooks.yml
+++ b/etc/kayobe/hooks/control-host-bootstrap/post.d/50-install-pre-commit-hooks.yml
@@ -1,1 +1,0 @@
-../../../ansible/install-pre-commit-hooks.yml

--- a/etc/kayobe/hooks/control-host-bootstrap/post.d/50-install-pre-commit-hooks.yml
+++ b/etc/kayobe/hooks/control-host-bootstrap/post.d/50-install-pre-commit-hooks.yml
@@ -1,0 +1,1 @@
+../../../ansible/install-pre-commit-hooks.yml

--- a/releasenotes/notes/add-pre-commit-hooks-07ce3b82bbe1d7a3.yaml
+++ b/releasenotes/notes/add-pre-commit-hooks-07ce3b82bbe1d7a3.yaml
@@ -4,6 +4,5 @@ features:
     Add playbook to install pre-commit hooks and register them with git.
     The hooks currently configured to be installed will check yaml syntax,
     fix new line at end of file and remove excess whitespace. This is
-    currently opt-in and will require ``enable_pre_commit_hooks: true``
-    in the the install-pre-commit-hooks playbook.
-
+    currently opt-in which can be achieved by running `install-pre-commit-hooks`
+    playbook.

--- a/releasenotes/notes/add-pre-commit-hooks-07ce3b82bbe1d7a3.yaml
+++ b/releasenotes/notes/add-pre-commit-hooks-07ce3b82bbe1d7a3.yaml
@@ -1,0 +1,9 @@
+---
+features:
+  - |
+    Add playbook to install pre-commit hooks and register them with git.
+    The hooks currently configured to be installed will check yaml syntax,
+    fix new line at end of file and remove excess whitespace. This is
+    currently opt-in and will require ``enable_pre_commit_hooks: true``
+    in the the install-pre-commit-hooks playbook.
+


### PR DESCRIPTION
Add a simple playbook that can install [pre-commits](https://pre-commit.com/) and register a few simple hooks. This process is implemented as a hook that will run post control host bootstrap.

- check-yaml: perform basic yaml syntax linting
- end-of-file-fixer: identify and automatically fix missing newline
- trailing-whitespace: identify and automatically fix excessive white space
- ripsecrets: identify and prevent secrets from being committed to the branch

Note: this is currently configured as an opt-in feature and will only install and register hooks if `enable_pre_commit_hooks` is set to `true` in `install-pre-commit-hooks.yml`
