### PR TITLE
Update Ubuntu horizon tag to fix CVE-2023-31122

### DIFF
--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -12,6 +12,8 @@ kolla_image_tags:
   heat:
     rocky-9: 2023.1-rocky-9-20240319T134201
     ubuntu-jammy: 2023.1-ubuntu-jammy-20240319T134201
+  horizon:
+    ubuntu-jammy: 2023.1-ubuntu-jammy-20240402T104530
   letsencrypt:
     rocky-9: 2023.1-rocky-9-20240205T162323
     ubuntu-jammy: 2023.1-ubuntu-jammy-20240221T133905

--- a/releasenotes/notes/bump-horizon-694d426decbf7df3.yaml
+++ b/releasenotes/notes/bump-horizon-694d426decbf7df3.yaml
@@ -1,0 +1,5 @@
+---
+security:
+  - |
+    Update Horizon on Ubuntu to include apache2 package ``2.4.52-1ubuntu4.8``
+    which fixes CVE-2023-31122.


### PR DESCRIPTION
While updating horizon in Ubuntu to current SKC version, it was found that apache2 patch ``2.4.52-1ubuntu4.8`` was not included.
This patch is needed to fix CVE-2023-31122.