### PR TITLE
bump nova tag - no need to define switchdev in port bindings for VF-lag

### DIFF
--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -18,6 +18,9 @@ kayobe_image_tags:
   neutron:
     rocky: 2023.1-rocky-9-20231220T222020
     ubuntu: 2023.1-ubuntu-jammy-20231220T222020
+  nova:
+    rocky: 2023.1-rocky-9-20231220T222020
+    ubuntu: 2023.1-ubuntu-jammy-20231220T222020
   octavia:
     rocky: 2023.1-rocky-9-20231220T222020
     ubuntu: 2023.1-ubuntu-jammy-20231220T222020
@@ -29,6 +32,7 @@ openstack_tag: "{% raw %}{{ kayobe_image_tags['openstack'][kolla_base_distro] }}
 bifrost_tag: "{% raw %}{{ kayobe_image_tags['bifrost'][kolla_base_distro] }}{% endraw %}"
 cloudkitty_tag: "{% raw %}{{ kayobe_image_tags['cloudkitty'][kolla_base_distro] }}{% endraw %}"
 neutron_tag: "{% raw %}{{ kayobe_image_tags['neutron'][kolla_base_distro] }}{% endraw %}"
+nova_tag: "{% raw %}{{ kayobe_image_tags['nova'][kolla_base_distro] }}{% endraw %}"
 octavia_tag: "{% raw %}{{ kayobe_image_tags['octavia'][kolla_base_distro] }}{% endraw %}"
 opensearch_tag: "{% raw %}{{ kayobe_image_tags['opensearch'][kolla_base_distro] }}{% endraw %}"
 

--- a/etc/kayobe/releasenotes/notes/nova-vflag-noswitchdev-needed-79aaa276bc799923.yaml
+++ b/etc/kayobe/releasenotes/notes/nova-vflag-noswitchdev-needed-79aaa276bc799923.yaml
@@ -1,0 +1,18 @@
+---
+fixes:
+  - |
+    Previously ``switchdev`` capabilities should be configured manually by a
+    user with admin privileges using port's binding profile. This blocked
+    regular users from managing ports with Open vSwitch hardware offloading
+    as providing write access to a port's binding profile to non-admin users
+    introduces security risks. For example, a binding profile may contain a
+    ``pci_slot`` definition, which denotes the host PCI address of the
+    device attached to the VM. A malicious user can use this parameter to
+    passthrough any host device to a guest, so it is impossible to provide
+    write access to a binding profile to regular users in many scenarios.
+
+    This patch fixes this situation by translating VF capabilities reported
+    by Libvirt to Neutron port binding profiles. Other VF capabilities are
+    translated as well for possible future use.
+    `LP#2008238 <https://bugs.launchpad.net/nova/+bug/2008238>`__.
+    `LP#2020813 <https://bugs.launchpad.net/nova/+bug/2020813>`__.


### PR DESCRIPTION
fixes:
https://bugs.launchpad.net/nova/+bug/2008238
https://bugs.launchpad.net/nova/+bug/2020813

https://review.opendev.org/c/openstack/nova/+/898945

tested in one env on both Geneve and vlan vf-lag - no switchdev is needed in port bindings