### PR TITLE
Raise alert on degraded network bonds

### DIFF
--- a/etc/kayobe/kolla/config/prometheus/system.rules
+++ b/etc/kayobe/kolla/config/prometheus/system.rules
@@ -96,6 +96,15 @@ groups:
       summary: Host clock not synchronising (instance {{ $labels.instance }})
       description: "Clock not synchronising. Ensure NTP is configured on this host."
 
+  - alert: HostNetworkBondDegraded
+    expr: (node_bonding_active - node_bonding_slaves) != 0
+    for: 2m
+    labels:
+      severity: warning
+    annotations:
+      summary: Host network bond degraded (instance {{ $labels.instance }})
+      description: "Bond {{ $labels.master }} degraded on {{ $labels.instance }}"
+
   - alert: HostConntrackLimit
     expr: node_nf_conntrack_entries / node_nf_conntrack_entries_limit > 0.8
     for: 5m

--- a/releasenotes/notes/network-bond-degraded-alert-d2a0b05002609ac1.yaml
+++ b/releasenotes/notes/network-bond-degraded-alert-d2a0b05002609ac1.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Adds a new Prometheus alert ``HostNetworkBondDegraded`` which will be
+    raised when at least one bond member is down.


### PR DESCRIPTION
This will raise a alert when at least one of the bond members is down. Adapted from awesome-prometheus-alerts [1].

[1] https://samber.github.io/awesome-prometheus-alerts/rules.html#rule-host-and-hardware-1-34