### PR TITLE
Ubuntu Jammy 2023.1 kolla image upgrade

### DIFF
--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -12,4 +12,3 @@ kolla_image_tags:
     rocky-9: 2023.1-rocky-9-20240205T162323
   neutron:
     rocky-9: 2023.1-rocky-9-20240202T145927
-    ubuntu-jammy: 2023.1-ubuntu-jammy-20231220T222020

--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -5,23 +5,11 @@
 kolla_image_tags:
   openstack:
     rocky-9: 2023.1-rocky-9-20240202T105928
-    ubuntu-jammy: 2023.1-ubuntu-jammy-20231011T200357
-  bifrost:
-    ubuntu-jammy: 2023.1-ubuntu-jammy-20231228T140806
-  cloudkitty:
-    ubuntu-jammy: 2023.1-ubuntu-jammy-20231115T110235
+    ubuntu-jammy: 2023.1-ubuntu-jammy-20240129T151608
   haproxy_ssh:
-    ubuntu-jammy: 2023.1-ubuntu-jammy-20240104T071640
     rocky-9: 2023.1-rocky-9-20240205T162323
   letsencrypt:
-    ubuntu-jammy: 2023.1-ubuntu-jammy-20240104T071640
     rocky-9: 2023.1-rocky-9-20240205T162323
   neutron:
     rocky-9: 2023.1-rocky-9-20240202T145927
     ubuntu-jammy: 2023.1-ubuntu-jammy-20231220T222020
-  nova:
-    ubuntu-jammy: 2023.1-ubuntu-jammy-20231220T222020
-  octavia:
-    ubuntu-jammy: 2023.1-ubuntu-jammy-20231220T222020
-  opensearch:
-    ubuntu-jammy: 2023.1-ubuntu-jammy-20231214T151917

--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -8,8 +8,10 @@ kolla_image_tags:
     ubuntu-jammy: 2023.1-ubuntu-jammy-20240129T151608
   haproxy_ssh:
     rocky-9: 2023.1-rocky-9-20240205T162323
+    ubuntu-jammy: 2023.1-ubuntu-jammy-20240221T133905
   letsencrypt:
     rocky-9: 2023.1-rocky-9-20240205T162323
+    ubuntu-jammy: 2023.1-ubuntu-jammy-20240221T133905
   neutron:
     rocky-9: 2023.1-rocky-9-20240202T145927
     ubuntu-jammy: 2023.1-ubuntu-jammy-20240221T103817

--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -12,3 +12,4 @@ kolla_image_tags:
     rocky-9: 2023.1-rocky-9-20240205T162323
   neutron:
     rocky-9: 2023.1-rocky-9-20240202T145927
+    ubuntu-jammy: 2023.1-ubuntu-jammy-20240221T103817


### PR DESCRIPTION
OVS images are not included in this new tag `2023.1-ubuntu-jammy-20240129T151608`
Due to the issue where not all images can be built at the same time. (See https://github.com/stackhpc/kayobe/pull/239)