### PR TITLE
Rebuild heat images with yaql 3.0.0 for yoga

### DIFF
--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -19,6 +19,10 @@ kayobe_image_tags:
     centos: yoga-20231107T165648
     rocky: yoga-20231218T141822
     ubuntu: yoga-20231107T165648
+  heat:
+    centos: yoga-20240320T082414
+    rocky: yoga-20240320T082414
+    ubuntu: yoga-20240320T082414
   magnum:
     centos: yoga-20240308T154440
     rocky: yoga-20240308T154440
@@ -33,6 +37,7 @@ kayobe_image_tags:
     ubuntu: yoga-20231103T161400
 
 cloudkitty_tag: "{% raw %}{{ kayobe_image_tags['cloudkitty'][kolla_base_distro] }}{% endraw %}"
+heat_tag: "{% raw %}{{ kayobe_image_tags['heat'][kolla_base_distro] }}{% endraw %}"
 magnum_tag: "{% raw %}{{ kayobe_image_tags['magnum'][kolla_base_distro] }}{% endraw %}"
 neutron_tag: "{% raw %}{{ kayobe_image_tags['neutron'][kolla_base_distro] }}{% endraw %}"
 nova_tag: "{% raw %}{{ kayobe_image_tags['nova'][kolla_base_distro] }}{% endraw %}"

--- a/releasenotes/notes/rebuild-heat-with-yaql-3.0.0-4415d8232bc547df.yaml
+++ b/releasenotes/notes/rebuild-heat-with-yaql-3.0.0-4415d8232bc547df.yaml
@@ -1,0 +1,7 @@
+---
+security:
+  - |
+    The Heat container images are rebuilt with yaql 3.0.0 to include patch for
+    vulnerability OSSN/OSSN-0093. It is recommended that you redeploy Heat
+    services in your system with the current version of Heat images from
+    StackHPC Release Train.


### PR DESCRIPTION
To patch vulnerability https://wiki.openstack.org/wiki/OSSN/OSSN-0093 from yaql, bumped yaql requirements to 3.0.0 (See https://github.com/stackhpc/requirements/pull/13)
Then rebuilt heat images as they use yaql.