### PR TITLE
Zed: Update to Rocky 9.3 based kolla images

### DIFF
--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -12,30 +12,25 @@ kolla_base_distro: "{% raw %}{{ ansible_facts.distribution | lower }}{% endraw %
 
 kayobe_image_tags:
   openstack:
-    rocky: zed-rocky-9-20230921T153510
+    rocky: zed-rocky-9-20240202T105829
     ubuntu: zed-ubuntu-jammy-20230921T153510
   bifrost:
-    rocky: zed-rocky-9-20230927T142529
     ubuntu: zed-ubuntu-jammy-20230927T154443
   ovn:
-    rocky: zed-rocky-9-20230925T132313
     ubuntu: zed-ubuntu-jammy-20230821T155947
   cloudkitty:
-    rocky: zed-rocky-9-20231114T124701
     ubuntu: zed-ubuntu-jammy-20231114T124701
   neutron:
-    rocky: zed-rocky-9-20231115T094053
     ubuntu: zed-ubuntu-jammy-20231115T094053
   opensearch:
-    rocky: zed-rocky-9-20231214T095452
     ubuntu: zed-ubuntu-jammy-20231214T095452
 
 openstack_tag: "{% raw %}{{ kayobe_image_tags['openstack'][kolla_base_distro] }}{% endraw %}"
-bifrost_tag: "{% raw %}{{ kayobe_image_tags['bifrost'][kolla_base_distro] }}{% endraw %}"
-ovn_tag: "{% raw %}{{ kayobe_image_tags['ovn'][kolla_base_distro] }}{% endraw %}"
-cloudkitty_tag: "{% raw %}{{ kayobe_image_tags['cloudkitty'][kolla_base_distro] }}{% endraw %}"
-neutron_tag: "{% raw %}{{ kayobe_image_tags['neutron'][kolla_base_distro] }}{% endraw %}"
-opensearch_tag: "{% raw %}{{ kayobe_image_tags['opensearch'][kolla_base_distro] }}{% endraw %}"
+bifrost_tag: "{% raw %}{{ kayobe_image_tags['bifrost'][kolla_base_distro] | default(openstack_tag) }}{% endraw %}"
+ovn_tag: "{% raw %}{{ kayobe_image_tags['ovn'][kolla_base_distro] | default(openstack_tag) }}{% endraw %}"
+cloudkitty_tag: "{% raw %}{{ kayobe_image_tags['cloudkitty'][kolla_base_distro] | default(openstack_tag) }}{% endraw %}"
+neutron_tag: "{% raw %}{{ kayobe_image_tags['neutron'][kolla_base_distro] | default(openstack_tag) }}{% endraw %}"
+opensearch_tag: "{% raw %}{{ kayobe_image_tags['opensearch'][kolla_base_distro] | default(openstack_tag) }}{% endraw %}"
 
 om_enable_rabbitmq_high_availability: true
 

--- a/releasenotes/notes/kolla-rocky9.3-images-a3ff235485093191.yaml
+++ b/releasenotes/notes/kolla-rocky9.3-images-a3ff235485093191.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Rocky images have been rebuilt and are now based on Rocky 9.3.


### PR DESCRIPTION
These have been rebuilt using Rocky 9.3 snapshots.

Builds:

neutron: https://github.com/stackhpc/stackhpc-kayobe-config/actions/runs/7757168800
others: https://github.com/stackhpc/stackhpc-kayobe-config/actions/runs/7754948585