### PR TITLE
Disable os-capacity by default

### DIFF
--- a/etc/kayobe/kolla/config/haproxy/services.d/os_exporter.cfg
+++ b/etc/kayobe/kolla/config/haproxy/services.d/os_exporter.cfg
@@ -1,3 +1,4 @@
+{% if stackhpc_enable_os_capacity | bool %}
 {% raw %}
 frontend os_capacity_frontend
     mode http
@@ -17,3 +18,4 @@ backend os_capacity_backend
     server {{ host_name }} {{ host_ip }}:9000 check inter 2000 rise 2 fall 5
 {% endfor %}
 {% endraw %}
+{% endif %}

--- a/etc/kayobe/kolla/config/prometheus/prometheus.yml.d/70-oscapacity.yml
+++ b/etc/kayobe/kolla/config/prometheus/prometheus.yml.d/70-oscapacity.yml
@@ -1,3 +1,5 @@
+# yamllint disable-file
+---
 {% if stackhpc_enable_os_capacity | bool %}
 {% raw %}
 scrape_configs:

--- a/etc/kayobe/kolla/config/prometheus/prometheus.yml.d/70-oscapacity.yml
+++ b/etc/kayobe/kolla/config/prometheus/prometheus.yml.d/70-oscapacity.yml
@@ -1,3 +1,4 @@
+{% if stackhpc_enable_os_capacity | bool %}
 {% raw %}
 scrape_configs:
   - job_name: os-capacity
@@ -7,3 +8,4 @@ scrape_configs:
     scrape_interval: 15m
     scrape_timeout: 10m
 {% endraw %}
+{% endif %}

--- a/etc/kayobe/stackhpc-monitoring.yml
+++ b/etc/kayobe/stackhpc-monitoring.yml
@@ -9,3 +9,9 @@
 alertmanager_low_memory_threshold_gib: 5
 
 ###############################################################################
+# Exporter configuration
+
+# Whether the OpenStack Capacity exporter is enabled.
+# Enabling this flag will result in HAProxy configuration and Prometheus scrape
+# targets being templated during deployment.
+stackhpc_enable_os_capacity: false


### PR DESCRIPTION
The HAProxy configuration for os-capacity is enabled by default and is causing alerts on every deployment until the exporter is deployed.

Disable it while its configuration is being finalised [1].

[1] https://github.com/stackhpc/stackhpc-kayobe-config/pull/697