### PR TITLE
Fix cluster health in Grafana Elasticsearch dashboard

### DIFF
--- a/etc/kayobe/kolla/config/grafana/dashboards/openstack/elasticsearch.json
+++ b/etc/kayobe/kolla/config/grafana/dashboards/openstack/elasticsearch.json
@@ -148,7 +148,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "topk(1, elasticsearch_cluster_health_status{cluster=\"$cluster\",color=\"red\"}==1 or (elasticsearch_cluster_health_status{cluster=\"$cluster\",color=\"green\"}==1)+4 or (elasticsearch_cluster_health_status{cluster=\"$cluster\",color=\"yellow\"}==1)+22)",
+          "expr": "topk(1, elasticsearch_cluster_health_status{cluster=\"$cluster\",color=\"red\"}==1 or (elasticsearch_cluster_health_status{cluster=\"$cluster\",color=\"green\"}==1)+4 or (elasticsearch_cluster_health_status{cluster=\"$cluster\",color=\"yellow\"}==1)+2)",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 2,

--- a/releasenotes/notes/grafana-elasticsearch-cluster-health-154275e8d39dd89f.yaml
+++ b/releasenotes/notes/grafana-elasticsearch-cluster-health-154275e8d39dd89f.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes display of the Elasticsearch or OpenSearch cluster health in Grafana
+    when in yellow state.


### PR DESCRIPTION
When Elasticsearch/OpenSearch was in yellow state, the number 23 was
displayed instead of Yellow.
