### PR TITLE
Magnum - removed appending to ca.cart

### DIFF
--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -18,8 +18,8 @@ kolla_image_tags:
     rocky-9: 2023.1-rocky-9-20240205T162323
     ubuntu-jammy: 2023.1-ubuntu-jammy-20240221T133905
   magnum:
-    rocky-9: 2023.1-rocky-9-20240411T125311
-    ubuntu-jammy: 2023.1-ubuntu-jammy-20240411T125311
+    rocky-9: 2023.1-rocky-9-20240422T152338
+    ubuntu-jammy: 2023.1-ubuntu-jammy-20240422T152338
   neutron:
     rocky-9: 2023.1-rocky-9-20240202T145927
     ubuntu-jammy: 2023.1-ubuntu-jammy-20240221T103817

--- a/releasenotes/notes/magnum-remove-cert-append-8797b640f25644ea.yaml
+++ b/releasenotes/notes/magnum-remove-cert-append-8797b640f25644ea.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes appending to ca.crt in make-cert-client.sh causing multiple identical
+    ca certs being added into /etc/kubernetes/certs/ca.crt.


### PR DESCRIPTION
Appending to ca.crt in make-cert-client.sh (introduced in #724203) causes multiple identical ca certs being added into /etc/kubernetes/certs/ca.crt which prevents kube-controller-manager from starting.