### PR TITLE
Fix issue with pulp sync

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -74,6 +74,8 @@ kolla_ansible_source_version: "{{ stackhpc_kolla_ansible_source_version }}"
 # Default is kolla_base_distro_version_default_map[kolla_base_distro].
 #kolla_base_distro_version:
 
+kolla_base_distro_and_version: "{{ kolla_base_distro }}-{{ kolla_base_distro_version }}"
+
 # URL of docker registry to use for Kolla images. Default is not set, in which
 # case Quay.io will be used.
 #kolla_docker_registry:

--- a/etc/kayobe/pulp.yml
+++ b/etc/kayobe/pulp.yml
@@ -565,7 +565,7 @@ stackhpc_pulp_distribution_container_kolla_common:
 stackhpc_pulp_distribution_container_kolla: >-
   {%- set distributions = [] -%}
   {%- for image in stackhpc_pulp_images_kolla_filtered -%}
-  {%- if image not in stackhpc_kolla_unbuildable_images[kolla_base_distro]-%}
+  {%- if image not in stackhpc_kolla_unbuildable_images[kolla_base_distro_and_version]-%}
   {%- set image_repo = kolla_docker_namespace ~ "/" ~ image -%}
   {%- set distribution = {"name": image_repo, "repository": image_repo, "base_path": image_repo} -%}
   {%- set _ = distributions.append(stackhpc_pulp_distribution_container_kolla_common | combine(distribution)) -%}

--- a/etc/kayobe/pulp.yml
+++ b/etc/kayobe/pulp.yml
@@ -548,7 +548,7 @@ stackhpc_pulp_repository_container_repos_kolla_common:
 stackhpc_pulp_repository_container_repos_kolla: >-
   {%- set repos = [] -%}
   {%- for image in stackhpc_pulp_images_kolla_filtered -%}
-  {%- if image not in stackhpc_kolla_unbuildable_images[kolla_base_distro]-%}
+  {%- if image not in stackhpc_kolla_unbuildable_images[kolla_base_distro_and_version]-%}
   {%- set image_repo = kolla_docker_namespace ~ "/" ~ image -%}
   {%- set repo = {"name": image_repo} -%}
   {%- set _ = repos.append(stackhpc_pulp_repository_container_repos_kolla_common | combine(repo)) -%}


### PR DESCRIPTION
```
TASK [stackhpc.pulp.pulp_repository : include_tasks] ************************************************************************************************************************
Friday 02 February 2024  18:54:16 +0100 (0:00:00.189)       0:00:00.189 *******
fatal: [localhost]: FAILED! =>
  msg: |-
    The conditional check 'pulp_repository_container_repos | length > 0' failed. The error was: error while evaluating conditional (pulp_repository_container_repos | length
> 0): {{ stackhpc_pulp_repository_container_repos }}: {{ (stackhpc_pulp_repository_container_repos_kolla +
        stackhpc_pulp_repository_container_repos_ceph +
        stackhpc_pulp_repository_container_repos_hashicorp) | selectattr('required') }}: {%- set repos = [] -%} {%- for image in stackhpc_pulp_images_kolla_filtered -%} {%-
if image not in stackhpc_kolla_unbuildable_images[kolla_base_distro]-%} {%- set image_repo = kolla_docker_namespace ~ "/" ~ image -%} {%- set repo = {"name": image_repo} -%}
 {%- set _ = repos.append(stackhpc_pulp_repository_container_repos_kolla_common | combine(repo)) -%} {%- endif -%} {%- endfor -%} {{ repos }}: 'dict object' has no attribute
 'rocky'

    The error appears to be in '/home/stack/kayobe-env-zed/src/kayobe-config/etc/kayobe/ansible/collections/ansible_collections/stackhpc/pulp/roles/pulp_repository/tasks/mai
n.yml': line 2, column 3, but may
    be elsewhere in the file depending on the exact syntax problem.

    The offending line appears to be:

    ---
    - include_tasks: container.yml
      ^ here
```