### PR TITLE
AUFN-Ceph fixes

### DIFF
--- a/etc/kayobe/environments/aufn-ceph/a-universe-from-nothing.sh
+++ b/etc/kayobe/environments/aufn-ceph/a-universe-from-nothing.sh
@@ -87,7 +87,7 @@ kayobe seed vm provision
 kayobe seed host configure
 
 # Deploy local pulp server as a container on the seed VM
-kayobe seed service deploy --tags seed-deploy-containers --kolla-tags none
+kayobe seed service deploy --tags seed-deploy-containers --kolla-tags none -e deploy_containers_registry_attempt_login=False
 
 # Deploying the seed restarts networking interface, run configure-local-networking.sh again to re-add routes.
 $KAYOBE_CONFIG_PATH/environments/$KAYOBE_ENVIRONMENT/configure-local-networking.sh

--- a/etc/kayobe/environments/aufn-ceph/networks.yml
+++ b/etc/kayobe/environments/aufn-ceph/networks.yml
@@ -55,19 +55,19 @@ cleaning_net_name: provision_wl
 # Network definitions.
 
 mgmt_cidr: 192.168.35.0/24
-mgmt_mtu: 1450
+mgmt_mtu: 1442
 # Native VLAN
 mgmt_physical_network: mgmt
 
 provision_oc_cidr: 192.168.33.0/24
-provision_oc_mtu: 1450
+provision_oc_mtu: 1442
 provision_oc_inspection_allocation_pool_start: 192.168.33.128
 provision_oc_inspection_allocation_pool_end: 192.168.33.254
 # Native VLAN
 provision_oc_physical_network: provision
 
 provision_wl_cidr: 192.168.36.0/24
-provision_wl_mtu: 1450
+provision_wl_mtu: 1442
 provision_wl_inspection_allocation_pool_start: 192.168.36.128
 provision_wl_inspection_allocation_pool_end: 192.168.36.254
 provision_wl_neutron_allocation_pool_start: 192.168.36.2
@@ -76,7 +76,7 @@ provision_wl_neutron_allocation_pool_end: 192.168.36.127
 provision_wl_physical_network: cloud
 
 internal_cidr: 192.168.37.0/24
-internal_mtu: 1450
+internal_mtu: 1442
 internal_allocation_pool_start: 192.168.37.3
 internal_allocation_pool_end: 192.168.37.254
 internal_vip_address: 192.168.37.2
@@ -89,7 +89,7 @@ external_vlan: 102
 external_physical_network: cloud
 
 public_cidr: 192.168.39.0/24
-public_mtu: 1450
+public_mtu: 1442
 public_allocation_pool_start: 192.168.39.3
 public_allocation_pool_end: 192.168.39.254
 public_vip_address: 192.168.39.2
@@ -97,17 +97,17 @@ public_vlan: 103
 public_physical_network: cloud
 
 tunnel_cidr: 192.168.40.0/24
-tunnel_mtu: 1450
+tunnel_mtu: 1442
 tunnel_vlan: 104
 tunnel_physical_network: cloud
 
 storage_cidr: 192.168.41.0/24
-storage_mtu: 1450
+storage_mtu: 1442
 storage_vlan: 105
 storage_physical_network: cloud
 
 storage_mgmt_cidr: 192.168.42.0/24
-storage_mgmt_mtu: 1450
+storage_mgmt_mtu: 1442
 storage_mgmt_vlan: 106
 storage_mgmt_physical_network: cloud
 


### PR DESCRIPTION
Now that we're lacking in baremetals, AUFNs need to be run in VMs. The geneve network on SMS lab has MTU 1442, so networks need to be lowered to match this.