### PR TITLE
Missing cherry pick from 2023.1

### DIFF
--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -1,6 +1,11 @@
 # yamllint disable-file
 ---
 
+# To work around issue of trying to install docker from
+# empty pulp server, use upstream docker dnf repo on
+# non-overcloud hosts
+enable_docker_repo: "{% raw %}{{ 'overcloud' not in group_names }}{% endraw %}"
+
 # kolla_base_distro must be set here to be resolvable on a per-host basis
 # This is necessary for os migrations where mixed clouds might be deployed
 kolla_base_distro: "{% raw %}{{ ansible_facts.distribution | lower }}{% endraw %}"


### PR DESCRIPTION
non-overcloud hosts e.g. the seed hypervisor are configured before the seed and its services are deployed. This means that they will look for the local package repo mirrors before they exist.

(Cherry-picked manually due to some parts getting lost in a merge)