### PR TITLE
Fix Ceph "Objects in the Cluster" dashboard panel

### DIFF
--- a/etc/kayobe/kolla/config/grafana/dashboards/ceph/ceph_overview.json
+++ b/etc/kayobe/kolla/config/grafana/dashboards/ceph/ceph_overview.json
@@ -1924,23 +1924,25 @@
         }
       ],
       "spaceLength": 10,
-      "stack": true,
+      "stack": false,
       "steppedLine": false,
       "targets": [
         {
-          "expr": "ceph_cluster_total_objects",
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "ceph_pool_objects * on(pool_id) group_left(instance,name) ceph_pool_metadata",
           "format": "time_series",
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "Total",
+          "legendFormat": "{{name}}",
+          "range": true,
           "refId": "A",
           "step": 300
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Objects in the Cluster",
       "tooltip": {
         "msResolution": false,


### PR DESCRIPTION
The `ceph_cluster_total_objects` metric was removed several releases ago [1]. Use `ceph_pool_objects` which provides per-pool metrics.

[1] https://github.com/ceph/ceph-ansible/issues/6032