### PR TITLE
Correct RL9 seed backup instructions

### DIFF
--- a/doc/source/operations/rocky-linux-9.rst
+++ b/doc/source/operations/rocky-linux-9.rst
@@ -745,8 +745,8 @@ Full procedure
 
     .. code:: console
 
-       sudo mkdir /var/lib/libvirt/images/backup
-       sudo cp -r /var/lib/libvirt/images /var/lib/libvirt/images/backup
+       sudo mkdir /var/lib/libvirt/images-backup
+       sudo cp -r /var/lib/libvirt/images /var/lib/libvirt/images-backup
 
 9.  Delete the seed root volume (check the structure & naming
     conventions first)


### PR DESCRIPTION
Current instructions have a recursive copy:

``cp: cannot copy a directory, '/var/lib/libvirt/images', into itself, '/var/lib/libvirt/images/backup/images'``