### PR TITLE
Remove node-exporter override

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -352,9 +352,7 @@ kolla_build_customizations_ubuntu: {}
 kolla_build_customizations: "{{ kolla_build_customizations_common | combine(kolla_build_customizations_rocky if kolla_base_distro == 'rocky' else kolla_build_customizations_ubuntu) }}"
 
 # Dict mapping Kolla Dockerfile ARG names to their values.
-kolla_build_args:
-  node_exporter_version: "1.5.0" # kolla has 1.4.0
-  node_exporter_sha256sum: "af999fd31ab54ed3a34b9f0b10c28e9acee9ef5ac5a5d5edfdde85437db7acbb"
+kolla_build_args: {}
 
 ###############################################################################
 # Kolla-ansible inventory configuration.


### PR DESCRIPTION
We are backporting a kolla change bumping node-exporter to 1.7.0 [1].

[1] https://github.com/stackhpc/kolla/pull/281