### PR TITLE
Reduce multinode lvm allocations

### DIFF
--- a/etc/kayobe/environments/ci-multinode/inventory/group_vars/compute/lvm.yml
+++ b/etc/kayobe/environments/ci-multinode/inventory/group_vars/compute/lvm.yml
@@ -7,25 +7,25 @@ stackhpc_lvm_group_rootvg_lvs_extra:
 # StackHPC LVM Logical Volume (LV) configuration.
 
 # StackHPC LVM lv_swap LV size.
-stackhpc_lvm_lv_swap_size: 1g
+stackhpc_lvm_lv_swap_size: 500m
 
 # StackHPC LVM lv_root LV size.
-stackhpc_lvm_lv_root_size: 10g
+stackhpc_lvm_lv_root_size: 5g
 
 # StackHPC LVM lv_tmp LV size.
-stackhpc_lvm_lv_tmp_size: 10g
+stackhpc_lvm_lv_tmp_size: 5g
 
 # StackHPC LVM lv_var LV size.
-stackhpc_lvm_lv_var_size: 20g
+stackhpc_lvm_lv_var_size: 2g
 
 # StackHPC LVM lv_var_tmp LV size.
-stackhpc_lvm_lv_var_tmp_size: 5g
+stackhpc_lvm_lv_var_tmp_size: 2g
 
 # StackHPC LVM lv_log LV size.
-stackhpc_lvm_lv_log_size: 10g
+stackhpc_lvm_lv_log_size: 5g
 
 # StackHPC LVM lv_audit LV size.
-stackhpc_lvm_lv_audit_size: 5g
+stackhpc_lvm_lv_audit_size: 250m
 
 # StackHPC LVM lv_home LV size.
 stackhpc_lvm_lv_home_size: 5g

--- a/etc/kayobe/environments/ci-multinode/inventory/group_vars/controllers/lvm.yml
+++ b/etc/kayobe/environments/ci-multinode/inventory/group_vars/controllers/lvm.yml
@@ -7,25 +7,25 @@ stackhpc_lvm_group_rootvg_lvs_extra:
 # StackHPC LVM Logical Volume (LV) configuration.
 
 # StackHPC LVM lv_swap LV size.
-stackhpc_lvm_lv_swap_size: 1g
+stackhpc_lvm_lv_swap_size: 500m
 
 # StackHPC LVM lv_root LV size.
-stackhpc_lvm_lv_root_size: 10g
+stackhpc_lvm_lv_root_size: 5g
 
 # StackHPC LVM lv_tmp LV size.
-stackhpc_lvm_lv_tmp_size: 10g
+stackhpc_lvm_lv_tmp_size: 5g
 
 # StackHPC LVM lv_var LV size.
-stackhpc_lvm_lv_var_size: 20g
+stackhpc_lvm_lv_var_size: 2g
 
 # StackHPC LVM lv_var_tmp LV size.
-stackhpc_lvm_lv_var_tmp_size: 5g
+stackhpc_lvm_lv_var_tmp_size: 2g
 
 # StackHPC LVM lv_log LV size.
-stackhpc_lvm_lv_log_size: 10g
+stackhpc_lvm_lv_log_size: 5g
 
 # StackHPC LVM lv_audit LV size.
-stackhpc_lvm_lv_audit_size: 5g
+stackhpc_lvm_lv_audit_size: 250m
 
 # StackHPC LVM lv_home LV size.
 stackhpc_lvm_lv_home_size: 5g

--- a/etc/kayobe/environments/ci-multinode/inventory/group_vars/seed/lvm.yml
+++ b/etc/kayobe/environments/ci-multinode/inventory/group_vars/seed/lvm.yml
@@ -7,25 +7,25 @@ stackhpc_lvm_group_rootvg_lvs_extra:
 # StackHPC LVM Logical Volume (LV) configuration.
 
 # StackHPC LVM lv_swap LV size.
-stackhpc_lvm_lv_swap_size: 1g
+stackhpc_lvm_lv_swap_size: 500m
 
 # StackHPC LVM lv_root LV size.
-stackhpc_lvm_lv_root_size: 10g
+stackhpc_lvm_lv_root_size: 5g
 
 # StackHPC LVM lv_tmp LV size.
-stackhpc_lvm_lv_tmp_size: 10g
+stackhpc_lvm_lv_tmp_size: 5g
 
 # StackHPC LVM lv_var LV size.
-stackhpc_lvm_lv_var_size: 20g
+stackhpc_lvm_lv_var_size: 2g
 
 # StackHPC LVM lv_var_tmp LV size.
-stackhpc_lvm_lv_var_tmp_size: 5g
+stackhpc_lvm_lv_var_tmp_size: 2g
 
 # StackHPC LVM lv_log LV size.
-stackhpc_lvm_lv_log_size: 10g
+stackhpc_lvm_lv_log_size: 5g
 
 # StackHPC LVM lv_audit LV size.
-stackhpc_lvm_lv_audit_size: 5g
+stackhpc_lvm_lv_audit_size: 250m
 
 # StackHPC LVM lv_home LV size.
 stackhpc_lvm_lv_home_size: 5g

--- a/etc/kayobe/environments/ci-multinode/inventory/group_vars/wazuh-manager/lvm.yml
+++ b/etc/kayobe/environments/ci-multinode/inventory/group_vars/wazuh-manager/lvm.yml
@@ -7,25 +7,25 @@ stackhpc_lvm_group_rootvg_lvs_extra:
 # StackHPC LVM Logical Volume (LV) configuration.
 
 # StackHPC LVM lv_swap LV size.
-stackhpc_lvm_lv_swap_size: 1g
+stackhpc_lvm_lv_swap_size: 500m
 
 # StackHPC LVM lv_root LV size.
-stackhpc_lvm_lv_root_size: 10g
+stackhpc_lvm_lv_root_size: 5g
 
 # StackHPC LVM lv_tmp LV size.
-stackhpc_lvm_lv_tmp_size: 10g
+stackhpc_lvm_lv_tmp_size: 5g
 
 # StackHPC LVM lv_var LV size.
-stackhpc_lvm_lv_var_size: 20g
+stackhpc_lvm_lv_var_size: 2g
 
 # StackHPC LVM lv_var_tmp LV size.
-stackhpc_lvm_lv_var_tmp_size: 5g
+stackhpc_lvm_lv_var_tmp_size: 2g
 
 # StackHPC LVM lv_log LV size.
-stackhpc_lvm_lv_log_size: 10g
+stackhpc_lvm_lv_log_size: 5g
 
 # StackHPC LVM lv_audit LV size.
-stackhpc_lvm_lv_audit_size: 5g
+stackhpc_lvm_lv_audit_size: 250m
 
 # StackHPC LVM lv_home LV size.
 stackhpc_lvm_lv_home_size: 5g


### PR DESCRIPTION
We're constantly running low on space in SMS, this PR goes with another in the multinode terraform to reduce the allocations across the board.

These sizes are tested and working for Rocky 9