### PR TITLE
Fix Wazuh manager playbook with no custom policies

### DIFF
--- a/etc/kayobe/ansible/wazuh-manager.yml
+++ b/etc/kayobe/ansible/wazuh-manager.yml
@@ -41,7 +41,9 @@
             dest: "/var/ossec/etc/shared/default/"
             owner: wazuh
             group: wazuh
-          when: custom_sca_policies.files | length > 0
+          when:
+            - custom_sca_policies_folder.stat.exists
+            - custom_sca_policies.files | length > 0
 
         - name: Add custom policy definition(s) to the shared Agent config
           blockinfile:
@@ -61,7 +63,9 @@
                 </policies>
               </sca>
               {% endfilter %}
-          when: custom_sca_policies.files | length > 0
+          when:
+            - custom_sca_policies_folder.stat.exists
+            - custom_sca_policies.files | length > 0
       notify:
         - Restart wazuh
 


### PR DESCRIPTION
`etc/kayobe/ansible/wazuh-manager.yml` also has same problem that was addressed on https://github.com/stackhpc/stackhpc-kayobe-config/pull/812

Added "The file exists" check for tasks that is conditional to the length of the file.