### PR TITLE
bumping ansible vault

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 kayobe@git+https://github.com/stackhpc/kayobe@stackhpc/yoga
 ansible-modules-hashivault@git+https://github.com/stackhpc/ansible-modules-hashivault@stackhpc;python_version < "3.8"
-ansible-modules-hashivault;python_version >= "3.8"
+ansible-modules-hashivault@git+https://github.com/stackhpc/ansible-modules-hashivault@stackhpc-py39;python_version >= "3.8"
 jmespath


### PR DESCRIPTION
Recently I have found bug in ansible-modules-hashivault. 

More details regarding bug here: https://stackhpc.atlassian.net/browse/INFRA-572.

I have created branch which is synchronised with latest upstream version and have required patch: https://github.com/stackhpc/ansible-modules-hashivault/tree/stackhpc-py39 .

This PR aims to use version from our repo until upstream PR won't be merged. 