### PR TITLE
Use StackHPC downstream requirements fork (Zed)

### DIFF
--- a/etc/kayobe/kolla/kolla-build.conf
+++ b/etc/kayobe/kolla/kolla-build.conf
@@ -9,3 +9,8 @@ base_tag = jammy-20231004
 base_tag = 9.{{ stackhpc_pulp_repo_rocky_9_minor_version }}
 {% endif %}
 build_args = {{ kolla_build_args.items() | map('join', ':') | join(',') }}
+
+[openstack-base]
+type = git
+location = https://github.com/stackhpc/requirements
+reference = stackhpc/{{ openstack_release }}


### PR DESCRIPTION
Use StackHPC downstream requirements fork

Cherry-picked from commit c591acdbeae03a4c82bbe7e7224adcedccb09565