### PR TITLE
Update Bifrost container images

### DIFF
--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -10,8 +10,8 @@ kayobe_image_tags:
     rocky: 2023.1-rocky-9-20231011T200357
     ubuntu: 2023.1-ubuntu-jammy-20231011T200357
   bifrost:
-    rocky: 2023.1-rocky-9-20231013T151957
-    ubuntu: 2023.1-ubuntu-jammy-20231013T151957
+    rocky: 2023.1-rocky-9-20231228T140806
+    ubuntu: 2023.1-ubuntu-jammy-20231228T140806
   cloudkitty:
     rocky: 2023.1-rocky-9-20231115T110235
     ubuntu: 2023.1-ubuntu-jammy-20231115T110235

--- a/releasenotes/notes/bifrost-update-discovery-fix-220d745e22d6fbe0.yaml
+++ b/releasenotes/notes/bifrost-update-discovery-fix-220d745e22d6fbe0.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Update Bifrost container images to include a fix for
+    DHCP-based hardware discovery from
+    https://review.opendev.org/c/openstack/bifrost/+/902233.
+


### PR DESCRIPTION
Include upstream fix that reinstates autodiscovery for the dnsmasq DHCP provider:
https://review.opendev.org/c/openstack/bifrost/+/902233