### PR TITLE
Disable SELinux for Yoga environments

### DIFF
--- a/etc/kayobe/environments/ci-aio/globals.yml
+++ b/etc/kayobe/environments/ci-aio/globals.yml
@@ -59,7 +59,7 @@ os_release: >-
 ###############################################################################
 
 # Avoid a reboot.
-disable_selinux_do_reboot: false
+selinux_state: disabled
 
 ###############################################################################
 # Dummy variable to allow Ansible to accept this file.

--- a/etc/kayobe/environments/ci-builder/globals.yml
+++ b/etc/kayobe/environments/ci-builder/globals.yml
@@ -12,4 +12,4 @@ os_distribution: "{{ lookup('pipe', '. /etc/os-release && echo $ID') | trim }}"
 # SELinux.
 
 # Avoid a reboot.
-disable_selinux_do_reboot: false
+selinux_state: disabled

--- a/etc/kayobe/environments/ci-multinode/globals.yml
+++ b/etc/kayobe/environments/ci-multinode/globals.yml
@@ -64,7 +64,7 @@ stackhpc_barbican_role_id_file_path: "/tmp/barbican-role-id"
 ###############################################################################
 
 # Avoid a reboot.
-disable_selinux_do_reboot: false
+selinux_state: disabled
 
 ###############################################################################
 # Dummy variable to allow Ansible to accept this file.


### PR DESCRIPTION
Disable SELinux for Yoga CI environments to avoid need for reboot as seen in Zed/Antelope.