### PR TITLE
add playbook with workaround for 'tc mirred to Houston'

### DIFF
--- a/etc/kayobe/ansible/fix-houston.yml
+++ b/etc/kayobe/ansible/fix-houston.yml
@@ -1,0 +1,44 @@
+---
+# When OVS HW offloading is enabled - typically in conjunction with VF-LAG and ASAP^2
+# the DMESG log reports frequent errors on the internal OVS Bridge interface:
+# "tc mirred to Houston: device bond0-ovs is down".
+# This interface is down by default. The errors are mitigated by bringing the interface up.
+# For further context, see:
+# https://bugs.launchpad.net/charm-neutron-openvswitch/+bug/1899364
+# https://patchwork.kernel.org/project/netdevbpf/patch/c2ef23da1d9a4eb62f4e7b7c4540f9bafb553c15.1658420239.git.dcaratti@redhat.com/
+# To deploy this playbook, use the following commands:
+# kayobe playbook run $KAYOBE_CONFIG_PATH/ansible/fix-houston.yml
+# Enable with Kayobe Hooks by running:
+# mkdir -p ${KAYOBE_CONFIG_PATH}/hooks/overcloud-service-deploy/post.d
+# cd ${KAYOBE_CONFIG_PATH}/hooks/overcloud-service-deploy/post.d
+# ln -s ../../../ansible/fix-houston.yml 90-fix-houston.yml
+
+- name: Create Systemd Unit to workaround 'tc mirred to Houston' error
+  hosts: network,compute
+  become: yes
+
+  tasks:
+    - name: Include kolla-ansible host vars
+      include_vars: "{{ kolla_config_path }}/inventory/overcloud/host_vars/{{ inventory_hostname }}"
+
+    - name: Create systemd service for -ovs network interface
+      template:
+        src: fix-houston-interface.service.j2
+        dest: "/etc/systemd/system/fix-houston-{{ item }}.service"
+      loop: "{{ neutron_bridge_name.split(',') }}"
+      vars:
+        interface_name: "{{ item }}"
+      when: neutron_bridge_name | length > 0
+      notify: reload systemd
+
+    - name: Enable and start systemd service for -ovs network interface
+      systemd:
+        name: "fix-houston-{{ item }}"
+        enabled: yes
+        state: started
+      when: neutron_bridge_name | length > 0
+      loop: "{{ neutron_bridge_name.split(',') }}"
+
+  handlers:
+    - name: reload systemd
+      command: systemctl daemon-reload

--- a/etc/kayobe/ansible/templates/fix-houston-interface.service.j2
+++ b/etc/kayobe/ansible/templates/fix-houston-interface.service.j2
@@ -1,0 +1,20 @@
+[Unit]
+# This service addresses a specific issue when OVS HW offloading is enabled
+# typically in conjunction with VF-LAG and ASAP^2
+# the DMESG log reports frequent errors on the internal OVS Bridge interface:
+# "tc mirred to Houston: device bond0-ovs is down".
+# This interface is down by default. The errors are mitigated by bringing the interface up.
+# For further context, see:
+# https://bugs.launchpad.net/charm-neutron-openvswitch/+bug/1899364
+# https://patchwork.kernel.org/project/netdevbpf/patch/c2ef23da1d9a4eb62f4e7b7c4540f9bafb553c15.1658420239.git.dcaratti@redhat.com/
+Description=Bring up {{ interface_name }} interface
+After=kolla-openvswitch_vswitchd-container.service
+
+[Service]
+Type=oneshot
+ExecStartPre=/usr/bin/timeout 60s /bin/bash -c 'until ip link show {{ interface_name }}; do sleep 1; done'
+ExecStart=/sbin/ip link set {{ interface_name }} up
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/releasenotes/notes/fix-houston-tc-mirred-bfb16c89f63b472a.yaml
+++ b/releasenotes/notes/fix-houston-tc-mirred-bfb16c89f63b472a.yaml
@@ -1,0 +1,12 @@
+---
+fixes:
+  - |
+    Adds a custom ``fix-houston.yml`` playbook to address dmesg errors, specifically:
+    "tc mirred to Houston: device bond0-ovs is down". This error typically appears
+    when OVS HW offloading is enabled, often in conjunction with VF-LAG and ASAP^2.
+    Detailed usage instructions are provided within the playbook's comments.
+    Additional context is available at the following links:
+    `LP#1899364
+    <https://bugs.launchpad.net/charm-neutron-openvswitch/+bug/1899364>`__
+    `Kernel Patch
+    <https://patchwork.kernel.org/project/netdevbpf/patch/c2ef23da1d9a4eb62f4e7b7c4540f9bafb553c15.1658420239.git.dcaratti@redhat.com/>`__


### PR DESCRIPTION
Related kernel patch and bug reports: 
    https://patchwork.kernel.org/project/netdevbpf/patch/c2ef23da1d9a4eb62f4e7b7c4540f9bafb553c15.1658420239.git.dcaratti@redhat.com/#24948930
https://bugs.launchpad.net/charm-neutron-openvswitch/+bug/1899364

this PR is not backportable, as it assumes uses of systemd units for Kolla containers:

`After=kolla-openvswitch_vswitchd-container.service`