### PR TITLE
Fix tox whitespace warning

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -369,7 +369,7 @@ kolla_build_customizations: "{{ kolla_build_customizations_common | combine(koll
 
 # Dict mapping Kolla Dockerfile ARG names to their values.
 kolla_build_args:
-  node_exporter_version: "1.5.0" # kolla has 1.4.0
+  node_exporter_version: "1.5.0"  # kolla has 1.4.0
   node_exporter_sha256sum: "af999fd31ab54ed3a34b9f0b10c28e9acee9ef5ac5a5d5edfdde85437db7acbb"
 
 ###############################################################################


### PR DESCRIPTION
See [here](https://github.com/stackhpc/stackhpc-kayobe-config/actions/runs/8649973848/job/23717449450?pr=1016#step:5:22) for an example of the warning in CI