### PR TITLE
Update certificate path for os_capacity haproxy

### DIFF
--- a/etc/kayobe/kolla/config/haproxy/services.d/os_capacity.cfg
+++ b/etc/kayobe/kolla/config/haproxy/services.d/os_capacity.cfg
@@ -7,7 +7,7 @@ frontend os_capacity_frontend
     option forwardfor
     http-request set-header X-Forwarded-Proto https if { ssl_fc }
 {% if kolla_enable_tls_internal | bool %}
-    bind {{ kolla_internal_vip_address }}:9090 ssl crt /etc/haproxy/haproxy-internal.pem
+    bind {{ kolla_internal_vip_address }}:9090 ssl crt /etc/haproxy/certificates/haproxy-internal.pem
 {% else %}
     bind {{ kolla_internal_vip_address }}:9090
 {% endif %}


### PR DESCRIPTION
Update certificate path for os_capacity haproxy configuration as per this backported change to Antelope:

https://github.com/stackhpc/kolla-ansible/commit/46933f3e80ea1c3e762dc5e1f47debe611c18174