### PR TITLE
Add pvresize before lvextend

### DIFF
--- a/etc/kayobe/environments/ci-aio/automated-setup.sh
+++ b/etc/kayobe/environments/ci-aio/automated-setup.sh
@@ -7,8 +7,7 @@ cat << EOF | sudo tee -a /etc/hosts
 EOF
 
 if sudo vgdisplay | grep -q lvm2; then
-   disk=$(sudo pvs --noheadings | head -n 1 | awk '{print $1}')
-   sudo pvresize $disk
+   sudo pvresize $(sudo pvs --noheadings | head -n 1 | awk '{print $1}')
    sudo lvextend -L 4G /dev/rootvg/lv_home -r || true
    sudo lvextend -L 4G /dev/rootvg/lv_tmp -r || true
 fi

--- a/etc/kayobe/environments/ci-aio/automated-setup.sh
+++ b/etc/kayobe/environments/ci-aio/automated-setup.sh
@@ -7,6 +7,8 @@ cat << EOF | sudo tee -a /etc/hosts
 EOF
 
 if sudo vgdisplay | grep -q lvm2; then
+   disk=$(sudo pvs --noheadings | head -n 1 | awk '{print $1}')
+   sudo pvresize $disk
    sudo lvextend -L 4G /dev/rootvg/lv_home -r || true
    sudo lvextend -L 4G /dev/rootvg/lv_tmp -r || true
 fi

--- a/etc/kayobe/environments/ci-aio/automated-setup.sh
+++ b/etc/kayobe/environments/ci-aio/automated-setup.sh
@@ -69,8 +69,6 @@ source kayobe-env --environment ci-aio
 
 kayobe control host bootstrap
 
-kayobe playbook run etc/kayobe/ansible/growroot.yml
-
 kayobe overcloud host configure
 
 kayobe overcloud service deploy

--- a/etc/kayobe/environments/ci-aio/automated-setup.sh
+++ b/etc/kayobe/environments/ci-aio/automated-setup.sh
@@ -68,6 +68,8 @@ source kayobe-env --environment ci-aio
 
 kayobe control host bootstrap
 
+kayobe playbook run etc/kayobe/ansible/growroot.yml
+
 kayobe overcloud host configure
 
 kayobe overcloud service deploy


### PR DESCRIPTION
Running pvresize before lvextend ensures that there is enough space for extension.

There are some cases where `lvextend` fails because initial usable space of a physical volume is not enough.
This leads the automated setup failure at package or python module installation stage.
As this happens earlier than kayobe setup, `kayobe playbook run etc/kayobe/ansible/growroot.yml` can't be used.
https://github.com/stackhpc/stackhpc-kayobe-config/blob/e1a64bdb28201fe8b00b3adca07d6d366439961e/etc/kayobe/ansible/growroot.yml#L87-L93 
Therefore I propose adding bash equivalent of the Ansible task above before `lvextend`.

The command gets the name of the physical volume by filtering the output of `sudo pvs --noheadings`.
`head -n 1` is used to take first line of output only then `awk '{print $1}'` is used to take first element of it, which is essentially the way the `growroot.yml` does to get PV name.