### PR TITLE
Default to RegionOne for os-capacity

### DIFF
--- a/etc/kayobe/stackhpc-monitoring.yml
+++ b/etc/kayobe/stackhpc-monitoring.yml
@@ -20,7 +20,7 @@ stackhpc_enable_os_capacity: false
 stackhpc_os_capacity_auth_url: "http{% if kolla_enable_tls_internal | bool %}s{% endif %}://{{ kolla_internal_fqdn }}:5000"
 
 # OpenStack region for OpenStack Capacity
-stackhpc_os_capacity_openstack_region_name: "{{ openstack_region_name | default(RegionOne) }}"
+stackhpc_os_capacity_openstack_region_name: "RegionOne"
 
 # Whether TLS certificate verification is enabled for the OpenStack Capacity
 # exporter during Keystone authentication.


### PR DESCRIPTION
Fix deployment playbook crashing on templating an undefined variable.

https://github.com/stackhpc/stackhpc-kayobe-config/actions/runs/8005807156/job/21866719951