### PR TITLE
Rebuild heat images with yaql 3.0.0 for zed

### DIFF
--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -6,6 +6,9 @@ kolla_image_tags:
   openstack:
     rocky-9: zed-rocky-9-20240202T105829
     ubuntu-jammy: zed-ubuntu-jammy-20240129T151534
+  heat:
+    rocky-9: zed-rocky-9-20240320T113114
+    ubuntu-jammy: zed-ubuntu-jammy-20240320T113114
   magnum:
     rocky-9: zed-rocky-9-20240301T100039
     ubuntu-jammy: zed-ubuntu-jammy-20240301T100039

--- a/releasenotes/notes/rebuild-heat-with-yaql-3.0.0-4415d8232bc547df.yaml
+++ b/releasenotes/notes/rebuild-heat-with-yaql-3.0.0-4415d8232bc547df.yaml
@@ -1,0 +1,7 @@
+---
+security:
+  - |
+    The Heat container images are rebuilt with yaql 3.0.0 to include patch for
+    vulnerability OSSN/OSSN-0093. It is recommended that you redeploy Heat
+    services in your system with the current version of Heat images from
+    StackHPC Release Train.


### PR DESCRIPTION
To patch vulnerability https://wiki.openstack.org/wiki/OSSN/OSSN-0093 from yaql, bumped yaql requirements to 3.0.0 (See https://github.com/stackhpc/requirements/pull/14)
Then rebuilt heat images as they use yaql.