### PR TITLE
Fix query for top Ceph pools by capacity used

### DIFF
--- a/etc/kayobe/kolla/config/grafana/dashboards/ceph/ceph_pools.json
+++ b/etc/kayobe/kolla/config/grafana/dashboards/ceph/ceph_pools.json
@@ -657,7 +657,7 @@
       ],
       "targets": [
         {
-          "expr": "topk(1,((ceph_pool_stored / (ceph_pool_stored + ceph_pool_max_avail)) * on(pool_id) group_left(name) ceph_pool_metadata))",
+          "expr": "topk($topk,((ceph_pool_stored / (ceph_pool_stored + ceph_pool_max_avail)) * on(pool_id) group_left(name) ceph_pool_metadata))",
           "format": "table",
           "hide": false,
           "instant": true,

--- a/releasenotes/notes/fix-ceph-pools-top-capacity-used-panel-26d495c45f2678c8.yaml
+++ b/releasenotes/notes/fix-ceph-pools-top-capacity-used-panel-26d495c45f2678c8.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixes Grafana panel of top Ceph pools by capacity used. This panel was only
+    showing the most used pool instead of as many pools as configured with the
+    ``$topk`` variable.


### PR DESCRIPTION
This panel was only showing the most used pool instead of as many pools as configured with the ``$topk`` variable.