### PR TITLE
Fix Interface and SELinux errors in CI

### DIFF
--- a/.github/workflows/stackhpc-all-in-one.yml
+++ b/.github/workflows/stackhpc-all-in-one.yml
@@ -34,7 +34,7 @@ on:
       vm_interface:
         description: Default network interface name
         type: string
-        default: ens3
+        default: enp3s0
       vm_flavor:
         description: Flavor for the all-in-one VM
         type: string

--- a/etc/kayobe/environments/ci-aio/inventory/group_vars/controllers/selinux
+++ b/etc/kayobe/environments/ci-aio/inventory/group_vars/controllers/selinux
@@ -1,0 +1,4 @@
+---
+# Configure SELinux to be disabled in all cases. This is a short term fix, we
+# want RL9 hosts to be be permissive but our host images need to be rebuilt.
+selinux_state: "disabled"


### PR DESCRIPTION
Fix Interface and SELinux errors in CI:

- Change default interface from ens3 to enp3s0.
- Disable SELinux until we have new host images.