### PR TITLE
Fix Barbican templating

### DIFF
--- a/etc/kayobe/environments/ci-multinode/kolla/config/barbican.conf
+++ b/etc/kayobe/environments/ci-multinode/kolla/config/barbican.conf
@@ -7,7 +7,9 @@ enabled_secretstore_plugins=vault_plugin
 [vault_plugin]
 vault_url = https://{{ kolla_internal_vip_address }}:8200
 use_ssl = True
-ssl_ca_crt_file = {% raw %}{{ openstack_cacert }}{% endraw %}
+{% raw %}
+ssl_ca_crt_file = {{ openstack_cacert }}
+{% endraw %}
 approle_role_id = {{ secrets_barbican_approle_role_id }}
 approle_secret_id = {{ secrets_barbican_approle_secret_id }}
 kv_mountpoint = barbican


### PR DESCRIPTION
The existing template removes the newline after {% endraw%}, so the two config options get stacked onto the same line, breaking Barbican