### PR TITLE
Bump docker build and push action to v5

### DIFF
--- a/.github/workflows/stackhpc-build-kayobe-image.yml
+++ b/.github/workflows/stackhpc-build-kayobe-image.yml
@@ -81,7 +81,7 @@ jobs:
       # Setting KAYOBE_USER_UID and KAYOBE_USER_GID to 1001 to match docker's defaults
       # so that docker can run as a privileged user within the Kayobe image.
       - name: Build and push Docker image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           file: ./.automation/docker/kayobe/Dockerfile
           context: .


### PR DESCRIPTION
Yet another actions bump for node js. See https://github.com/stackhpc/stackhpc-kayobe-config/actions/runs/7846380764?pr=926