### PR TITLE
CI: Fix default kayobe base image when built on push

### DIFF
--- a/.github/workflows/stackhpc-build-kayobe-image.yml
+++ b/.github/workflows/stackhpc-build-kayobe-image.yml
@@ -90,7 +90,7 @@ jobs:
           build-args: |
              http_proxy=${{ inputs.http_proxy }}
              https_proxy=${{ inputs.https_proxy }}
-             BASE_IMAGE=${{ inputs.base_image }}
+             BASE_IMAGE=${{ inputs.base_image || 'rockylinux:9' }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Inputs are not available to workflows triggered by a push. Apply a default to the base image.
