### PR TITLE
Fix Jinja templating in Barbican Vault config

### DIFF
--- a/doc/source/configuration/vault.rst
+++ b/doc/source/configuration/vault.rst
@@ -296,7 +296,9 @@ Configure Barbican
       [vault_plugin]
       vault_url = https://{{ kolla_internal_vip_address }}:8200
       use_ssl = True
-      ssl_ca_crt_file = {% raw %}{{ openstack_cacert }}{% endraw %}
+      {% raw %}
+      ssl_ca_crt_file = {{ openstack_cacert }}
+      {% endraw %}
       approle_role_id = {{ secrets_barbican_approle_role_id }}
       approle_secret_id = {{ secrets_barbican_approle_secret_id }}
       kv_mountpoint = barbican


### PR DESCRIPTION
The raw tags cause ``ssl_ca_crt_file`` to be templated without a newline on the end. This would give the following misconfiguration:

```
use_ssl = True
ssl_ca_crt_file = <openstack_cacert_path>approle_role_id = <approle_role_id>
approle_secret_id = <approle_secret_id>
```