### PR TITLE
fix: conditional error when no seed exists

### DIFF
--- a/etc/kayobe/inventory/group_vars/seed-hypervisor/proxy.yml
+++ b/etc/kayobe/inventory/group_vars/seed-hypervisor/proxy.yml
@@ -1,0 +1,12 @@
+---
+###############################################################################
+# Configuration of HTTP(S) proxies.
+
+# The default value whilst only applied if `http_proxy` and `https_proxy` are set
+# will not work as the conditional fails to evaluate if the seed node does not exist.
+# This makes the `seed-hypervisor` reliant on the seed node.
+no_proxy: []
+
+###############################################################################
+# Dummy variable to allow Ansible to accept this file.
+workaround_ansible_issue_8743: yes


### PR DESCRIPTION
In situations where there is no `seed` the `seed-hypervisor` will fail a  host configure against `no_proxy` settings due to the conditional  attempting to access attributes that do not exist.