### PR TITLE
Add network group to AIO inventory

### DIFF
--- a/etc/kayobe/environments/ci-aio/inventory/hosts
+++ b/etc/kayobe/environments/ci-aio/inventory/hosts
@@ -7,3 +7,6 @@ controllers
 
 [monitoring:children]
 controllers
+
+[network:children]
+controllers


### PR DESCRIPTION
Add network group to AIO inventory.

Address CI failures in https://github.com/stackhpc/stackhpc-kayobe-config/actions/runs/7988671833/job/21814662568?pr=829

