### PR TITLE
Use python3 -m venv for nova playbooks

### DIFF
--- a/etc/kayobe/ansible/nova-compute-disable.yml
+++ b/etc/kayobe/ansible/nova-compute-disable.yml
@@ -11,6 +11,7 @@
     - name: Set up openstack cli virtualenv
       pip:
         virtualenv: "{{ venv }}"
+        virtualenv_command: "/usr/bin/python3 -m venv"
         name:
           - python-openstackclient
         state: latest

--- a/etc/kayobe/ansible/nova-compute-drain.yml
+++ b/etc/kayobe/ansible/nova-compute-drain.yml
@@ -11,6 +11,7 @@
     - name: Set up openstack cli virtualenv
       pip:
         virtualenv: "{{ venv }}"
+        virtualenv_command: "/usr/bin/python3 -m venv"
         name:
           - python-openstackclient
         state: latest

--- a/etc/kayobe/ansible/nova-compute-enable.yml
+++ b/etc/kayobe/ansible/nova-compute-enable.yml
@@ -11,6 +11,7 @@
     - name: Set up openstack cli virtualenv
       pip:
         virtualenv: "{{ venv }}"
+        virtualenv_command: "/usr/bin/python3 -m venv"
         name:
           - python-openstackclient
         state: latest


### PR DESCRIPTION
Cotinues with our ongoing switch from virtualenv to python3 -m venv.