### PR TITLE
Fix vif unplug operations failing on RL9.3

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -396,6 +396,10 @@ kolla_build_blocks:
     {% endif %}
     {% endraw %}
     {% endif %}
+    # Fix for https://bugs.launchpad.net/ubuntu/+source/pyroute2/+bug/1995469
+    # which was experienced on Rocky Linux 9.3 kernel. This file is from
+    # pyroute2 0.6.6 with the fix backported from 0.6.10.
+    RUN curl -o /var/lib/kolla/venv/lib/python3.9/site-packages/pr2modules/iproute/linux.py https://raw.githubusercontent.com/stackhpc/pyroute2/stackhpc/yoga/pyroute2.core/pr2modules/iproute/linux.py
   magnum_base_footer: |
     RUN curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | head -n -1 | bash
     {% raw %}

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -400,6 +400,13 @@ kolla_build_blocks:
     # which was experienced on Rocky Linux 9.3 kernel. This file is from
     # pyroute2 0.6.6 with the fix backported from 0.6.10.
     RUN curl -o /var/lib/kolla/venv/lib/python3.9/site-packages/pr2modules/iproute/linux.py https://raw.githubusercontent.com/stackhpc/pyroute2/stackhpc/yoga/pyroute2.core/pr2modules/iproute/linux.py
+  neutron_base_footer: |
+    # Fix for neutron_ovn_metadata_agent start up failure caused by https://bugs.launchpad.net/ubuntu/+source/pyroute2/+bug/1995469
+    # which was experienced on Rocky Linux 9.3 kernel. This file is from
+    # pyroute2 0.6.6 with the fix backported from 0.6.10.
+    # This ultimately fixes ssh key authentication failure on newly created
+    # instances with Rocky Linux 9.3 kernel.
+    RUN curl -o /var/lib/kolla/venv/lib/python3.9/site-packages/pr2modules/iproute/linux.py https://raw.githubusercontent.com/stackhpc/pyroute2/stackhpc/yoga/pyroute2.core/pr2modules/iproute/linux.py
   magnum_base_footer: |
     RUN curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | head -n -1 | bash
     {% raw %}


### PR DESCRIPTION
An instance on a hypervisor running Rocky Linux 9.3 would fail to resize or cold migrate with the error:

    Traceback (most recent call last):
      File "/var/lib/kolla/venv/lib/python3.9/site-packages/os_vif/__init__.py", line 110, in unplug
        plugin.unplug(vif, instance_info)
      File "/var/lib/kolla/venv/lib/python3.9/site-packages/vif_plug_ovs/ovs.py", line 445, in unplug
        self._unplug_bridge(vif, instance_info)
      File "/var/lib/kolla/venv/lib/python3.9/site-packages/vif_plug_ovs/ovs.py", line 376, in _unplug_bridge
        linux_net.delete_bridge(vif.bridge_name, v1_name)
      File "/var/lib/kolla/venv/lib/python3.9/site-packages/oslo_privsep/priv_context.py", line 271, in _wrap
        return self.channel.remote_call(name, args, kwargs,
      File "/var/lib/kolla/venv/lib/python3.9/site-packages/oslo_privsep/daemon.py", line 215, in remote_call
        raise exc_type(*result[2])
    pr2modules.netlink.exceptions.NetlinkError: (95, 'Operation not supported')

This appears to be caused by incompatibility between pyroute2<0.6.10 and the Rocky Linux 9.3 kernel. More details are available on Launchpad [1].

[1] https://bugs.launchpad.net/ubuntu/+source/pyroute2/+bug/1995469