### PR TITLE
Rebuild heat images with yaql 3.0.0 for 2023.1

### DIFF
--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -9,6 +9,9 @@ kolla_image_tags:
   haproxy_ssh:
     rocky-9: 2023.1-rocky-9-20240205T162323
     ubuntu-jammy: 2023.1-ubuntu-jammy-20240221T133905
+  heat:
+    rocky-9: 2023.1-rocky-9-20240319T134201
+    ubuntu-jammy: 2023.1-ubuntu-jammy-20240319T134201
   letsencrypt:
     rocky-9: 2023.1-rocky-9-20240205T162323
     ubuntu-jammy: 2023.1-ubuntu-jammy-20240221T133905

--- a/releasenotes/notes/rebuild-heat-with-yaql-3.0.0-4415d8232bc547df.yaml
+++ b/releasenotes/notes/rebuild-heat-with-yaql-3.0.0-4415d8232bc547df.yaml
@@ -1,0 +1,7 @@
+---
+security:
+  - |
+    The Heat container images are rebuilt with yaql 3.0.0 to include patch for
+    vulnerability OSSN/OSSN-0093. It is recommended that you redeploy Heat
+    services in your system with the current version of Heat images from
+    StackHPC Release Train.


### PR DESCRIPTION
To patch vulnerability https://wiki.openstack.org/wiki/OSSN/OSSN-0093 from yaql, bumped yaql requirements to 3.0.0 (See https://github.com/stackhpc/requirements/pull/15)
Then rebuilt heat images as they use yaql.