### PR TITLE
Set selinux policy to permissive

### DIFF
--- a/etc/kayobe/stackhpc-overcloud-dib.yml
+++ b/etc/kayobe/stackhpc-overcloud-dib.yml
@@ -23,7 +23,7 @@ stackhpc_overcloud_dib_name: "deployment_image"
 stackhpc_overcloud_dib_elements:
   - "{{ os_distribution }}-{% if os_distribution == 'rocky' %}container-stackhpc{% else %}minimal{% endif %}"
   - "cloud-init-datasources"
-  - "{% if os_distribution in ['centos', 'rocky'] %}disable-selinux{% endif %}"
+  - "{% if os_distribution in ['centos', 'rocky'] %}selinux-permissive{% endif %}"
   - "enable-serial-console"
   - "{% if kayobe_environment == 'ci-builder' %}etc-hosts{% endif %}"
   - "vm"


### PR DESCRIPTION
This will avoid the need for a reboot:

```
TASK [selinux : Ensure desired SELinux state] **********************************************************************************************************************[36/1977]
Wednesday 29 November 2023  12:45:39 +0100 (0:00:00.850)       0:01:15.944 ****                                                                                              
[WARNING]: Reboot is required to set SELinux state to 'permissive'
changed: [monitor1]                                                                   
                                                                                      
TASK [selinux : Abort SELinux configuration because reboot is disabled] *****************************************************************************************************
Wednesday 29 November 2023  12:45:41 +0100 (0:00:01.457)       0:01:17.401 **** 
fatal: [monitor1]: FAILED! => changed=false               
  msg: |-                                                                             
    SELinux state change requires a reboot, but selinux_do_reboot is false. Please run again with selinux_do_reboot set to true to reboot.

```