### PR TITLE
Set selinux disabled in RL9 AIOs

### DIFF
--- a/etc/kayobe/environments/ci-aio/inventory/group_vars/controllers/selinux
+++ b/etc/kayobe/environments/ci-aio/inventory/group_vars/controllers/selinux
@@ -1,0 +1,4 @@
+---
+# Configure SELinux to be disabled in all cases. This is a short term fix, we
+# want RL9 hosts to be be permissive but our host images need to be rebuilt.
+selinux_state: "disabled"


### PR DESCRIPTION
This is currently blocking RL9 AIOs in CI. Hopefully we can build new images soon and rever this.

I was also hoping to fix the focal and RL8 issues with this PR but haven't been able to replicate them yet