### PR TITLE
CI: Register overcloud host image as shared and add stackhpc-dev

### DIFF
--- a/.github/workflows/overcloud-host-image-build.yml
+++ b/.github/workflows/overcloud-host-image-build.yml
@@ -472,7 +472,7 @@ jobs:
         run: |
           source venvs/kayobe/bin/activate &&
           source src/kayobe-config/kayobe-env --environment ci-builder &&
-          kayobe playbook run \
+          kayobe playbook run -vvv \
           src/kayobe-config/etc/kayobe/ansible/openstack-host-image-upload.yml \
           -e local_image_path="/opt/kayobe/images/overcloud-ubuntu-jammy/overcloud-ubuntu-jammy.qcow2" \
           -e image_name=overcloud-ubuntu-jammy-${{ steps.host_image_tag.outputs.host_image_tag }}

--- a/etc/kayobe/ansible/openstack-host-image-upload.yml
+++ b/etc/kayobe/ansible/openstack-host-image-upload.yml
@@ -31,7 +31,8 @@
 
         - name: Ensure dependencies are installed
           pip:
-            name: openstacksdk
+            name: python-openstackclient
+            virtualenv: "{{ ansible_python_interpreter | dirname | dirname }}"
 
         - name: Upload an image to Glance
           openstack.cloud.image:
@@ -41,6 +42,33 @@
             disk_format: qcow2
             state: present
             filename: "{{ local_image_path }}"
+            # FIXME: Uncomment this when we have a newer openstack.cloud collection
+            #visibility: shared
+          register: image
+
+        # FIXME: Remove this when we have a newer openstack.cloud collection
+        - name: Make the image shared
+          command: openstack image set --shared {{ image.image.id }}
+
+        # Allow users in stackhpc-dev to use these images.
+        - name: Add image to stackhpc-dev project
+          command: openstack image add project {{ image.image.id }} stackhpc-dev
+
+        # FIXME: This needs to be done when authenticated in the stackhpc-dev
+        # project, but we don't have an app cred for this. It must be done
+        # manually for now.
+        # - name: Accept image membership in stackhpc-dev project
+        #   command: openstack image set {{ image.image.id }} --accept
+
+        - name: Display how to add the image to the stackhpc-dev project
+          debug:
+            msg: |-
+              The {{ image_name }} image has been shared with the stackhpc-dev
+              project but it must be accepted by a user authenticated in the
+              stackhpc-dev project before it can be used there. This can be
+              done using the following command:
+
+              openstack image add project {{ image.image.id }} stackhpc-dev
 
       always:
         - name: Remove clouds.yaml

--- a/etc/kayobe/ansible/openstack-host-image-upload.yml
+++ b/etc/kayobe/ansible/openstack-host-image-upload.yml
@@ -52,7 +52,7 @@
 
         # Allow users in stackhpc-dev to use these images.
         - name: Add image to stackhpc-dev project
-          command: openstack image add project {{ image.image.id }} stackhpc-dev
+          command: openstack image add project {{ image.image.id }} 2fbf511968aa443e883a82283b0f0160
 
         # FIXME: This needs to be done when authenticated in the stackhpc-dev
         # project, but we don't have an app cred for this. It must be done


### PR DESCRIPTION
In order for developers to be able to use overcloud images for testing,
they must be available in the stackhpc-dev project on Leafcloud. To do
this we can make the image shared, and add stackhpc-dev as a member.
Unfortunately someone in the stackhpc-dev project must also accept the
image membership before it becomes active. It's not possible to do this
with the existing app creds which are scoped to the stackhpc-ci project.
Instead we provide instructions on how to do it as a debug message.
