### PR TITLE
yoga: Support running multinode clusters on Leafcloud

### DIFF
--- a/doc/source/configuration/vault.rst
+++ b/doc/source/configuration/vault.rst
@@ -111,7 +111,7 @@ Setup HAProxy config for Vault
 
    .. code-block::
 
-      kayobe overcloud service deploy -kt haproxy
+      kayobe overcloud service deploy --skip-tags os_capacity -kt haproxy
 
 Setup Vault HA on the overcloud hosts
 -------------------------------------

--- a/etc/kayobe/ansible/deploy-os-capacity-exporter.yml
+++ b/etc/kayobe/ansible/deploy-os-capacity-exporter.yml
@@ -1,6 +1,7 @@
 ---
 - name: Remove legacy os_exporter.cfg file
   hosts: network
+  tags: os_capacity
   gather_facts: false
   tasks:
     - name: Ensure legacy os_exporter.cfg config file is deleted
@@ -11,6 +12,7 @@
 
 - name: Deploy os-capacity exporter
   hosts: monitoring
+  tags: os_capacity
   gather_facts: false
   tasks:
     - name: Create os-capacity directory

--- a/etc/kayobe/ansible/fix-networking.yml
+++ b/etc/kayobe/ansible/fix-networking.yml
@@ -10,11 +10,13 @@
     # Work around no known_hosts entry on first boot.
     ansible_ssh_common_args: "-o StrictHostKeyChecking=no"
   tasks:
-    - name: Ensure `hosts` file contains pulp entries
+    - name: Ensure `hosts` file contains pulp and API entries
       blockinfile:
         path: /etc/hosts
-        marker: "# {mark} Kayobe Pulp entries"
+        marker: "# {mark} Kayobe entries"
         block: |
           10.0.0.34 pelican pelican.service.compute.sms-lab.cloud
           10.205.3.187 pulp-server pulp-server.internal.sms-cloud
+          192.168.37.2 internal.infra.mos.{{ root_domain }}
+          192.168.39.2 public.infra.mos.{{ root_domain }}
       become: true

--- a/etc/kayobe/ansible/fix-networking.yml
+++ b/etc/kayobe/ansible/fix-networking.yml
@@ -10,6 +10,9 @@
     # Work around no known_hosts entry on first boot.
     ansible_ssh_common_args: "-o StrictHostKeyChecking=no"
   tasks:
+    - name: Ensure hosts are reachable
+      ansible.builtin.wait_for_connection:
+
     - name: Ensure `hosts` file contains pulp and API entries
       blockinfile:
         path: /etc/hosts

--- a/etc/kayobe/environments/ci-multinode/cephadm.yml
+++ b/etc/kayobe/environments/ci-multinode/cephadm.yml
@@ -2,6 +2,12 @@
 ###############################################################################
 # Cephadm deployment configuration.
 
+# Ceph release name.
+cephadm_ceph_release: "{{ 'quincy' if (ansible_facts['distribution_release'] == 'jammy' or ansible_facts.distribution_major_version == '9') else 'pacific' }}"
+
+# Ceph container image tag.
+cephadm_image_tag: "{{ 'v17.2.7' if cephadm_ceph_release == 'quincy' else 'v16.2.14' }}"
+
 # Ceph OSD specification.
 cephadm_osd_spec:
   service_type: osd

--- a/etc/kayobe/environments/ci-multinode/globals.yml
+++ b/etc/kayobe/environments/ci-multinode/globals.yml
@@ -64,7 +64,7 @@ stackhpc_barbican_role_id_file_path: "/tmp/barbican-role-id"
 ###############################################################################
 
 # Avoid a reboot.
-disable_selinux_do_reboot: false
+disable_selinux_do_reboot: true
 
 ###############################################################################
 # Dummy variable to allow Ansible to accept this file.

--- a/etc/kayobe/environments/ci-multinode/kolla/globals.yml
+++ b/etc/kayobe/environments/ci-multinode/kolla/globals.yml
@@ -1,4 +1,9 @@
 ---
+# Most development environments will use nested virtualisation, and we can't
+# guarantee that nested KVM support is available. Use QEMU as a lowest common
+# denominator.
+nova_compute_virt_type: qemu
+
 # Reduce the control plane's memory footprint by limiting the number of worker
 # processes to two per-service when running in a VM.
 openstack_service_workers: "{% raw %}{{ [ansible_facts.processor_vcpus, 2 if ansible_facts.virtualization_role == 'guest' else 5] | min }}{% endraw %}"

--- a/etc/kayobe/environments/ci-multinode/stackhpc-ci.yml
+++ b/etc/kayobe/environments/ci-multinode/stackhpc-ci.yml
@@ -10,7 +10,8 @@ kolla_docker_namespace: stackhpc-dev
 
 # Host and port of a package repository mirror.
 # Build and deploy the development Pulp service repositories.
-stackhpc_repo_mirror_url: "http://pulp-server.internal.sms-cloud:8080"
+# Use Ark's package repositories to install packages.
+stackhpc_repo_mirror_url: "{{ stackhpc_release_pulp_url }}"
 stackhpc_repo_mirror_username: "skc-ci-aio"
 stackhpc_repo_mirror_password: !vault |
   $ANSIBLE_VAULT;1.1;AES256

--- a/etc/kayobe/environments/ci-multinode/stackhpc-ci.yml
+++ b/etc/kayobe/environments/ci-multinode/stackhpc-ci.yml
@@ -11,6 +11,14 @@ kolla_docker_namespace: stackhpc-dev
 # Host and port of a package repository mirror.
 # Build and deploy the development Pulp service repositories.
 stackhpc_repo_mirror_url: "http://pulp-server.internal.sms-cloud:8080"
+stackhpc_repo_mirror_username: "skc-ci-aio"
+stackhpc_repo_mirror_password: !vault |
+  $ANSIBLE_VAULT;1.1;AES256
+  36373536303261313239613761653261663437356566343865383563346334396136653666383765
+  6634396534653865633936653038383132396532386665370a366562383166353966663838316266
+  65333133636330623936623438666632316238376264313234346333346461623765633163353635
+  6565326136313564320a303231383438333062643533333335663034613439393665656162626137
+  65356232656164663831316530333136336362393636656566353635306565626636
 
 # Build and deploy released Pulp repository versions.
 stackhpc_repo_centos_stream_baseos_version: "{{ stackhpc_pulp_repo_centos_stream_8_baseos_version }}"
@@ -66,12 +74,5 @@ stackhpc_include_os_minor_version_in_repo_url: true
 # Push built images to the development Pulp service registry.
 stackhpc_docker_registry: "{{ stackhpc_repo_mirror_url | regex_replace('^https?://', '') }}"
 
-# Username and password of container registry.
-stackhpc_docker_registry_username: "stackhpc-kayobe-ci"
-stackhpc_docker_registry_password: !vault |
-          $ANSIBLE_VAULT;1.1;AES256
-          33356166343730633865363431306535613736663764373034396132356131343066636530393534
-          3262646436663034633131316438633230383330633533350a386365313239303464383636376338
-          61656662333939333063343131633963636431663136643137636664633233633133396339613861
-          3038613063626138610a333566393937643630366564653163613364323965396130613433316537
-          39653335393831633362343934363866346262613166393561666336623062393935
+stackhpc_docker_registry_username: "{{ stackhpc_repo_mirror_username }}"
+stackhpc_docker_registry_password: "{{ stackhpc_repo_mirror_password }}"


### PR DESCRIPTION
This PR includes various changes. The first two affect all deployments:

- os_capacity: Add tags to playbook, update vault docs

The remaining ones affect only the multinode environment.

- ci-multinode: Set default Ceph release to Quincy on Rocky Linux 9
- ci-multinode: Use skc-ci-aio user for ci-multinode env
- ci-multinode: Use Ark package repositories to install packages
- ci-multinode: Allow rebooting for SELinux state
- ci-multinode: Add API FQDNs to /etc/hosts in fix-networking.yml
- ci-multinode: Wait for connection in fix-networking.yml
- ci-multinode: Use qemu virtualisation

Details are in individual commit messages.

This PR is required by https://github.com/stackhpc/terraform-kayobe-multinode/pull/45.