### PR TITLE
CI: Reduce aio flavor to en1.medium (8G)

### DIFF
--- a/.github/workflows/stackhpc-all-in-one.yml
+++ b/.github/workflows/stackhpc-all-in-one.yml
@@ -38,7 +38,7 @@ on:
       vm_flavor:
         description: Flavor for the all-in-one VM
         type: string
-        default: en1.large
+        default: en1.medium
       vm_network:
         description: Network for the all-in-one VM
         type: string

--- a/etc/kayobe/environments/ci-aio/kolla/globals.yml
+++ b/etc/kayobe/environments/ci-aio/kolla/globals.yml
@@ -13,8 +13,8 @@ docker_yum_baseurl: "{{ stackhpc_repo_docker_url }}"
 docker_yum_gpgkey: "https://download.docker.com/linux/centos/gpg"
 
 # Elasticsearch / OpenSearch memory tuning
-es_heap_size: 1g
-opensearch_heap_size: 1g
+es_heap_size: 200m
+opensearch_heap_size: 200m
 
 # Increase Grafana timeout
 grafana_start_first_node_retries: 20

--- a/etc/kayobe/environments/ci-aio/stackhpc-ci.yml
+++ b/etc/kayobe/environments/ci-aio/stackhpc-ci.yml
@@ -5,6 +5,9 @@
 # Docker namespace to use for Kolla images. Default is 'kolla'.
 kolla_docker_namespace: stackhpc-dev
 
+# Disable some services to reduce memory footprint.
+kolla_enable_heat: false
+
 ###############################################################################
 # Network configuration.
 


### PR DESCRIPTION
- Reduce Elasticsearch/OpenSearch heap size to 200m in ci-aio env
- Disable Heat in ci-aio env
- Reduce aio flavor to en1.medium
