### PR TITLE
Update vault haproxy template

### DIFF
--- a/doc/source/configuration/vault.rst
+++ b/doc/source/configuration/vault.rst
@@ -108,9 +108,10 @@ Setup HAProxy config for Vault
          option httpchk GET /v1/sys/health
          # https://www.vaultproject.io/api-docs/system/health
          # 200: initialized, unsealed, and active
+         # 429: backup
          # 501: not initialised (required for bootstrapping)
          # 503: sealed (required for bootstrapping)
-         http-check expect rstatus (200|501|503)
+         http-check expect rstatus (200|429)
 
       {% for host in groups['control'] %}
       {% set host_name = hostvars[host].ansible_facts.hostname %}


### PR DESCRIPTION
This is to stop alerts that are firing at client sites. This will also alert us if a vault is sealed and/or needs bootstrapping. 

In the future we should look at using the built in exporters as [suggested by](https://stackhpc.slack.com/archives/C01HX4N1G3X/p1710325604898319?thread_ts=1710183886.551489&cid=C01HX4N1G3X) @dougszumski 