### PR TITLE
Set OpenSearch heap size

### DIFF
--- a/etc/kayobe/environments/aufn-ceph/kolla/globals.yml
+++ b/etc/kayobe/environments/aufn-ceph/kolla/globals.yml
@@ -13,5 +13,6 @@ glance_backend_ceph: "yes"
 cinder_backend_ceph: "yes"
 nova_backend_ceph: "yes"
 
-# Elasticsearch memory tuning
+# Elasticsearch / OpenSearch memory tuning
 es_heap_size: 1g
+opensearch_heap_size: 1g

--- a/etc/kayobe/environments/ci-aio/kolla/globals.yml
+++ b/etc/kayobe/environments/ci-aio/kolla/globals.yml
@@ -12,8 +12,9 @@ openstack_service_rpc_workers: "1"
 docker_yum_baseurl: "{{ stackhpc_repo_docker_url }}"
 docker_yum_gpgkey: "https://download.docker.com/linux/centos/gpg"
 
-# Elasticsearch memory tuning
+# Elasticsearch / OpenSearch memory tuning
 es_heap_size: 1g
+opensearch_heap_size: 1g
 
 # Increase Grafana timeout
 grafana_start_first_node_retries: 20

--- a/etc/kayobe/environments/ci-multinode/kolla/globals.yml
+++ b/etc/kayobe/environments/ci-multinode/kolla/globals.yml
@@ -20,8 +20,9 @@ nova_backend_ceph: "yes"
 neutron_bridge_name: "{{ vxlan_interfaces[0].device }}-ovs"
 neutron_external_interface: "{{ vxlan_interfaces[0].device }}"
 
-# Elasticsearch memory tuning
+# Elasticsearch / OpenSearch memory tuning
 es_heap_size: 1g
+opensearch_heap_size: 1g
 
 # Octavia load balancer configuration
 octavia_auto_configure: "no"

--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -43,6 +43,7 @@ om_enable_rabbitmq_high_availability: true
 # Monitoring and alerting related settings
 
 es_heap_size: 8g
+opensearch_heap_size: 8g
 prometheus_cmdline_extras: "--storage.tsdb.retention.time=30d"
 
 # Additional command line flags for node exporter to enable texfile collector for disk metrics and create textfile docker volume

--- a/releasenotes/notes/fix-opensearch-heap-size-0cd31054927d4bbd.yaml
+++ b/releasenotes/notes/fix-opensearch-heap-size-0cd31054927d4bbd.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Bumps OpenSearch heap size to 8 GB, to be identical to Elasticsearch.


### PR DESCRIPTION
This is required for deployments using Rocky Linux 9. Without this
setting, OpenSearch would set heap size to 1 GB by default, which can
trigger alerts on production systems.
