### PR TITLE
Initial seed deployment docs update

### DIFF
--- a/doc/source/configuration/release-train.rst
+++ b/doc/source/configuration/release-train.rst
@@ -222,7 +222,7 @@ has not yet been deployed. This can be avoided with the following workflow:
 
 .. code-block:: console
 
-   kayobe seed service deploy --tags seed-deploy-containers --kolla-tags none
+   kayobe seed service deploy --tags seed-deploy-containers --kolla-tags none -e deploy_containers_registry_attempt_login=false
    kayobe playbook run $KAYOBE_CONFIG_PATH/ansible/pulp-container-sync.yml
    kayobe playbook run $KAYOBE_CONFIG_PATH/ansible/pulp-container-publish.yml
    kayobe seed service deploy


### PR DESCRIPTION
Following https://stackhpc-kayobe-config.readthedocs.io/en/stackhpc-2023.1/configuration/release-train.html#syncing-content to deploy Pulp before Bifrost, I hit an error

```
TASK [deploy-containers : Login to docker registry] *********************************************************************************************************************************************************************************************************
Tuesday 19 March 2024  08:38:59 +0000 (0:00:01.467)       0:00:01.500 *********
fatal: [seedvm]: FAILED! => changed=false
  msg: 'Logging into 192.168.1.20:80 for user admin failed - 500 Server Error for http+docker://localhost/v1.44/auth: Internal Server Error ("Get "http://192.168.1.20:80/v2/": dial tcp 192.168.1.20:80: connect: connection refused")'
```
The extra var disables the task via 
```
  when:
   - deploy_containers_registry_attempt_login | bool
```