### PR TITLE
Add Cephadm version conditon for Rocky multi-node

### DIFF
--- a/etc/kayobe/cephadm.yml
+++ b/etc/kayobe/cephadm.yml
@@ -3,7 +3,7 @@
 # Cephadm deployment configuration.
 
 # Ceph release name.
-cephadm_ceph_release: "{{ 'quincy' if (ansible_facts['distribution_release'] == 'jammy') else 'pacific' }}"
+cephadm_ceph_release: "{{ 'quincy' if (ansible_facts['distribution_release'] == 'jammy') or (ansible_facts['distribution_release'] == '9') else 'pacific' }}"
 
 # Ceph FSID.
 #cephadm_fsid:
@@ -12,7 +12,7 @@ cephadm_ceph_release: "{{ 'quincy' if (ansible_facts['distribution_release'] == 
 cephadm_image: "{{ stackhpc_docker_registry if stackhpc_sync_ceph_images | bool else 'quay.io' }}/ceph/ceph:{{ cephadm_image_tag }}"
 
 # Ceph container image tag.
-cephadm_image_tag: "{{ 'v17.2.7' if os_release == 'jammy' else 'v16.2.14' }}"
+cephadm_image_tag: "{{ 'v17.2.7' if (os_release == 'jammy') or (os_release == '9') else 'v16.2.14' }}"
 
 # Ceph custom repo workaround for Ubuntu Jammy as there are no official ceph repos for jammy.
 cephadm_custom_repos: "{{ ansible_facts['distribution_release'] == 'jammy' }}"

--- a/etc/kayobe/environments/ci-multinode/cephadm.yml
+++ b/etc/kayobe/environments/ci-multinode/cephadm.yml
@@ -2,6 +2,12 @@
 ###############################################################################
 # Cephadm deployment configuration.
 
+# Ceph release name.
+cephadm_ceph_release: "{{ 'quincy' if (ansible_facts['distribution_release'] == 'jammy') or (ansible_facts['distribution_release'] == '9') else 'pacific' }}"
+
+# Ceph container image tag.
+cephadm_image_tag: "{{ 'v17.2.7' if (os_release == 'jammy') or (os_release == '9') else 'v16.2.14' }}"
+
 # Ceph OSD specification.
 cephadm_osd_spec:
   service_type: osd

--- a/etc/kayobe/environments/ci-multinode/cephadm.yml
+++ b/etc/kayobe/environments/ci-multinode/cephadm.yml
@@ -2,12 +2,6 @@
 ###############################################################################
 # Cephadm deployment configuration.
 
-# Ceph release name.
-cephadm_ceph_release: "{{ 'quincy' if (ansible_facts['distribution_release'] == 'jammy') or (ansible_facts['distribution_release'] == '9') else 'pacific' }}"
-
-# Ceph container image tag.
-cephadm_image_tag: "{{ 'v17.2.7' if (os_release == 'jammy') or (os_release == '9') else 'v16.2.14' }}"
-
 # Ceph OSD specification.
 cephadm_osd_spec:
   service_type: osd

--- a/etc/kayobe/environments/ci-multinode/inventory/group_vars/seed/stackhpc-dnf-repos
+++ b/etc/kayobe/environments/ci-multinode/inventory/group_vars/seed/stackhpc-dnf-repos
@@ -1,0 +1,1 @@
+dnf_custom_repos: "{{ stackhpc_dnf_repos }}"


### PR DESCRIPTION
Add condition of checking Rocky Linux release number on conditional variables `cephadm_ceph_release` and `cephadm_image_tag`

The upstream Cephadm Pacific repository is no more available and this change prevents targeting the repository when building Rocky Linux 9 multi-node environment.

The change was made at `etc/kayobe/environments/ci-multinode/cephadm.yml` to override only when environment is set to be ci-multinode