### PR TITLE
Update Kolla container images for Ubuntu Jammy Zed

### DIFF
--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -5,19 +5,19 @@
 kolla_image_tags:
   openstack:
     rocky-9: zed-rocky-9-20230921T153510
-    ubuntu-jammy: zed-ubuntu-jammy-20230921T153510
+    ubuntu-jammy: zed-ubuntu-jammy-20240129T151534
   bifrost:
     rocky-9: zed-rocky-9-20230927T142529
-    ubuntu-jammy: zed-ubuntu-jammy-20231101T132522
+    ubuntu-jammy: zed-ubuntu-jammy-20240129T151534
   ovn:
     rocky-9: zed-rocky-9-20230925T132313
-    ubuntu-jammy: zed-ubuntu-jammy-20230821T155947
+    ubuntu-jammy: zed-ubuntu-jammy-20240129T151534
   cloudkitty:
     rocky-9: zed-rocky-9-20231114T124701
-    ubuntu-jammy: zed-ubuntu-jammy-20231114T124701
+    ubuntu-jammy: zed-ubuntu-jammy-20240129T151534
   neutron:
     rocky-9: zed-rocky-9-20231115T094053
-    ubuntu-jammy: zed-ubuntu-jammy-20231115T094053
+    ubuntu-jammy: zed-ubuntu-jammy-20240202T143208
   opensearch:
     rocky-9: zed-rocky-9-20231214T095452
-    ubuntu-jammy: zed-ubuntu-jammy-20231214T095452
+    ubuntu-jammy: zed-ubuntu-jammy-20240129T151534

--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -8,16 +8,12 @@ kolla_image_tags:
     ubuntu-jammy: zed-ubuntu-jammy-20240129T151534
   bifrost:
     rocky-9: zed-rocky-9-20230927T142529
-    ubuntu-jammy: zed-ubuntu-jammy-20240129T151534
   ovn:
     rocky-9: zed-rocky-9-20230925T132313
-    ubuntu-jammy: zed-ubuntu-jammy-20240129T151534
   cloudkitty:
     rocky-9: zed-rocky-9-20231114T124701
-    ubuntu-jammy: zed-ubuntu-jammy-20240129T151534
   neutron:
     rocky-9: zed-rocky-9-20231115T094053
     ubuntu-jammy: zed-ubuntu-jammy-20240202T143208
   opensearch:
     rocky-9: zed-rocky-9-20231214T095452
-    ubuntu-jammy: zed-ubuntu-jammy-20240129T151534

--- a/releasenotes/notes/update-ubuntu-jammy-zed-kolla-containers-0774af3c590b89d0.yaml
+++ b/releasenotes/notes/update-ubuntu-jammy-zed-kolla-containers-0774af3c590b89d0.yaml
@@ -1,0 +1,4 @@
+---
+upgrade:
+  - |
+    Update Ubuntu Jammy Zed Kolla container tags.


### PR DESCRIPTION
Tested during Ubuntu jammy Yoga to Zed migration with tempest. No alert was fired at Prometheus.