### PR TITLE
Update HAProxy dashboard and alerts

### DIFF
--- a/etc/kayobe/kolla/config/grafana/dashboards/openstack/haproxy.json
+++ b/etc/kayobe/kolla/config/grafana/dashboards/openstack/haproxy.json
@@ -27,8 +27,7 @@
   "fiscalYearStartMonth": 0,
   "gnetId": 2428,
   "graphTooltip": 1,
-  "id": 92,
-  "iteration": 1658139194737,
+  "id": 27,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -61,7 +60,8 @@
       "decimals": 0,
       "fieldConfig": {
         "defaults": {
-          "links": []
+          "links": [],
+          "unitScale": true
         },
         "overrides": []
       },
@@ -94,7 +94,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.3.1",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -113,19 +113,31 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "count(haproxy_backend_up{backend=~\"$backend\", instance=~\"$host:?[0-9]*\"} == 1)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "count(haproxy_backend_status{state=\"UP\", proxy=~\"$backend\", instance=~\"$host:?[0-9]*\"} == 1)",
           "hide": false,
           "interval": "$interval",
           "intervalFactor": 2,
           "legendFormat": "Backends Up",
+          "range": true,
           "refId": "A",
           "step": 60
         },
         {
-          "expr": "count(haproxy_backend_up{backend=~\"$backend\",instance=~\"$host:?[0-9]*\"} == 0)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "count(haproxy_backend_status{state=\"DOWN\", proxy=~\"$backend\", instance=~\"$host:?[0-9]*\"} == 1)",
           "interval": "$interval",
           "intervalFactor": 2,
           "legendFormat": "Backends Down",
+          "range": true,
           "refId": "B",
           "step": 60
         }
@@ -191,7 +203,8 @@
       "error": false,
       "fieldConfig": {
         "defaults": {
-          "links": []
+          "links": [],
+          "unitScale": true
         },
         "overrides": []
       },
@@ -226,7 +239,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.3.1",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -265,20 +278,32 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(haproxy_frontend_http_responses_total{frontend=~\"$frontend\",code=~\"$code\",instance=~\"$host:?[0-9]*\"}[5m])) by (code)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(irate(haproxy_frontend_http_responses_total{proxy=~\"$frontend\",code=~\"$code\",instance=~\"$host:?[0-9]*\"}[5m])) by (code)",
           "interval": "$interval",
           "intervalFactor": 1,
           "legendFormat": "Frontend {{ code }}",
           "metric": "",
+          "range": true,
           "refId": "A",
           "step": 30
         },
         {
-          "expr": "sum(irate(haproxy_backend_http_responses_total{backend=~\"$backend\",code=~\"$code\",instance=~\"$host:?[0-9]*\"}[5m])) by (code)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(irate(haproxy_backend_http_responses_total{proxy=~\"$backend\",code=~\"$code\",instance=~\"$host:?[0-9]*\"}[5m])) by (code)",
           "interval": "$interval",
           "intervalFactor": 1,
           "legendFormat": "Backend {{ code }}",
           "metric": "",
+          "range": true,
           "refId": "B",
           "step": 30
         }
@@ -330,7 +355,8 @@
       "error": false,
       "fieldConfig": {
         "defaults": {
-          "links": []
+          "links": [],
+          "unitScale": true
         },
         "overrides": []
       },
@@ -365,7 +391,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.3.1",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -380,33 +406,57 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(haproxy_frontend_bytes_in_total{frontend=~\"$frontend\",instance=~\"$host:?[0-9]*\"}[5m])*8) by (instance)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(irate(haproxy_frontend_bytes_in_total{proxy=~\"$frontend\",instance=~\"$host:?[0-9]*\"}[5m])*8) by (instance)",
           "interval": "$interval",
           "intervalFactor": 1,
           "legendFormat": "IN Front",
           "metric": "",
+          "range": true,
           "refId": "A",
           "step": 30
         },
         {
-          "expr": "sum(irate(haproxy_frontend_bytes_out_total{frontend=~\"$frontend\",instance=~\"$host:?[0-9]*\"}[5m])*8) by (instance)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(irate(haproxy_frontend_bytes_out_total{proxy=~\"$frontend\",instance=~\"$host:?[0-9]*\"}[5m])*8) by (instance)",
           "interval": "$interval",
           "intervalFactor": 2,
           "legendFormat": "OUT Front",
+          "range": true,
           "refId": "B",
           "step": 60
         },
         {
-          "expr": "sum(irate(haproxy_backend_bytes_in_total{backend=~\"$backend\",instance=~\"$host:?[0-9]*\"}[5m])*8) by (instance)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(irate(haproxy_backend_bytes_in_total{proxy=~\"$backend\",instance=~\"$host:?[0-9]*\"}[5m])*8) by (instance)",
           "intervalFactor": 2,
           "legendFormat": "IN Back",
+          "range": true,
           "refId": "C",
           "step": 240
         },
         {
-          "expr": "sum(irate(haproxy_backend_bytes_out_total{backend=~\"$backend\",instance=~\"$host:?[0-9]*\"}[5m])*8) by (instance)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(irate(haproxy_backend_bytes_out_total{proxy=~\"$backend\",instance=~\"$host:?[0-9]*\"}[5m])*8) by (instance)",
           "intervalFactor": 2,
           "legendFormat": "OUT Back",
+          "range": true,
           "refId": "D",
           "step": 240
         }
@@ -457,7 +507,8 @@
       "error": false,
       "fieldConfig": {
         "defaults": {
-          "links": []
+          "links": [],
+          "unitScale": true
         },
         "overrides": []
       },
@@ -492,7 +543,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.3.1",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -507,29 +558,47 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(haproxy_frontend_connections_total{frontend=~\"$frontend\",instance=~\"$host:?[0-9]*\"}[5m])) by (instance)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(irate(haproxy_frontend_connections_total{proxy=~\"$frontend\",instance=~\"$host:?[0-9]*\"}[5m])) by (instance)",
           "interval": "$interval",
           "intervalFactor": 1,
           "legendFormat": "Front",
           "metric": "",
+          "range": true,
           "refId": "A",
           "step": 30
         },
         {
-          "expr": "sum(irate(haproxy_backend_connections_total{backend=~\"$backend\",instance=~\"$host:?[0-9]*\"}[5m])) by (instance)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(irate(haproxy_backend_connections_total{proxy=~\"$backend\",instance=~\"$host:?[0-9]*\"}[5m])) by (instance)",
           "interval": "$interval",
           "intervalFactor": 1,
           "legendFormat": "Back",
           "metric": "",
+          "range": true,
           "refId": "B",
           "step": 30
         },
         {
-          "expr": "sum(irate(haproxy_backend_connection_errors_total{backend=~\"$backend\",instance=~\"$host:?[0-9]*\"}[5m])) by (instance)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(irate(haproxy_backend_connection_errors_total{proxy=~\"$backend\",instance=~\"$host:?[0-9]*\"}[5m])) by (instance)",
           "interval": "$interval",
           "intervalFactor": 1,
           "legendFormat": "Back errors",
           "metric": "",
+          "range": true,
           "refId": "C",
           "step": 30
         }
@@ -580,7 +649,8 @@
       "error": false,
       "fieldConfig": {
         "defaults": {
-          "links": []
+          "links": [],
+          "unitScale": true
         },
         "overrides": []
       },
@@ -615,7 +685,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.3.1",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -634,60 +704,102 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(haproxy_frontend_http_requests_total{frontend=~\"$frontend\",instance=~\"$host:?[0-9]*\"}[5m])) by (instance)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(irate(haproxy_frontend_http_requests_total{proxy=~\"$frontend\",instance=~\"$host:?[0-9]*\"}[5m])) by (instance)",
           "interval": "$interval",
           "intervalFactor": 1,
           "legendFormat": "Requests",
           "metric": "",
+          "range": true,
           "refId": "A",
           "step": 30
         },
         {
-          "expr": "sum(irate(haproxy_backend_response_errors_total{backend=~\"$backend\",instance=~\"$host:?[0-9]*\"}[5m])) by (instance)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(irate(haproxy_backend_response_errors_total{proxy=~\"$backend\",instance=~\"$host:?[0-9]*\"}[5m])) by (instance)",
           "interval": "$interval",
           "intervalFactor": 2,
           "legendFormat": "Response errors",
+          "range": true,
           "refId": "B",
           "step": 60
         },
         {
-          "expr": "sum(irate(haproxy_frontend_request_errors_total{frontend=~\"$frontend\",instance=~\"$host:?[0-9]*\"}[5m])) by (instance)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(irate(haproxy_frontend_request_errors_total{proxy=~\"$frontend\",instance=~\"$host:?[0-9]*\"}[5m])) by (instance)",
           "interval": "$interval",
           "intervalFactor": 1,
           "legendFormat": "Requests errors",
           "metric": "",
+          "range": true,
           "refId": "C",
           "step": 30
         },
         {
-          "expr": "sum(irate(haproxy_backend_redispatch_warnings_total{backend=~\"$backend\",instance=~\"$host:?[0-9]*\"}[5m])) by (instance)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(irate(haproxy_backend_redispatch_warnings_total{proxy=~\"$backend\",instance=~\"$host:?[0-9]*\"}[5m])) by (instance)",
           "interval": "$interval",
           "intervalFactor": 2,
           "legendFormat": "Backend redispatch",
+          "range": true,
           "refId": "D",
           "step": 60
         },
         {
-          "expr": "sum(irate(haproxy_backend_retry_warnings_total{backend=~\"$backend\",instance=~\"$host:?[0-9]*\"}[5m])) by (instance)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(irate(haproxy_backend_retry_warnings_total{proxy=~\"$backend\",instance=~\"$host:?[0-9]*\"}[5m])) by (instance)",
           "interval": "$interval",
           "intervalFactor": 2,
           "legendFormat": "Backend retry",
+          "range": true,
           "refId": "E",
           "step": 60
         },
         {
-          "expr": "sum(irate(haproxy_frontend_requests_denied_total{frontend=~\"$frontend\",instance=~\"$host:?[0-9]*\"}[5m])) by (instance)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(irate(haproxy_frontend_requests_denied_total{proxy=~\"$frontend\",instance=~\"$host:?[0-9]*\"}[5m])) by (instance)",
           "interval": "$interval",
           "intervalFactor": 2,
           "legendFormat": "Request denied",
+          "range": true,
           "refId": "F",
           "step": 60
         },
         {
-          "expr": "sum(haproxy_backend_current_queue{backend=~\"$backend\",instance=~\"$host:?[0-9]*\"}) by (instance)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(haproxy_backend_current_queue{backend=~\"$backend\",proxy=~\"$host:?[0-9]*\"}) by (instance)",
           "interval": "$interval",
           "intervalFactor": 2,
           "legendFormat": "Backend Queued",
+          "range": true,
           "refId": "G",
           "step": 60
         }
@@ -738,7 +850,8 @@
       "error": false,
       "fieldConfig": {
         "defaults": {
-          "links": []
+          "links": [],
+          "unitScale": true
         },
         "overrides": []
       },
@@ -773,7 +886,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.3.1",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -788,38 +901,62 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(haproxy_frontend_current_sessions{frontend=~\"$frontend\",instance=~\"$host:?[0-9]*\"}) by (instance)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(haproxy_frontend_current_sessions{proxy=~\"$frontend\",instance=~\"$host:?[0-9]*\"}) by (instance)",
           "interval": "$interval",
           "intervalFactor": 1,
           "legendFormat": "Frontend current sessions",
           "metric": "",
+          "range": true,
           "refId": "B",
           "step": 30
         },
         {
-          "expr": "sum(haproxy_frontend_current_session_rate{frontend=~\"$frontend\",instance=~\"$host:?[0-9]*\"}) by (instance)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(haproxy_frontend_current_session_rate{proxy=~\"$frontend\",instance=~\"$host:?[0-9]*\"}) by (instance)",
           "interval": "$interval",
           "intervalFactor": 1,
           "legendFormat": "Frontend current session rate",
           "metric": "",
+          "range": true,
           "refId": "C",
           "step": 30
         },
         {
-          "expr": "sum(haproxy_backend_current_sessions{backend=~\"$backend\",instance=~\"$host:?[0-9]*\"}) by (instance)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(haproxy_backend_current_sessions{proxy=~\"$backend\",instance=~\"$host:?[0-9]*\"}) by (instance)",
           "interval": "$interval",
           "intervalFactor": 1,
           "legendFormat": "Backend current sessions",
           "metric": "",
+          "range": true,
           "refId": "A",
           "step": 30
         },
         {
-          "expr": "sum(haproxy_backend_current_session_rate{backend=~\"$backend\",instance=~\"$host:?[0-9]*\"}) by (instance)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(haproxy_backend_current_session_rate{proxy=~\"$backend\",instance=~\"$host:?[0-9]*\"}) by (instance)",
           "interval": "$interval",
           "intervalFactor": 1,
           "legendFormat": "Backend current session rate",
           "metric": "",
+          "range": true,
           "refId": "D",
           "step": 30
         }
@@ -888,7 +1025,8 @@
       "error": false,
       "fieldConfig": {
         "defaults": {
-          "links": []
+          "links": [],
+          "unitScale": true
         },
         "overrides": []
       },
@@ -925,7 +1063,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.3.1",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -940,19 +1078,31 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(haproxy_backend_bytes_in_total{backend=~\"$backend\",instance=~\"$host:?[0-9]*\"}[5m])*8",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "irate(haproxy_backend_bytes_in_total{proxy=~\"$backend\",instance=~\"$host:?[0-9]*\"}[5m])*8",
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "IN-{{ backend }}",
+          "legendFormat": "IN-{{ proxy }}",
           "metric": "haproxy_backend_",
+          "range": true,
           "refId": "A",
           "step": 30
         },
         {
-          "expr": "irate(haproxy_backend_bytes_out_total{backend=~\"$backend\",instance=~\"$host:?[0-9]*\"}[5m])*8",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "irate(haproxy_backend_bytes_out_total{proxy=~\"$backend\",instance=~\"$host:?[0-9]*\"}[5m])*8",
           "interval": "$interval",
           "intervalFactor": 2,
-          "legendFormat": "OUT-{{ backend }}",
+          "legendFormat": "OUT-{{ proxy }}",
+          "range": true,
           "refId": "B",
           "step": 60
         }
@@ -1004,7 +1154,8 @@
       "error": false,
       "fieldConfig": {
         "defaults": {
-          "links": []
+          "links": [],
+          "unitScale": true
         },
         "overrides": []
       },
@@ -1041,7 +1192,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.3.1",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1056,19 +1207,31 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(haproxy_frontend_bytes_in_total{frontend=~\"$frontend\",instance=~\"$host:?[0-9]*\"}[5m])*8",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "irate(haproxy_frontend_bytes_in_total{proxy=~\"$frontend\",instance=~\"$host:?[0-9]*\"}[5m])*8",
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "IN-{{ frontend }}",
+          "legendFormat": "IN-{{ proxy }}",
           "metric": "",
+          "range": true,
           "refId": "A",
           "step": 30
         },
         {
-          "expr": "irate(haproxy_frontend_bytes_out_total{frontend=~\"$frontend\",instance=~\"$host:?[0-9]*\"}[5m])*8",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "irate(haproxy_frontend_bytes_out_total{proxy=~\"$frontend\",instance=~\"$host:?[0-9]*\"}[5m])*8",
           "interval": "$interval",
           "intervalFactor": 2,
-          "legendFormat": "OUT-{{ frontend }}",
+          "legendFormat": "OUT-{{ proxy }}",
+          "range": true,
           "refId": "B",
           "step": 60
         }
@@ -1137,7 +1300,8 @@
       "error": false,
       "fieldConfig": {
         "defaults": {
-          "links": []
+          "links": [],
+          "unitScale": true
         },
         "overrides": []
       },
@@ -1174,7 +1338,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.3.1",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1189,19 +1353,31 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(haproxy_server_bytes_in_total{backend=~\"$backend\",server=~\"$server\",instance=~\"$host:?[0-9]*\"}[5m])*8",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "irate(haproxy_server_bytes_in_total{proxy=~\"$backend\",server=~\"$server\",instance=~\"$host:?[0-9]*\"}[5m])*8",
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "IN-{{ backend }} / {{ server }}",
+          "legendFormat": "IN-{{ proxy }} / {{ server }}",
           "metric": "",
+          "range": true,
           "refId": "A",
           "step": 30
         },
         {
-          "expr": "irate(haproxy_server_bytes_out_total{backend=~\"$backend\",server=~\"$server\",instance=~\"$host:?[0-9]*\"}[5m])*8",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "irate(haproxy_server_bytes_out_total{proxy=~\"$backend\",server=~\"$server\",instance=~\"$host:?[0-9]*\"}[5m])*8",
           "interval": "$interval",
           "intervalFactor": 2,
-          "legendFormat": "OUT-{{ backend }} / {{ server }}",
+          "legendFormat": "OUT-{{ proxy }} / {{ server }}",
+          "range": true,
           "refId": "B",
           "step": 60
         }
@@ -1269,7 +1445,8 @@
       "error": false,
       "fieldConfig": {
         "defaults": {
-          "links": []
+          "links": [],
+          "unitScale": true
         },
         "overrides": []
       },
@@ -1304,7 +1481,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.3.1",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1319,18 +1496,30 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(haproxy_backend_connections_total{backend=~\"$backend\",instance=~\"$host:?[0-9]*\"}[5m])",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "haproxy_backend_current_sessions{proxy=~\"$backend\",instance=~\"$host:?[0-9]*\"}",
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "{{ backend }}",
+          "legendFormat": "{{ proxy }}",
           "metric": "",
+          "range": true,
           "refId": "B",
           "step": 30
         },
         {
-          "expr": "irate(haproxy_backend_connection_errors_total{backend=~\"$backend\",instance=~\"$host:?[0-9]*\"}[5m])",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "irate(haproxy_backend_connection_errors_total{proxy=~\"$backend\",instance=~\"$host:?[0-9]*\"}[5m])",
           "intervalFactor": 2,
-          "legendFormat": "{{ backend }} Error",
+          "legendFormat": "{{ proxy }} Error",
+          "range": true,
           "refId": "A",
           "step": 240
         }
@@ -1381,7 +1570,8 @@
       "error": false,
       "fieldConfig": {
         "defaults": {
-          "links": []
+          "links": [],
+          "unitScale": true
         },
         "overrides": []
       },
@@ -1416,7 +1606,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.3.1",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1426,11 +1616,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(haproxy_frontend_connections_total{frontend=~\"$frontend\",instance=~\"$host:?[0-9]*\"}[5m])",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "irate(haproxy_frontend_connections_total{proxy=~\"$frontend\",instance=~\"$host:?[0-9]*\"}[5m])",
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "{{ frontend }}",
+          "legendFormat": "{{ proxy }}",
           "metric": "haproxy_backe",
+          "range": true,
           "refId": "B",
           "step": 30
         }
@@ -1499,7 +1695,8 @@
       "error": false,
       "fieldConfig": {
         "defaults": {
-          "links": []
+          "links": [],
+          "unitScale": true
         },
         "overrides": []
       },
@@ -1534,7 +1731,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.3.1",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1544,11 +1741,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(haproxy_backend_max_queue{backend=~\"$backend\",instance=~\"$host:?[0-9]*\"}[5m])",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "irate(haproxy_backend_max_queue{proxy=~\"$backend\",instance=~\"$host:?[0-9]*\"}[5m])",
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "{{ backend }}",
+          "legendFormat": "{{ proxy }}",
           "metric": "",
+          "range": true,
           "refId": "A",
           "step": 30
         }
@@ -1600,7 +1803,8 @@
       "error": false,
       "fieldConfig": {
         "defaults": {
-          "links": []
+          "links": [],
+          "unitScale": true
         },
         "overrides": []
       },
@@ -1635,7 +1839,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.3.1",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1649,12 +1853,14 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
+          "editorMode": "code",
           "exemplar": true,
-          "expr": "haproxy_backend_current_queue{backend=~\"$backend\",instance=~\"$host:?[0-9]*\"}",
+          "expr": "haproxy_backend_current_queue{proxy=~\"$backend\",instance=~\"$host:?[0-9]*\"}",
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "{{ backend }}",
+          "legendFormat": "{{ proxy }}",
           "metric": "haproxy_backend_current_queue",
+          "range": true,
           "refId": "A",
           "step": 30
         }
@@ -1723,7 +1929,8 @@
       "error": false,
       "fieldConfig": {
         "defaults": {
-          "links": []
+          "links": [],
+          "unitScale": true
         },
         "overrides": []
       },
@@ -1760,7 +1967,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.3.1",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1775,26 +1982,44 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(haproxy_backend_redispatch_warnings_total{backend=~\"$backend\", instance=~\"$host:?[0-9]*\"}[5m])",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "irate(haproxy_backend_redispatch_warnings_total{proxy=~\"$backend\", instance=~\"$host:?[0-9]*\"}[5m])",
           "interval": "$interval",
           "intervalFactor": 1,
           "legendFormat": "Redispatch {{ backend }}",
           "metric": "",
+          "range": true,
           "refId": "A",
           "step": 30
         },
         {
-          "expr": "irate(haproxy_backend_retry_warnings_total{backend=~\"$backend\", instance=~\"$host:?[0-9]*\"}[5m])",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "irate(haproxy_backend_retry_warnings_total{proxy=~\"$backend\", instance=~\"$host:?[0-9]*\"}[5m])",
           "interval": "$interval",
           "intervalFactor": 2,
           "legendFormat": "Retry {{ backend }}",
+          "range": true,
           "refId": "B",
           "step": 60
         },
         {
-          "expr": "irate(haproxy_backend_response_errors_total{backend=~\"$backend\", instance=~\"$host:?[0-9]*\"}[5m])",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "irate(haproxy_backend_response_errors_total{proxy=~\"$backend\", instance=~\"$host:?[0-9]*\"}[5m])",
           "intervalFactor": 2,
           "legendFormat": "Error {{ backend }}",
+          "range": true,
           "refId": "C",
           "step": 240
         }
@@ -1845,7 +2070,8 @@
       "error": false,
       "fieldConfig": {
         "defaults": {
-          "links": []
+          "links": [],
+          "unitScale": true
         },
         "overrides": []
       },
@@ -1880,7 +2106,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.3.1",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1899,25 +2125,43 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(haproxy_frontend_http_requests_total{frontend=~\"$frontend\",instance=~\"$host:?[0-9]*\"}[5m])",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "irate(haproxy_frontend_http_requests_total{proxy=~\"$frontend\",instance=~\"$host:?[0-9]*\"}[5m])",
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "{{ frontend }}",
+          "legendFormat": "{{ proxy }}",
           "metric": "",
+          "range": true,
           "refId": "A",
           "step": 30
         },
         {
-          "expr": "irate(haproxy_frontend_request_errors_total{frontend=~\"$frontend\", instance=~\"$host:?[0-9]*\"}[5m])",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "irate(haproxy_frontend_request_errors_total{proxy=~\"$frontend\", instance=~\"$host:?[0-9]*\"}[5m])",
           "intervalFactor": 2,
-          "legendFormat": "{{ frontend }} Error",
+          "legendFormat": "{{ proxy }} Error",
+          "range": true,
           "refId": "B",
           "step": 240
         },
         {
-          "expr": "irate(haproxy_frontend_requests_denied_total{frontend=~\"$frontend\", instance=~\"$host:?[0-9]*\"}[5m])",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "irate(haproxy_frontend_requests_denied_total{proxy=~\"$frontend\", instance=~\"$host:?[0-9]*\"}[5m])",
           "intervalFactor": 2,
-          "legendFormat": "{{ frontend }} Denied",
+          "legendFormat": "{{ proxy }} Denied",
+          "range": true,
           "refId": "C",
           "step": 240
         }
@@ -1983,6 +2227,12 @@
       "description": "",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "unitScale": true
+        },
+        "overrides": []
+      },
       "fill": 2,
       "fillGradient": 0,
       "grid": {},
@@ -2014,7 +2264,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.3.1",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -2024,11 +2274,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(haproxy_backend_http_responses_total{backend=~\"$backend\", code=~\"$code\",instance=~\"$host:?[0-9]*\"}[5m])",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "irate(haproxy_backend_http_responses_total{proxy=~\"$backend\", code=~\"$code\",instance=~\"$host:?[0-9]*\"}[5m])",
           "interval": "$interval",
           "intervalFactor": 1,
           "legendFormat": "{{ code }} {{ backend }}",
           "metric": "",
+          "range": true,
           "refId": "A",
           "step": 30
         }
@@ -2078,6 +2334,12 @@
       "description": "",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "unitScale": true
+        },
+        "overrides": []
+      },
       "fill": 2,
       "fillGradient": 0,
       "grid": {},
@@ -2109,7 +2371,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.3.1",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -2119,11 +2381,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(haproxy_frontend_http_responses_total{frontend=~\"$frontend\", code=~\"$code\",instance=~\"$host:?[0-9]*\"}[5m])",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "irate(haproxy_frontend_http_responses_total{proxy=~\"$frontend\", code=~\"$code\",instance=~\"$host:?[0-9]*\"}[5m])",
           "interval": "$interval",
           "intervalFactor": 1,
           "legendFormat": "{{ code }} {{ frontend }} ",
           "metric": "",
+          "range": true,
           "refId": "A",
           "step": 30
         }
@@ -2190,6 +2458,12 @@
       "description": "",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "unitScale": true
+        },
+        "overrides": []
+      },
       "fill": 2,
       "fillGradient": 0,
       "grid": {},
@@ -2221,7 +2495,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.3.1",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -2231,12 +2505,18 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "haproxy_backend_current_sessions{backend=~\"$backend\",instance=~\"$host:?[0-9]*\"}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "haproxy_backend_current_sessions{proxy=~\"$backend\",instance=~\"$host:?[0-9]*\"}",
           "hide": false,
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "{{ backend }}",
+          "legendFormat": "{{ proxy }}",
           "metric": "",
+          "range": true,
           "refId": "A",
           "step": 30
         }
@@ -2286,6 +2566,12 @@
       "description": "",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "unitScale": true
+        },
+        "overrides": []
+      },
       "fill": 2,
       "fillGradient": 0,
       "grid": {},
@@ -2317,7 +2603,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.3.1",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -2327,12 +2613,18 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "haproxy_frontend_current_sessions{frontend=~\"$frontend\",instance=~\"$host:?[0-9]*\"}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "haproxy_frontend_current_sessions{proxy=~\"$frontend\",instance=~\"$host:?[0-9]*\"}",
           "hide": false,
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "{{ frontend }}",
+          "legendFormat": "{{ proxy }}",
           "metric": "haproxy_backend_current_queue",
+          "range": true,
           "refId": "A",
           "step": 30
         }
@@ -2382,6 +2674,12 @@
       "description": "",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "unitScale": true
+        },
+        "overrides": []
+      },
       "fill": 2,
       "fillGradient": 0,
       "grid": {},
@@ -2413,7 +2711,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.3.1",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -2423,11 +2721,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "haproxy_backend_current_session_rate{backend=~\"$backend\",instance=~\"$host:?[0-9]*\"}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "rate(haproxy_backend_sessions_total{proxy=~\"$backend\",instance=~\"$host:?[0-9]*\"}[$interval])",
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "{{ backend }}",
+          "legendFormat": "{{ proxy }}",
           "metric": "haproxy_backend_current_queue",
+          "range": true,
           "refId": "A",
           "step": 30
         }
@@ -2477,6 +2781,12 @@
       "description": "",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "unitScale": true
+        },
+        "overrides": []
+      },
       "fill": 2,
       "fillGradient": 0,
       "grid": {},
@@ -2508,7 +2818,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.3.1",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -2518,11 +2828,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "haproxy_frontend_current_session_rate{frontend=~\"$frontend\",instance=~\"$host:?[0-9]*\"}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "rate(haproxy_frontend_current_sessions{proxy=~\"$frontend\",instance=~\"$host:?[0-9]*\"}[$interval])",
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "{{ frontend }}",
+          "legendFormat": "{{ proxy }}",
           "metric": "",
+          "range": true,
           "refId": "A",
           "step": 30
         }
@@ -2572,6 +2888,13 @@
       "description": "",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "fieldMinMax": false,
+          "unitScale": true
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "grid": {},
@@ -2587,6 +2910,8 @@
         "alignAsTable": true,
         "avg": true,
         "current": true,
+        "hideEmpty": false,
+        "hideZero": false,
         "max": true,
         "min": true,
         "rightSide": false,
@@ -2603,12 +2928,13 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.3.1",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
       "seriesOverrides": [
         {
+          "$$hashKey": "object:1847",
           "alias": "/.*limit.*/",
           "fill": 0
         }
@@ -2618,19 +2944,31 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "haproxy_backend_max_sessions{backend=~\"$backend\",instance=~\"$host:?[0-9]*\"}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "haproxy_backend_max_sessions{proxy=~\"$backend\",instance=~\"$host:?[0-9]*\"}",
           "hide": false,
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "{{ backend }}",
+          "legendFormat": "{{ proxy }} ",
           "metric": "",
+          "range": true,
           "refId": "A",
           "step": 30
         },
         {
-          "expr": "haproxy_backend_limit_sessions{backend=~\"$backend\",instance=~\"$host:?[0-9]*\"}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "haproxy_backend_limit_sessions{proxy=~\"$backend\",instance=~\"$host:?[0-9]*\"}",
           "intervalFactor": 2,
-          "legendFormat": "{{ backend }} limit",
+          "legendFormat": "{{ proxy }} limit",
+          "range": true,
           "refId": "B",
           "step": 120
         }
@@ -2680,6 +3018,12 @@
       "description": "",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "unitScale": true
+        },
+        "overrides": []
+      },
       "fill": 2,
       "fillGradient": 0,
       "grid": {},
@@ -2711,34 +3055,47 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.3.1",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
       "seriesOverrides": [
         {
+          "$$hashKey": "object:1809",
           "alias": "/.*limit.*/",
           "fill": 0
         }
       ],
       "spaceLength": 10,
-      "stack": true,
+      "stack": false,
       "steppedLine": false,
       "targets": [
         {
-          "expr": "haproxy_frontend_max_sessions{frontend=~\"$frontend\",instance=~\"$host:?[0-9]*\"}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "haproxy_frontend_max_sessions{proxy=~\"$frontend\",instance=~\"$host:?[0-9]*\"}",
           "hide": false,
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "{{ frontend }}",
+          "legendFormat": "{{ proxy }}",
           "metric": "",
+          "range": true,
           "refId": "A",
           "step": 30
         },
         {
-          "expr": "haproxy_frontend_limit_sessions{frontend=~\"$frontend\",instance=~\"$host:?[0-9]*\"}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "haproxy_frontend_limit_sessions{proxy=~\"$frontend\",instance=~\"$host:?[0-9]*\"}",
           "intervalFactor": 2,
-          "legendFormat": "{{ frontend }} limit",
+          "legendFormat": "{{ proxy }} limit",
+          "range": true,
           "refId": "B",
           "step": 120
         }
@@ -2760,12 +3117,14 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:1793",
           "format": "short",
           "logBase": 1,
           "min": 0,
           "show": true
         },
         {
+          "$$hashKey": "object:1794",
           "format": "short",
           "logBase": 1,
           "min": 0,
@@ -2788,6 +3147,12 @@
       "description": "",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "unitScale": true
+        },
+        "overrides": []
+      },
       "fill": 2,
       "fillGradient": 0,
       "grid": {},
@@ -2819,7 +3184,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.3.1",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -2829,12 +3194,18 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "haproxy_backend_max_session_rate{backend=~\"$backend\",instance=~\"$host:?[0-9]*\"}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "haproxy_backend_max_session_rate{proxy=~\"$backend\",instance=~\"$host:?[0-9]*\"}",
           "hide": false,
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "{{ backend }}",
+          "legendFormat": "{{ proxy }}",
           "metric": "",
+          "range": true,
           "refId": "A",
           "step": 30
         }
@@ -2884,6 +3255,12 @@
       "description": "",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "unitScale": true
+        },
+        "overrides": []
+      },
       "fill": 2,
       "fillGradient": 0,
       "grid": {},
@@ -2915,7 +3292,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.3.1",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -2930,19 +3307,31 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "haproxy_frontend_max_session_rate{frontend=~\"$frontend\",instance=~\"$host:?[0-9]*\"}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "haproxy_frontend_max_session_rate{proxy=~\"$frontend\",instance=~\"$host:?[0-9]*\"}",
           "hide": false,
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "{{ frontend }}",
+          "legendFormat": "{{ proxy }}",
           "metric": "",
+          "range": true,
           "refId": "A",
           "step": 30
         },
         {
-          "expr": "haproxy_frontend_limit_session_rate{frontend=~\"$frontend\",instance=~\"$host:?[0-9]*\"}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "haproxy_frontend_limit_session_rate{proxy=~\"$frontend\",instance=~\"$host:?[0-9]*\"}",
           "intervalFactor": 2,
-          "legendFormat": "{{ frontend }} limit",
+          "legendFormat": "{{ proxy}} limit",
+          "range": true,
           "refId": "B",
           "step": 120
         }
@@ -3010,6 +3399,12 @@
       "description": "",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "unitScale": true
+        },
+        "overrides": []
+      },
       "fill": 2,
       "fillGradient": 0,
       "grid": {},
@@ -3041,21 +3436,31 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.3.1",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "seriesOverrides": [],
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:4007"
+        }
+      ],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
       "targets": [
         {
-          "expr": "haproxy_backend_up{backend=~\"$backend\", instance=~\"$host:?[0-9]*\"}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "haproxy_backend_status{state=\"UP\", proxy=~\"$backend\", instance=~\"$host:?[0-9]*\"}",
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "{{ backend }}",
+          "legendFormat": " {{ proxy }}",
           "metric": "",
+          "range": true,
           "refId": "A",
           "step": 30
         }
@@ -3069,6 +3474,7 @@
         "sort": 1,
         "value_type": "individual"
       },
+      "transformations": [],
       "type": "graph",
       "xaxis": {
         "mode": "time",
@@ -3105,6 +3511,12 @@
       "description": "",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "unitScale": true
+        },
+        "overrides": []
+      },
       "fill": 2,
       "fillGradient": 0,
       "grid": {},
@@ -3136,7 +3548,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.3.1",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -3146,11 +3558,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "haproxy_backend_weight{backend=~\"$backend\", instance=~\"$host:?[0-9]*\"}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "haproxy_backend_weight{proxy=~\"$backend\", instance=~\"$host:?[0-9]*\"}",
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "{{ backend }}",
+          "legendFormat": "{{ proxy }}",
           "metric": "",
+          "range": true,
           "refId": "A",
           "step": 30
         }
@@ -3217,6 +3635,12 @@
       "description": "",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "unitScale": true
+        },
+        "overrides": []
+      },
       "fill": 2,
       "fillGradient": 0,
       "grid": {},
@@ -3248,7 +3672,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.3.1",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -3262,12 +3686,14 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
+          "editorMode": "code",
           "exemplar": true,
           "expr": "irate(haproxy_server_sessions_total[5m])",
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "{{ backend }} / {{ server }}",
+          "legendFormat": "{{ proxy }} / {{ server }}",
           "metric": "haproxy_backe",
+          "range": true,
           "refId": "B",
           "step": 30
         }
@@ -3334,6 +3760,12 @@
       "description": "",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "unitScale": true
+        },
+        "overrides": []
+      },
       "fill": 2,
       "fillGradient": 0,
       "grid": {},
@@ -3365,7 +3797,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.3.1",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -3375,11 +3807,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(haproxy_server_max_queue{backend=~\"$backend\",server=~\"$server\",instance=~\"$host:?[0-9]*\"}[5m])",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "irate(haproxy_server_max_queue{proxy=~\"$backend\",server=~\"$server\",instance=~\"$host:?[0-9]*\"}[5m])",
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "{{ backend }} / {{ server }}",
+          "legendFormat": "{{ proxy}} / {{ server }}",
           "metric": "",
+          "range": true,
           "refId": "A",
           "step": 30
         }
@@ -3429,6 +3867,12 @@
       "description": "",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "unitScale": true
+        },
+        "overrides": []
+      },
       "fill": 2,
       "fillGradient": 0,
       "grid": {},
@@ -3460,7 +3904,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.3.1",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -3470,11 +3914,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(haproxy_server_current_queue{backend=~\"$backend\",server=~\"$server\",instance=~\"$host:?[0-9]*\"}[5m])",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "irate(haproxy_server_current_queue{proxy=~\"$backend\",server=~\"$server\",instance=~\"$host:?[0-9]*\"}[5m])",
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "{{ backend }} / {{ server }}",
+          "legendFormat": "{{ proxy }} / {{ server }}",
           "metric": "",
+          "range": true,
           "refId": "A",
           "step": 30
         }
@@ -3542,7 +3992,8 @@
       "error": false,
       "fieldConfig": {
         "defaults": {
-          "links": []
+          "links": [],
+          "unitScale": true
         },
         "overrides": []
       },
@@ -3577,7 +4028,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.3.1",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -3592,11 +4043,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(haproxy_server_http_responses_total{backend=~\"$backend\",server=~\"$server\",instance=~\"$host:?[0-9]*\"}[5m])) by (server)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(irate(haproxy_server_http_responses_total{proxy=~\"$backend\",server=~\"$server\",instance=~\"$host:?[0-9]*\"}[5m])) by (server)",
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "{{ backend }} {{ server }}",
+          "legendFormat": "{{ server }}",
           "metric": "",
+          "range": true,
           "refId": "A",
           "step": 30
         }
@@ -3648,7 +4105,8 @@
       "error": false,
       "fieldConfig": {
         "defaults": {
-          "links": []
+          "links": [],
+          "unitScale": true
         },
         "overrides": []
       },
@@ -3685,7 +4143,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.3.1",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -3700,30 +4158,48 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(haproxy_server_retry_warnings_total{backend=~\"$backend\", instance=~\"$host:?[0-9]*\"}[5m])",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "irate(haproxy_server_retry_warnings_total{proxy=~\"$backend\", instance=~\"$host:?[0-9]*\"}[5m])",
           "hide": false,
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "Retry {{ backend }} {{ server }}",
+          "legendFormat": "Retry {{ proxy }} {{ server }}",
           "metric": "",
+          "range": true,
           "refId": "A",
           "step": 30
         },
         {
-          "expr": "haproxy_server_redispatch_warnings_total{backend=~\"$backend\",server=~\"$server\",instance=~\"$host:?[0-9]*\"}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "haproxy_server_redispatch_warnings_total{proxy=~\"$backend\",server=~\"$server\",instance=~\"$host:?[0-9]*\"}",
           "hide": false,
           "interval": "$interval",
           "intervalFactor": 2,
-          "legendFormat": "Redispatch {{ backend }} {{ server }}",
+          "legendFormat": "Redispatch {{ proxy }} {{ server }}",
+          "range": true,
           "refId": "B",
           "step": 60
         },
         {
-          "expr": "irate(haproxy_server_response_errors_total{backend=~\"$backend\",server=~\"$server\",instance=~\"$host:?[0-9]*\"}[5m])",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "irate(haproxy_server_response_errors_total{proxy=~\"$backend\",server=~\"$server\",instance=~\"$host:?[0-9]*\"}[5m])",
           "hide": false,
           "interval": "$interval",
           "intervalFactor": 2,
-          "legendFormat": "Error {{ backend }} {{ server }}",
+          "legendFormat": "Error {{ proxy }} {{ server }}",
+          "range": true,
           "refId": "C",
           "step": 60
         }
@@ -3788,6 +4264,12 @@
       },
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "unitScale": true
+        },
+        "overrides": []
+      },
       "fill": 2,
       "fillGradient": 0,
       "grid": {},
@@ -3820,7 +4302,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.3.1",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -3830,11 +4312,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(haproxy_server_http_responses_total{backend=~\"$backend\",server=~\"$server\",code=~\"$code\",instance=~\"$host:?[0-9]*\"}[5m])",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "irate(haproxy_server_http_responses_total{proxy=~\"$backend\",server=~\"$server\",code=~\"$code\",instance=~\"$host:?[0-9]*\"}[5m])",
           "interval": "$interval",
           "intervalFactor": 1,
           "legendFormat": "{{ backend }} {{ server }} {{ code }}",
           "metric": "",
+          "range": true,
           "refId": "A",
           "step": 30
         }
@@ -3901,6 +4389,12 @@
       "description": "",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "unitScale": true
+        },
+        "overrides": []
+      },
       "fill": 2,
       "fillGradient": 0,
       "grid": {},
@@ -3932,7 +4426,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.3.1",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -3942,11 +4436,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "haproxy_server_current_sessions{backend=~\"$backend\",instance=~\"$host:?[0-9]*\"}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "haproxy_server_current_sessions{proxy=~\"$backend\",instance=~\"$host:?[0-9]*\"}",
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "{{ backend }} / {{ server }}",
+          "legendFormat": "{{ proxy }} / {{ server }}",
           "metric": "haproxy_backend_current_queue",
+          "range": true,
           "refId": "A",
           "step": 30
         }
@@ -3996,6 +4496,12 @@
       "description": "",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "unitScale": true
+        },
+        "overrides": []
+      },
       "fill": 2,
       "fillGradient": 0,
       "grid": {},
@@ -4006,7 +4512,7 @@
         "y": 209
       },
       "hiddenSeries": false,
-      "id": 60,
+      "id": 67,
       "legend": {
         "alignAsTable": true,
         "avg": true,
@@ -4027,28 +4533,34 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.3.1",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
-      "stack": true,
+      "stack": false,
       "steppedLine": false,
       "targets": [
         {
-          "expr": "haproxy_server_current_session_rate{backend=~\"$backend\",instance=~\"$host:?[0-9]*\"}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "haproxy_server_max_sessions{proxy=~\"$backend\",server=~\"$server\",instance=~\"$host:?[0-9]*\"}",
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "{{ backend }} / {{ server }}",
-          "metric": "haproxy_backend_current_queue",
+          "legendFormat": "{{ proxy }} / {{ server }}",
+          "metric": "",
+          "range": true,
           "refId": "A",
           "step": 30
         }
       ],
       "thresholds": [],
       "timeRegions": [],
-      "title": "Server - Current number of sessions rate per second over last elapsed second",
+      "title": "Server - Maximum observed number of active sessions",
       "tooltip": {
         "msResolution": true,
         "shared": false,
@@ -4091,6 +4603,12 @@
       "description": "",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "unitScale": true
+        },
+        "overrides": []
+      },
       "fill": 2,
       "fillGradient": 0,
       "grid": {},
@@ -4122,7 +4640,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.3.1",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -4132,11 +4650,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "haproxy_server_max_session_rate{backend=~\"$backend\",server=~\"$server\",instance=~\"$host:?[0-9]*\"}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "haproxy_server_max_session_rate{proxy=~\"$backend\",server=~\"$server\",instance=~\"$host:?[0-9]*\"}",
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "{{ backend }} / {{ server }}",
+          "legendFormat": "{{ proxy }} / {{ server }}",
           "metric": "",
+          "range": true,
           "refId": "A",
           "step": 30
         }
@@ -4144,101 +4668,6 @@
       "thresholds": [],
       "timeRegions": [],
       "title": "Server - Maximum observed number of sessions rate per second",
-      "tooltip": {
-        "msResolution": true,
-        "shared": false,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "logBase": 1,
-          "min": 0,
-          "show": true
-        },
-        {
-          "format": "short",
-          "logBase": 1,
-          "min": 0,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "description": "",
-      "editable": true,
-      "error": false,
-      "fill": 2,
-      "fillGradient": 0,
-      "grid": {},
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 12,
-        "y": 218
-      },
-      "hiddenSeries": false,
-      "id": 67,
-      "legend": {
-        "alignAsTable": true,
-        "avg": true,
-        "current": true,
-        "max": true,
-        "min": true,
-        "rightSide": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "maxPerRow": 2,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "8.5.3",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "haproxy_server_max_sessions{backend=~\"$backend\",server=~\"$server\",instance=~\"$host:?[0-9]*\"}",
-          "interval": "$interval",
-          "intervalFactor": 1,
-          "legendFormat": "{{ backend }} / {{ server }}",
-          "metric": "",
-          "refId": "A",
-          "step": 30
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "Server - Maximum observed number of active sessions",
       "tooltip": {
         "msResolution": true,
         "shared": false,
@@ -4298,6 +4727,12 @@
       "description": "",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "unitScale": true
+        },
+        "overrides": []
+      },
       "fill": 2,
       "fillGradient": 0,
       "grid": {},
@@ -4329,7 +4764,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.3.1",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -4339,11 +4774,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "haproxy_server_downtime_seconds_total{backend=~\"$backend\",instance=~\"$host:?[0-9]*\"}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "haproxy_server_downtime_seconds_total{proxy=~\"$backend\",instance=~\"$host:?[0-9]*\"}",
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "{{ backend }} / {{ server }}",
+          "legendFormat": "{{ proxy }} / {{ server }}",
           "metric": "haproxy_backend_current_queue",
+          "range": true,
           "refId": "A",
           "step": 30
         }
@@ -4394,6 +4835,12 @@
       "description": "",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "unitScale": true
+        },
+        "overrides": []
+      },
       "fill": 2,
       "fillGradient": 0,
       "grid": {},
@@ -4425,7 +4872,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.3.1",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -4435,11 +4882,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "increase(haproxy_server_check_failures_total{backend=~\"$backend\",server=~\"$server\",instance=~\"$host:?[0-9]*\"}[5m])",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "increase(haproxy_server_check_failures_total{proxy=~\"$backend\",server=~\"$server\",instance=~\"$host:?[0-9]*\"}[5m])",
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "{{ backend }} / {{ server }}",
+          "legendFormat": "{{ proxy }} / {{ server }}",
           "metric": "",
+          "range": true,
           "refId": "A",
           "step": 30
         }
@@ -4489,6 +4942,12 @@
       "description": "",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "unitScale": true
+        },
+        "overrides": []
+      },
       "fill": 2,
       "fillGradient": 0,
       "grid": {},
@@ -4520,7 +4979,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.3.1",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -4530,11 +4989,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(haproxy_server_connection_errors_total{backend=~\"$backend\",server=~\"$server\",instance=~\"$host:?[0-9]*\"}[5m])",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "irate(haproxy_server_connection_errors_total{proxy=~\"$backend\",server=~\"$server\",instance=~\"$host:?[0-9]*\"}[5m])",
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "{{ backend }} / {{ server }}",
+          "legendFormat": "{{ proxy }} / {{ server }}",
           "metric": "",
+          "range": true,
           "refId": "A",
           "step": 30
         }
@@ -4581,10 +5046,15 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "decimals": 1,
       "description": "",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "unitScale": true
+        },
+        "overrides": []
+      },
       "fill": 2,
       "fillGradient": 0,
       "grid": {},
@@ -4593,200 +5063,6 @@
         "w": 12,
         "x": 12,
         "y": 240
-      },
-      "hiddenSeries": false,
-      "id": 55,
-      "legend": {
-        "alignAsTable": true,
-        "avg": true,
-        "current": true,
-        "max": true,
-        "min": true,
-        "rightSide": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "maxPerRow": 1,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "8.5.3",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "exemplar": true,
-          "expr": "haproxy_server_check_duration_milliseconds",
-          "interval": "$interval",
-          "intervalFactor": 1,
-          "legendFormat": "{{ backend }} / {{ server }}",
-          "metric": "",
-          "refId": "A",
-          "step": 30
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "Server - Previously run health check duration, in milliseconds",
-      "tooltip": {
-        "msResolution": true,
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "ms",
-          "logBase": 1,
-          "show": true
-        },
-        {
-          "format": "short",
-          "logBase": 1,
-          "min": 0,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "description": "",
-      "editable": true,
-      "error": false,
-      "fill": 2,
-      "fillGradient": 0,
-      "grid": {},
-      "gridPos": {
-        "h": 12,
-        "w": 12,
-        "x": 0,
-        "y": 252
-      },
-      "hiddenSeries": false,
-      "id": 72,
-      "legend": {
-        "alignAsTable": true,
-        "avg": true,
-        "current": true,
-        "max": true,
-        "min": true,
-        "rightSide": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "maxPerRow": 2,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "8.5.3",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "haproxy_server_up{backend=~\"$backend\",instance=~\"$host:?[0-9]*\"}",
-          "interval": "$interval",
-          "intervalFactor": 1,
-          "legendFormat": "{{ backend }} / {{ server }}",
-          "metric": "haproxy_backend_current_queue",
-          "refId": "A",
-          "step": 30
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "Server - Current health status of the server",
-      "tooltip": {
-        "msResolution": true,
-        "shared": false,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "none",
-          "logBase": 1,
-          "min": 0,
-          "show": true
-        },
-        {
-          "format": "short",
-          "logBase": 1,
-          "min": 0,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "description": "",
-      "editable": true,
-      "error": false,
-      "fill": 2,
-      "fillGradient": 0,
-      "grid": {},
-      "gridPos": {
-        "h": 12,
-        "w": 12,
-        "x": 12,
-        "y": 252
       },
       "hiddenSeries": false,
       "id": 73,
@@ -4810,7 +5086,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.3.1",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -4820,11 +5096,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "haproxy_server_weight{backend=~\"$backend\",instance=~\"$host:?[0-9]*\"}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "haproxy_server_weight{proxy=~\"$backend\",instance=~\"$host:?[0-9]*\"}",
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "{{ backend }} / {{ server }}",
+          "legendFormat": "{{ proxy }} / {{ server }}",
           "metric": "haproxy_backend_current_queue",
+          "range": true,
           "refId": "A",
           "step": 30
         }
@@ -4872,227 +5154,16 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 264
+        "y": 252
       },
       "id": 102,
       "panels": [],
       "title": "Scrape info",
       "type": "row"
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "editable": true,
-      "error": false,
-      "fieldConfig": {
-        "defaults": {
-          "links": []
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "grid": {},
-      "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 0,
-        "y": 265
-      },
-      "hiddenSeries": false,
-      "id": 40,
-      "legend": {
-        "alignAsTable": true,
-        "avg": true,
-        "current": true,
-        "max": true,
-        "min": true,
-        "rightSide": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 2,
-      "links": [],
-      "maxPerRow": 1,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "8.5.3",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": true,
-      "steppedLine": false,
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "exemplar": true,
-          "expr": "sum by (instance) (haproxy_exporter_csv_parse_failures)",
-          "interval": "$interval",
-          "intervalFactor": 1,
-          "legendFormat": "Exporter csv failures {{ instance }}",
-          "metric": "",
-          "refId": "A",
-          "step": 30
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "Number of errors while parsing CSV",
-      "tooltip": {
-        "msResolution": true,
-        "shared": true,
-        "sort": 2,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "logBase": 1,
-          "min": 0,
-          "show": true
-        },
-        {
-          "format": "short",
-          "logBase": 1,
-          "min": 0,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "editable": true,
-      "error": false,
-      "fieldConfig": {
-        "defaults": {
-          "links": []
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "grid": {},
-      "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 12,
-        "y": 265
-      },
-      "hiddenSeries": false,
-      "id": 41,
-      "legend": {
-        "alignAsTable": true,
-        "avg": true,
-        "current": true,
-        "max": true,
-        "min": true,
-        "rightSide": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 2,
-      "links": [],
-      "maxPerRow": 1,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "8.5.3",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": true,
-      "steppedLine": false,
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "exemplar": true,
-          "expr": "sum by (instance) (haproxy_exporter_total_scrapes)",
-          "interval": "$interval",
-          "intervalFactor": 1,
-          "legendFormat": "HAProxy scrapes - {{ instance}}",
-          "metric": "",
-          "refId": "A",
-          "step": 30
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "Current total HAProxy scrapes",
-      "tooltip": {
-        "msResolution": true,
-        "shared": true,
-        "sort": 2,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "logBase": 1,
-          "min": 0,
-          "show": true
-        },
-        {
-          "format": "short",
-          "logBase": 1,
-          "min": 0,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
     }
   ],
   "refresh": "",
-  "schemaVersion": 36,
-  "style": "dark",
+  "schemaVersion": 39,
   "tags": [
     "haproxy",
     "servers"
@@ -5103,7 +5174,7 @@
         "current": {
           "selected": false,
           "text": "Prometheus",
-          "value": "Prometheus"
+          "value": "${datasource}"
         },
         "description": "The prometheus datasource used for queries.",
         "hide": 0,
@@ -5126,10 +5197,10 @@
           "value": "$__all"
         },
         "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
+          "type": "prometheus",
+          "uid": "${datasource}"
         },
-        "definition": "label_values(haproxy_up{cluster='$cluster'}, instance)",
+        "definition": "label_values(haproxy_backend_status,instance)",
         "hide": 0,
         "includeAll": true,
         "label": "Host",
@@ -5137,8 +5208,9 @@
         "name": "host",
         "options": [],
         "query": {
-          "query": "label_values(haproxy_up{cluster='$cluster'}, instance)",
-          "refId": "StandardVariableQuery"
+          "qryType": 1,
+          "query": "label_values(haproxy_backend_status,instance)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
         "regex": "/([^:]+).*/",
@@ -5158,10 +5230,10 @@
           ]
         },
         "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
+          "type": "prometheus",
+          "uid": "${datasource}"
         },
-        "definition": "",
+        "definition": "label_values(haproxy_backend_bytes_in_total{instance=~\"$host:?[0-9]*\"},proxy)",
         "hide": 0,
         "includeAll": true,
         "label": "Backend",
@@ -5169,8 +5241,9 @@
         "name": "backend",
         "options": [],
         "query": {
-          "query": "label_values(haproxy_backend_bytes_in_total{instance=~\"$host:?[0-9]*\"}, backend)",
-          "refId": "Prometheus-backend-Variable-Query"
+          "qryType": 1,
+          "query": "label_values(haproxy_backend_bytes_in_total{instance=~\"$host:?[0-9]*\"},proxy)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
         "regex": "",
@@ -5190,10 +5263,10 @@
           ]
         },
         "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
+          "type": "prometheus",
+          "uid": "${datasource}"
         },
-        "definition": "",
+        "definition": "label_values(haproxy_frontend_bytes_in_total{instance=~\"$host:?[0-9]*\"},proxy)",
         "hide": 0,
         "includeAll": true,
         "label": "Frontend",
@@ -5201,8 +5274,9 @@
         "name": "frontend",
         "options": [],
         "query": {
-          "query": "label_values(haproxy_frontend_bytes_in_total{instance=~\"$host:?[0-9]*\"}, frontend)",
-          "refId": "Prometheus-frontend-Variable-Query"
+          "qryType": 1,
+          "query": "label_values(haproxy_frontend_bytes_in_total{instance=~\"$host:?[0-9]*\"},proxy)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
         "regex": "",
@@ -5221,10 +5295,10 @@
           ]
         },
         "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
+          "type": "prometheus",
+          "uid": "${datasource}"
         },
-        "definition": "",
+        "definition": "label_values(haproxy_server_bytes_in_total{instance=~\"$host:?[0-9]*\", proxy=~\"$backend\"},server)",
         "hide": 0,
         "includeAll": true,
         "label": "Server",
@@ -5232,8 +5306,9 @@
         "name": "server",
         "options": [],
         "query": {
-          "query": "label_values(haproxy_server_bytes_in_total{instance=~\"$host:?[0-9]*\", backend=~\"$backend\"}, server)",
-          "refId": "Prometheus-server-Variable-Query"
+          "qryType": 1,
+          "query": "label_values(haproxy_server_bytes_in_total{instance=~\"$host:?[0-9]*\", proxy=~\"$backend\"},server)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
         "regex": "",
@@ -5253,10 +5328,10 @@
           ]
         },
         "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
+          "type": "prometheus",
+          "uid": "${datasource}"
         },
-        "definition": "",
+        "definition": "label_values(haproxy_server_http_responses_total{instance=~\"$host:?[0-9]*\", proxy=~\"$backend\", server=~\"$server\"},code)",
         "hide": 0,
         "includeAll": true,
         "label": "HTTP Code",
@@ -5264,8 +5339,9 @@
         "name": "code",
         "options": [],
         "query": {
-          "query": "label_values(haproxy_server_http_responses_total{instance=~\"$host:?[0-9]*\", backend=~\"$backend\", server=~\"$server\"}, code)",
-          "refId": "Prometheus-code-Variable-Query"
+          "qryType": 1,
+          "query": "label_values(haproxy_server_http_responses_total{instance=~\"$host:?[0-9]*\", proxy=~\"$backend\", server=~\"$server\"},code)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
         "regex": "",
@@ -5279,16 +5355,16 @@
         "auto_count": 30,
         "auto_min": "10s",
         "current": {
-          "selected": true,
-          "text": "auto",
-          "value": "$__auto_interval_interval"
+          "selected": false,
+          "text": "5m",
+          "value": "5m"
         },
         "hide": 0,
         "label": "Interval",
         "name": "interval",
         "options": [
           {
-            "selected": true,
+            "selected": false,
             "text": "auto",
             "value": "$__auto_interval_interval"
           },
@@ -5303,7 +5379,7 @@
             "value": "1m"
           },
           {
-            "selected": false,
+            "selected": true,
             "text": "5m",
             "value": "5m"
           },
@@ -5328,39 +5404,11 @@
         "refresh": 2,
         "skipUrlSync": false,
         "type": "interval"
-      },
-      {
-        "current": {
-          "isNone": true,
-          "selected": false,
-          "text": "None",
-          "value": ""
-        },
-        "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-        },
-        "definition": "label_values(haproxy_up, cluster)",
-        "hide": 0,
-        "includeAll": false,
-        "label": "Cluster",
-        "multi": false,
-        "name": "cluster",
-        "options": [],
-        "query": {
-          "query": "label_values(haproxy_up, cluster)",
-          "refId": "StandardVariableQuery"
-        },
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 1,
-        "type": "query"
       }
     ]
   },
   "time": {
-    "from": "now-1h",
+    "from": "now-30m",
     "to": "now"
   },
   "timepicker": {

--- a/etc/kayobe/kolla/config/prometheus/haproxy.rules
+++ b/etc/kayobe/kolla/config/prometheus/haproxy.rules
@@ -6,17 +6,8 @@ groups:
 - name: HAProxy
   rules:
 
-  - alert: HaproxyDown
-    expr: haproxy_up == 0
-    for: 1m
-    labels:
-      severity: critical
-    annotations:
-      summary: "HAProxy down (instance {{ $labels.instance }})"
-      description: "HAProxy down"
-
   - alert: HaproxyBackendDown
-    expr: haproxy_backend_up == 0
+    expr: haproxy_backend_status{state="DOWN"} == 1
     for: 1m
     labels:
       severity: critical
@@ -25,12 +16,12 @@ groups:
       description: "HAProxy backend is down"
 
   - alert: HaproxyServerDown
-    expr: haproxy_server_up == 0
+    expr: haproxy_server_status{state="DOWN"} == 1
     for: 1m
     labels:
       severity: critical
     annotations:
       summary: "HAProxy server down at {{ $labels.server }}"
-      description: "HAProxy server for {{ $labels.backend }} is down at {{ $labels.server }}"
+      description: "HAProxy server for {{ $labels.proxy }} is down at {{ $labels.server }}"
 
 {% endraw %}

--- a/releasenotes/notes/update-haproxy-dashboard-b8807c2a0645ca5e.yaml
+++ b/releasenotes/notes/update-haproxy-dashboard-b8807c2a0645ca5e.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    The HAProxy dashboard and alerts have been updated to use the new metrics
+    source in Kolla Ansible. For further details see `here
+    <https://review.opendev.org/c/openstack/kolla-ansible/+/877118`__.


### PR DESCRIPTION
Kolla has switched to using the built in HAProxy metrics source [1].

The new metrics source is not directly compatible, and therefore we need to update dashboards and alerts relying on the old metrics.

In a few cases, equivalent metrics were not available, so the plots have been removed.

[1] https://review.opendev.org/c/openstack/kolla-ansible/+/877118