### PR TITLE
Override kolla_base_distro_version

### DIFF
--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -10,6 +10,10 @@ enable_docker_repo: "{% raw %}{{ 'overcloud' not in group_names }}{% endraw %}"
 # This is necessary for os migrations where mixed clouds might be deployed
 kolla_base_distro: "{% raw %}{{ ansible_facts.distribution | lower }}{% endraw %}"
 
+# Use facts so this is determined correctly when the control host OS differs
+# from os_distribuition.
+kolla_base_distro_version: "{% raw %}{{ ansible_facts.distribution_major_version }}{% raw %}"
+
 # Convenience variable for base distro and version string.
 kolla_base_distro_and_version: "{% raw %}{{ kolla_base_distro }}-{{ kolla_base_distro_version }}{% endraw %}"
 

--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -12,7 +12,7 @@ kolla_base_distro: "{% raw %}{{ ansible_facts.distribution | lower }}{% endraw %
 
 # Use facts so this is determined correctly when the control host OS differs
 # from os_distribuition.
-kolla_base_distro_version: "{% raw %}{{ ansible_facts.distribution_major_version }}{% raw %}"
+kolla_base_distro_version: "{% raw %}{{ ansible_facts.distribution_major_version }}{% endraw %}"
 
 # Convenience variable for base distro and version string.
 kolla_base_distro_and_version: "{% raw %}{{ kolla_base_distro }}-{{ kolla_base_distro_version }}{% endraw %}"

--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -12,7 +12,7 @@ kolla_base_distro: "{% raw %}{{ ansible_facts.distribution | lower }}{% endraw %
 
 # Use facts so this is determined correctly when the control host OS differs
 # from os_distribuition.
-kolla_base_distro_version: "{% raw %}{{ ansible_facts.distribution_major_version }}{% endraw %}"
+kolla_base_distro_version: "{% raw %}{{ kolla_base_distro_version_default_map[kolla_base_distro] }}{% endraw %}"
 
 # Convenience variable for base distro and version string.
 kolla_base_distro_and_version: "{% raw %}{{ kolla_base_distro }}-{{ kolla_base_distro_version }}{% endraw %}"


### PR DESCRIPTION
When running the kayobe-automation CI on a Zed/Antelope cloud running Ubuntu host images, these variable overrides cause the kolla tags to template incorrectly. For example, a Jammy host gets ``kolla_base_distro_and_version = rocky-jammy``.

Given we will not be performing any host OS migrations on Zed (or Antelope), we can remove these overrides and use the default values based on ``os_distribution``.

Bug explanation:

These variables end up with the following values, meaning the CI picks up rocky but keeps jammy.

```
kolla_base_distro: '{{ ansible_facts.distribution | lower }}'
kolla_base_distro_and_version: '{{ kolla_base_distro }}-{{ kolla_base_distro_version}}'
kolla_base_distro_version: jammy
```

This is because the variables are first templated under the Kayobe group_vars based on os_distribution, so the version maps to jammy. ``kayobe/ansible/inventory/group/vars/all/kolla``

```
kolla_base_distro: "{{ os_distribution }}"

kolla_base_distro_version_default_map: {
  "centos": "stream9",
  "debian": "bullseye",
  "rocky": "9",
  "ubuntu": "jammy",
}

kolla_base_distro_version: "{{ kolla_base_distro_version_default_map[kolla_base_distro] }}"
```

Then, the base distro and the final variable are overwritten in kolla globals kayobe-config/etc/kayobe/kolla/globals.yml

```
kolla_base_distro: "{% raw %}{{ ansible_facts.distribution | lower }}{% endraw %}"

kolla_base_distro_and_version: "{% raw %}{{ kolla_base_distro }}-{{ kolla_base_distro_version }}{% endraw %}"
```