### PR TITLE
Stop warning about invalid group name characters

### DIFF
--- a/etc/kayobe/ansible.cfg
+++ b/etc/kayobe/ansible.cfg
@@ -8,6 +8,8 @@ bin_ansible_callbacks = True
 inject_facts_as_vars = False
 # Add timing information to output
 callbacks_enabled = ansible.posix.profile_tasks
+# Silence warning about invalid characters found in group names
+force_valid_group_names = ignore
 
 [ssh_connection]
 pipelining = True


### PR DESCRIPTION
This should silence the following Ansible warning [1]:

    [WARNING]: Invalid characters were found in group names but not replaced, use -vvvv to see details

[1] https://docs.ansible.com/ansible/latest/reference_appendices/config.html#transform-invalid-group-chars