### PR TITLE
Moving variable from play to group_vars

### DIFF
--- a/etc/kayobe/ansible/growroot.yml
+++ b/etc/kayobe/ansible/growroot.yml
@@ -23,8 +23,6 @@
     ansible_python_interpreter: /usr/bin/python3
     # Work around no known_hosts entry on first boot.
     ansible_ssh_common_args: "-o StrictHostKeyChecking=no"
-    # Name of the LVM VG containing the root PV.
-    growroot_vg: "rootvg"
     # Don't assume facts are present.
     os_family: "{{ ansible_facts.os_family | default('Debian' if os_distribution == 'ubuntu' else 'RedHat') }}"
     # Ignore LVM check

--- a/etc/kayobe/inventory/group_vars/all/growroot
+++ b/etc/kayobe/inventory/group_vars/all/growroot
@@ -1,0 +1,3 @@
+---
+# Name of the LVM VG containing the root PV for ansible/growroot.yml
+growroot_vg: "rootvg"


### PR DESCRIPTION
This lets us override in case one of the machines have different VG name Otherwise play variables take priority.

Cherry-picking to Yoga. Needed at a customer site.