### PR TITLE
fix for removal of OVN metadata ports on manual Neutron OVN db sync

### DIFF
--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -16,8 +16,11 @@ kayobe_image_tags:
     rocky: 2023.1-rocky-9-20231115T110235
     ubuntu: 2023.1-ubuntu-jammy-20231115T110235
   neutron:
-    rocky: 2023.1-rocky-9-20231115T110249
-    ubuntu: 2023.1-ubuntu-jammy-20231115T110249
+    rocky: 2023.1-rocky-9-20231220T222020
+    ubuntu: 2023.1-ubuntu-jammy-20231220T222020
+  octavia:
+    rocky: 2023.1-rocky-9-20231220T222020
+    ubuntu: 2023.1-ubuntu-jammy-20231220T222020
   opensearch:
     rocky: 2023.1-rocky-9-20231214T151917
     ubuntu: 2023.1-ubuntu-jammy-20231214T151917
@@ -26,6 +29,7 @@ openstack_tag: "{% raw %}{{ kayobe_image_tags['openstack'][kolla_base_distro] }}
 bifrost_tag: "{% raw %}{{ kayobe_image_tags['bifrost'][kolla_base_distro] }}{% endraw %}"
 cloudkitty_tag: "{% raw %}{{ kayobe_image_tags['cloudkitty'][kolla_base_distro] }}{% endraw %}"
 neutron_tag: "{% raw %}{{ kayobe_image_tags['neutron'][kolla_base_distro] }}{% endraw %}"
+octavia_tag: "{% raw %}{{ kayobe_image_tags['octavia'][kolla_base_distro] }}{% endraw %}"
 opensearch_tag: "{% raw %}{{ kayobe_image_tags['opensearch'][kolla_base_distro] }}{% endraw %}"
 
 om_enable_rabbitmq_high_availability: true

--- a/etc/kayobe/releasenotes/notes/octavia-sync-healthmonitor-bug-8602034e2185d12c.yaml
+++ b/etc/kayobe/releasenotes/notes/octavia-sync-healthmonitor-bug-8602034e2185d12c.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    Neutron ovn db sync operation will no longer removes OVN metadata ports in
+    networks with Octavia OVN Load balancers health monitors.
+    A maintenance task process has been added to update the existing OVN LB HM
+    ports to the new behaviour defined. Specifically, the "device_owner" field
+    will be updated from network:distributed to ovn-lb-hm:distributed.
+    Additionally, the "device_id" will be populated during update action.
+    `LP#2038091 <https://bugs.launchpad.net/neutron/+bug/2038091>`__.


### PR DESCRIPTION
fixes https://bugs.launchpad.net/neutron/+bug/2038091 and introduced by initial fix - https://bugs.launchpad.net/neutron/+bug/2046457

tested in one environment on Rocky:

octavia driver agent log:
```
2023-12-21 12:10:56.338 33 INFO ovn_octavia_provider.maintenance [-] Periodic task found: DBInconsistenciesPeriodics.change_device_owner_lb_hm_ports
```
after periodic task owner of LB HM port has changed:
```
Device Owner: ovn-lb-hm:distributed
```