### PR TITLE
Enable persistent journal in Rocky

### DIFF
--- a/etc/kayobe/ansible/rsyslog.yml
+++ b/etc/kayobe/ansible/rsyslog.yml
@@ -11,26 +11,26 @@
   become: yes
 
   tasks:
-   - name: Ensure rsyslog is installed
-     package:
+  - name: Ensure rsyslog is installed
+    package:
       name: rsyslog
       state: present
 
-   - name: Ensure rsyslog is started and enabled
-     systemd:
+  - name: Ensure rsyslog is started and enabled
+    systemd:
       state: started
       enabled: yes
       name: rsyslog
 
-   - name: Update rsyslog configuration
-     lineinfile:
+  - name: Update rsyslog configuration
+    lineinfile:
       path: /etc/rsyslog.conf
       insertafter: "^#*.* @@remote-host:514"
       line: "*.* @{{ internal_net_name | net_ip }}:5140"
-     register: rsyslog_config
+    register: rsyslog_config
 
-   - name: Restart rsyslog
-     systemd:
+  - name: Restart rsyslog
+    systemd:
       state: restarted
       name: rsyslog
-     when: rsyslog_config.changed
+    when: rsyslog_config.changed

--- a/etc/kayobe/ansible/rsyslog.yml
+++ b/etc/kayobe/ansible/rsyslog.yml
@@ -11,26 +11,41 @@
   become: yes
 
   tasks:
-  - name: Ensure rsyslog is installed
-    package:
-      name: rsyslog
-      state: present
+    - name: Ensure rsyslog is installed
+      package:
+        name: rsyslog
+        state: present
 
-  - name: Ensure rsyslog is started and enabled
-    systemd:
-      state: started
-      enabled: yes
-      name: rsyslog
+    - name: Ensure rsyslog is started and enabled
+      systemd:
+        state: started
+        enabled: yes
+        name: rsyslog
 
-  - name: Update rsyslog configuration
-    lineinfile:
-      path: /etc/rsyslog.conf
-      insertafter: "^#*.* @@remote-host:514"
-      line: "*.* @{{ internal_net_name | net_ip }}:5140"
-    register: rsyslog_config
+    - name: Update rsyslog configuration
+      lineinfile:
+        path: /etc/rsyslog.conf
+        insertafter: "^#*.* @@remote-host:514"
+        line: "*.* @{{ internal_net_name | net_ip }}:5140"
+      register: rsyslog_config
 
-  - name: Restart rsyslog
-    systemd:
-      state: restarted
-      name: rsyslog
-    when: rsyslog_config.changed
+    - name: Restart rsyslog
+      systemd:
+        state: restarted
+        name: rsyslog
+      when: rsyslog_config.changed
+
+    - name: create /var/log/journal for Rocky
+      become: true
+      file:
+        path: /var/log/journal
+        owner: "root"
+        group: "root"
+        mode: 0755
+        state: directory
+      when: ansible_facts.os_family == "RedHat"
+
+    - name: flush journal to disk
+      become: true
+      command: journalctl --flush
+      when: ansible_facts.os_family == "RedHat"

--- a/releasenotes/notes/add-rocky-persistent-journal-e36165e543f2fba2.yaml
+++ b/releasenotes/notes/add-rocky-persistent-journal-e36165e543f2fba2.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Enables a persistent systemd journal support for Rocky in custom rsyslog
+    playbook. This introduces the same behaviour as in Ubuntu's defaults.


### PR DESCRIPTION
This is a quick win to match Ubuntu's default behaviour - system's journal always persisted to disk and available after reboots.