### PR TITLE
Add placement-api in the rabbitmq-playbook

### DIFF
--- a/etc/kayobe/ansible/rabbitmq-reset.yml
+++ b/etc/kayobe/ansible/rabbitmq-reset.yml
@@ -69,4 +69,4 @@
     # The following services use RabbitMQ.
     - name: Restart OpenStack services
       shell: >-
-        docker ps -a | egrep '(barbican|blazar|cinder|cloudkitty|designate|heat|ironic|keystone|magnum|manila|neutron|nova|octavia)' | awk '{ print $NF }' | xargs docker restart
+        docker ps -a | egrep '(barbican|blazar|cinder|cloudkitty|designate|heat|ironic|keystone|magnum|manila|neutron|nova|octavia|placement)' | awk '{ print $NF }' | xargs docker restart


### PR DESCRIPTION
After rabbitmq is reset, the openstack services get restarted but placement_api does not because it is was not grepped.