### PR TITLE
CI: Fail aio job when Terraform reaches max attempts

### DIFF
--- a/.github/workflows/stackhpc-all-in-one.yml
+++ b/.github/workflows/stackhpc-all-in-one.yml
@@ -158,13 +158,15 @@ jobs:
           for attempt in $(seq 5); do
               if terraform apply -auto-approve; then
                   echo "Created infrastructure on attempt $attempt"
-                  break
+                  exit 0
               fi
               echo "Failed to create infrastructure on attempt $attempt"
               sleep 10
               terraform destroy -auto-approve
               sleep 60
           done
+          echo "Failed to create infrastructure after $attempt attempts"
+          exit 1
         working-directory: ${{ github.workspace }}/terraform/aio
         env:
           OS_CLOUD: ${{ inputs.OS_CLOUD }}


### PR DESCRIPTION
Previously the script exited 0 at the end of the loop, then failed in a later step.
