### PR TITLE
Bump Magnum

### DIFF
--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -19,6 +19,10 @@ kayobe_image_tags:
     centos: yoga-20231107T165648
     rocky: yoga-20231218T141822
     ubuntu: yoga-20231107T165648
+  magnum:
+    centos: yoga-20240214T151004
+    rocky: yoga-20240214T151004
+    ubuntu: yoga-20240214T151004
   neutron:
     centos: yoga-20231114T125927
     rocky: yoga-20240105T120257


### PR DESCRIPTION
Bump magnum_tag - support for k8s 1.27 fc38 Calico installed with Helm: Tigera Operator