### PR TITLE
Fix growroot playbook for NVMe devices

### DIFF
--- a/etc/kayobe/ansible/growroot.yml
+++ b/etc/kayobe/ansible/growroot.yml
@@ -77,7 +77,7 @@
           vars:
             pv: "{{ pvs.stdout | from_json }}"
             disk_tmp: "{{ pv.report[0].pv[0].pv_name[:-1] }}"
-            disk: "{{ disk_tmp[:-1] if disk_tmp[-1] == 'p' and disk_tmp[:4] == 'nvme' else disk_tmp }}"
+            disk: "{{ disk_tmp[:-1] if disk_tmp[-1] == 'p' and disk_tmp[:9] == '/dev/nvme' else disk_tmp }}"
             part_num: "{{ pv.report[0].pv[0].pv_name[-1] }}"
           become: true
           failed_when: "growpart.rc != 0 and 'NOCHANGE' not in growpart.stdout"


### PR DESCRIPTION
The `disk_tmp` variable uses a device path rather than a device name.