### PR TITLE
Install Wazuh 4.7.3 using wazuh-ansible

### DIFF
--- a/etc/kayobe/ansible/requirements.yml
+++ b/etc/kayobe/ansible/requirements.yml
@@ -26,7 +26,7 @@ roles:
     version: bugfix/inject-facts
   - name: wazuh-ansible
     src: https://github.com/stackhpc/wazuh-ansible
-    version: stackhpc
+    version: stackhpc-4.7.3
   - name: geerlingguy.pip
     version: 2.2.0
   - name: monolithprojects.github_actions_runner


### PR DESCRIPTION
Following the Wazuh installation instructions in the docs doesn't succeed on a fresh RL9 host, because of packaging issues with wazuh-manager (https://github.com/wazuh/wazuh/issues/14924).

Bump requirements.yml to bring in a branch of stackhpc/wazuh-ansible that deploys latest Wazuh (v4.7.3 ), which has a fix for the above issue.