### PR TITLE
Fail on any unparsed Ansible inventory

### DIFF
--- a/etc/kayobe/ansible.cfg
+++ b/etc/kayobe/ansible.cfg
@@ -11,5 +11,9 @@ callbacks_enabled = ansible.posix.profile_tasks
 # Silence warning about invalid characters found in group names
 force_valid_group_names = ignore
 
+[inventory]
+# Fail when any inventory source cannot be parsed.
+any_unparsed_is_failed = True
+
 [ssh_connection]
 pipelining = True

--- a/releasenotes/notes/fail-unparsed-inventory-c3b4e2ffcb620a6b.yaml
+++ b/releasenotes/notes/fail-unparsed-inventory-c3b4e2ffcb620a6b.yaml
@@ -1,0 +1,7 @@
+---
+upgrade:
+  - |
+    Updates the Ansible configuration to `fail on any unparsed inventory source
+    <https://docs.ansible.com/ansible/latest/reference_appendices/config.html#inventory-any-unparsed-is-failed>`__.
+    If you are using a separate Ansible configuration for Kolla Ansible, you
+    may wish to add this setting in ``etc/kayobe/kolla/ansible.cfg``.


### PR DESCRIPTION
If Ansible is unable to parse an inventory source, by default it will
print a warning and continue execution. Typically this highlights an
important error that should be addressed.

This change modifies the Ansible configuration to error out in this
case.
