### PR TITLE
Switch ansible-modules-hashivault back to upstream

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 kayobe@git+https://github.com/stackhpc/kayobe@stackhpc/2023.1
-ansible-modules-hashivault@git+https://github.com/stackhpc/ansible-modules-hashivault@stackhpc-py39
+ansible-modules-hashivault>=5.2.1
 jmespath


### PR DESCRIPTION
5.2.1 version was released with shebang fix [1].

[1]: https://github.com/TerryHowe/ansible-modules-hashivault/commit/f1d30f18193562c30ff8e3d63ec2f4d1e2745f47