### PR TITLE
Make ci-builder to build both OVS and OVN images on container image build

### DIFF
--- a/.github/workflows/stackhpc-container-image-build.yml
+++ b/.github/workflows/stackhpc-container-image-build.yml
@@ -171,9 +171,6 @@ jobs:
           if ${{ inputs.push }} == 'true'; then
             args="$args --push"
           fi
-          if [[ "${{ github.event.inputs.regexes }}" == "" ]]; then
-            args="$args -e kolla_build_neutron_ovs=true"
-          fi
           source venvs/kayobe/bin/activate &&
           source src/kayobe-config/kayobe-env --environment ci-builder &&
           kayobe overcloud container image build $args

--- a/.github/workflows/stackhpc-container-image-build.yml
+++ b/.github/workflows/stackhpc-container-image-build.yml
@@ -171,6 +171,9 @@ jobs:
           if ${{ inputs.push }} == 'true'; then
             args="$args --push"
           fi
+          if [[ ${{ github.event.inputs.regexes }} == "" ]]; then
+            args="$args -e kolla_build_neutron_ovs=true"
+          fi
           source venvs/kayobe/bin/activate &&
           source src/kayobe-config/kayobe-env --environment ci-builder &&
           kayobe overcloud container image build $args

--- a/.github/workflows/stackhpc-container-image-build.yml
+++ b/.github/workflows/stackhpc-container-image-build.yml
@@ -171,7 +171,7 @@ jobs:
           if ${{ inputs.push }} == 'true'; then
             args="$args --push"
           fi
-          if [[ ${{ github.event.inputs.regexes }} == "" ]]; then
+          if [[ "${{ github.event.inputs.regexes }}" == "" ]]; then
             args="$args -e kolla_build_neutron_ovs=true"
           fi
           source venvs/kayobe/bin/activate &&

--- a/etc/kayobe/environments/ci-builder/stackhpc-ci.yml
+++ b/etc/kayobe/environments/ci-builder/stackhpc-ci.yml
@@ -29,6 +29,7 @@ kolla_enable_ovn: true
 kolla_enable_prometheus: true
 kolla_enable_redis: true
 kolla_enable_skydive: true
+kolla_build_neutron_ovs: true
 
 ###############################################################################
 # StackHPC configuration.


### PR DESCRIPTION
As upstream kayobe change https://review.opendev.org/c/openstack/kayobe/+/907721 was merged, a condition for using ``kolla_build_neutron_ovs`` was added.
``kolla_build_neutron_ovs`` is set to true for ``kayobe overcloud container image build`` when no regex is given