### PR TITLE
xena: wallaby merge

### DIFF
--- a/.github/workflows/stackhpc-container-image-build.yml
+++ b/.github/workflows/stackhpc-container-image-build.yml
@@ -91,6 +91,7 @@ jobs:
     runs-on: [self-hosted, stackhpc-kayobe-config-kolla-builder]
     permissions: {}
     strategy:
+      fail-fast: false
       matrix: ${{ fromJson(needs.generate-tag.outputs.matrix) }}
     needs:
       - generate-tag


### PR DESCRIPTION
Previously if one of the container image build jobs (CS8, Ubuntu)
failed, the other would be cancelled. This is not necessarily helpful,
since the other job may complete successfully.

This change disables this fail fast behaviour.
