### PR TITLE
Bump stackhpc.kayobe_workflows to version 1.0.3

### DIFF
--- a/etc/kayobe/ansible/requirements.yml
+++ b/etc/kayobe/ansible/requirements.yml
@@ -11,7 +11,7 @@ collections:
   - name: stackhpc.hashicorp
     version: 2.4.0
   - name: stackhpc.kayobe_workflows
-    version: 1.0.2
+    version: 1.0.3
 roles:
   - src: stackhpc.vxlan
   - name: ansible-lockdown.rhel8_cis


### PR DESCRIPTION
We hit this error in a control host bootstrap otherwise.

```
ERROR! Failed to resolve the requested dependencies map. Could not satisfy the following requirements:
* stackhpc.kayobe_workflows:1.0.2 (direct request)
* stackhpc.kayobe_workflows:1.0.3 (dependency of "virtual collection Git repo")
```