### PR TITLE
Pin base image tag

### DIFF
--- a/etc/kayobe/kolla/kolla-build.conf
+++ b/etc/kayobe/kolla/kolla-build.conf
@@ -1,2 +1,11 @@
 [DEFAULT]
+{# Packages in the latest upstream Ubuntu base image can be ahead of our package repo #}
+{# snapshots, so pin to a specific tag. #}
+{# This tag should be updated when Ubuntu package repo snapshot versions are changed. #}
+{% if kolla_base_distro == 'ubuntu' %}
+base_tag = jammy-20231004
+{# Similarily pinning to Rocky 9 minor version used in our repos #}
+{% elif kolla_base_distro == 'rocky' %}
+base_tag = 9.{{ stackhpc_pulp_repo_rocky_9_minor_version }}
+{% endif %}
 build_args = {{ kolla_build_args.items() | map('join', ':') | join(',') }}

--- a/releasenotes/notes/pin-baseimage-3d224df5b6f56b10.yaml
+++ b/releasenotes/notes/pin-baseimage-3d224df5b6f56b10.yaml
@@ -1,0 +1,7 @@
+fixes:
+  - |
+    Pin the OCI image tag used for the base-image of Kolla image
+    builds. This prevents packages in the image with
+    the latest tag getting in front of StackHPC release-train
+    package repositories. Ubuntu tag should be bumped when new
+    packages are available in StackHPC release-train.


### PR DESCRIPTION
Pin the OCI image tag used for the base-image of Kolla image
builds. This prevents packages in the image with
the latest tag getting in front of StackHPC release-train
package repositories. Ubuntu tag should be bumped when new
packages are available in StackHPC release-train.