### PR TITLE
Fix os-capacity playbook crash on delegate_to

### DIFF
--- a/etc/kayobe/ansible/deploy-os-capacity-exporter.yml
+++ b/etc/kayobe/ansible/deploy-os-capacity-exporter.yml
@@ -1,15 +1,18 @@
 ---
-- hosts: monitoring
+- name: Remove legacy os_exporter.cfg file
+  hosts: network
   gather_facts: false
-
   tasks:
     - name: Ensure legacy os_exporter.cfg config file is deleted
       ansible.builtin.file:
         path: /etc/kolla/haproxy/services.d/os_exporter.cfg
         state: absent
-      delegate_to: network
       become: true
 
+- name: Deploy os-capacity exporter
+  hosts: monitoring
+  gather_facts: false
+  tasks:
     - name: Create os-capacity directory
       ansible.builtin.file:
         path: /opt/kayobe/os-capacity/


### PR DESCRIPTION
This patch fixes an issue where deploy-os-capaity-exporter playbook will crash due to `delegate_to` being misconfigured to the network group.

This patch was moved from #829 as not to block a critical fix on that pull request.