### PR TITLE
Add stop-openstack-services.yml playbook

### DIFF
--- a/etc/kayobe/ansible/stop-openstack-services.yml
+++ b/etc/kayobe/ansible/stop-openstack-services.yml
@@ -1,0 +1,29 @@
+---
+# Stops containers running OpenStack services
+
+- name: Stop OpenStack services
+  hosts: overcloud
+  become: true
+  gather_facts: false
+  vars:
+    - stop_service_list:
+        - "blazar"
+        - "barbican"
+        - "cinder"
+        - "cloudkitty"
+        - "designate"
+        - "glance"
+        - "heat"
+        - "horizon"
+        - "ironic"
+        - "keystone"
+        - "magnum"
+        - "manila"
+        - "neutron"
+        - "nova"
+        - "octavia"
+        - "placement"
+  tasks:
+    - name: Stop OpenStack services
+      shell: >-
+        docker ps -a | egrep '({{ stop_service_list | join('|') }})' | awk '{ print $NF }' | xargs docker stop

--- a/releasenotes/notes/stop-services-playbook-b85b53d1a7571009.yaml
+++ b/releasenotes/notes/stop-services-playbook-b85b53d1a7571009.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Added the ``stop-openstack-services.yml`` playbook, which can be used to
+    stop OpenStack services across the overcloud.


### PR DESCRIPTION
Adds a new playbook to stop openstack services across the overcloud.

I was undecided as to whether this warrants its own playbook but I've needed to use it enough times now that I think other people might want it.

One function I was considering was a variable to change the `docker stop` to a `docker restart` which we could then redirect to in the case of the `rabbitmq-reset.yml` playbook.