### PR TITLE
zed tempest docs

### DIFF
--- a/doc/source/contributor/environments/aufn-ceph.rst
+++ b/doc/source/contributor/environments/aufn-ceph.rst
@@ -14,7 +14,7 @@ This environment creates a Universe-from-nothing_-style deployment of Kayobe con
 Prerequisites
 =============
 
-* a baremetal node with at least 64GB of RAM running CentOS Stream 8 (or Ubuntu)
+* a baremetal node with at least 64GB of RAM running Rocky Linux 9 or Ubuntu Jammy.
 
 * access to the test pulp server on SMS lab
 

--- a/doc/source/contributor/environments/ci-builder.rst
+++ b/doc/source/contributor/environments/ci-builder.rst
@@ -25,7 +25,7 @@ Access the host via SSH.
 
 Install package dependencies.
 
-On CentOS:
+On Rocky Linux:
 
 .. parsed-literal::
 

--- a/doc/source/operations/tempest.rst
+++ b/doc/source/operations/tempest.rst
@@ -65,7 +65,7 @@ To install Docker on Ubuntu:
     sudo apt-get update
     sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
-Installing Docker on CentOS/Rocky:
+Installing Docker on Rocky:
 
 .. code-block:: bash
 
@@ -99,7 +99,7 @@ Build a Kayobe automation image:
 
     git submodule init
     git submodule update
-    # If running on Ubuntu, the fact cache can confuse Kayobe in the CentOS-based container
+    # If running on Ubuntu, the fact cache can confuse Kayobe in the Rocky-based container
     mv etc/kayobe/facts{,-old}
     sudo DOCKER_BUILDKIT=1 docker build --file .automation/docker/kayobe/Dockerfile --tag kayobe:latest .
 

--- a/doc/source/operations/tempest.rst
+++ b/doc/source/operations/tempest.rst
@@ -101,7 +101,7 @@ Build a Kayobe automation image:
     git submodule update
     # If running on Ubuntu, the fact cache can confuse Kayobe in the Rocky-based container
     mv etc/kayobe/facts{,-old}
-    sudo DOCKER_BUILDKIT=1 docker build --file .automation/docker/kayobe/Dockerfile --tag kayobe:latest .
+    sudo DOCKER_BUILDKIT=1 docker build --build-arg BASE_IMAGE=rockylinux:9 --file .automation/docker/kayobe/Dockerfile --tag kayobe:latest .
 
 Configuration
 =============

--- a/etc/kayobe/environments/aufn-ceph/configure-local-networking.sh
+++ b/etc/kayobe/environments/aufn-ceph/configure-local-networking.sh
@@ -43,7 +43,7 @@ if ! sudo ip l show brcloud >/dev/null 2>&1; then
     sudo ip l set brcloud up
 fi
 
-# On CentOS 8, bridges without a port are DOWN, which causes network
+# On Rocky Linux, bridges without a port are DOWN, which causes network
 # configuration to fail. Add a dummy interface and plug it into the bridge.
 for i in mgmt prov cloud; do
     if ! sudo ip l show dummy-$i >/dev/null 2>&1; then

--- a/etc/kayobe/environments/aufn-ceph/seed-hypervisor.yml
+++ b/etc/kayobe/environments/aufn-ceph/seed-hypervisor.yml
@@ -10,5 +10,5 @@ seed_hypervisor_extra_network_interfaces:
   - "{{ public_net_name }}"
   - "{{ external_net_names[0] }}"
 
-# Workaround change to cloud-user default login name on CentOS-Stream8
+# Workaround change to cloud-user default login name on Rocky Linux
 seed_hypervisor_bootstrap_user: "{{ lookup('env', 'USER') }}"


### PR DESCRIPTION
- Replace references to CentOS with Rocky Linux
- docs: Add BASE_IMAGE build-arg for kayobe image build
