### PR TITLE
Switch ansible-modules-hashivault back to upstream

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 kayobe@git+https://github.com/stackhpc/kayobe@stackhpc/yoga
 ansible-modules-hashivault@git+https://github.com/stackhpc/ansible-modules-hashivault@stackhpc;python_version < "3.8"
-ansible-modules-hashivault@git+https://github.com/stackhpc/ansible-modules-hashivault@stackhpc-py39;python_version >= "3.8"
+ansible-modules-hashivault>=5.2.1;python_version >= "3.8"
 jmespath


### PR DESCRIPTION
5.2.1 version was released with shebang fix [1].

[1]: TerryHowe/ansible-modules-hashivault@f1d30f1