### PR TITLE
Generate backend TLS files for network hosts

### DIFF
--- a/etc/kayobe/ansible/vault-generate-backend-tls.yml
+++ b/etc/kayobe/ansible/vault-generate-backend-tls.yml
@@ -1,8 +1,8 @@
 ---
 # Required for uri module to work with self-signed certificates and for systems to trust
 # the self-signed CA
-- name: Install CA on controllers
-  hosts: controllers
+- name: Install CA
+  hosts: controllers:network
   tasks:
     - name: Copy the intermediate CA
       copy:
@@ -16,7 +16,7 @@
       shell: "{{ 'update-ca-trust' if ansible_facts.os_family == 'RedHat' else 'update-ca-certificates' }}"
 
 - name: Generate backend API certificates
-  hosts: controllers
+  hosts: controllers:network
   vars:
     vault_api_addr: "https://{{ kolla_internal_fqdn }}:8200"
     vault_intermediate_ca_name: "OS-TLS-INT"

--- a/releasenotes/notes/backend-tls-network-aa7b09008a2e1914.yaml
+++ b/releasenotes/notes/backend-tls-network-aa7b09008a2e1914.yaml
@@ -1,0 +1,6 @@
+---
+issues:
+  - |
+    Generate backend TLS files for network hosts. This fixes backend TLS
+    configuration for deployments where some API services are running on
+    network hosts.


### PR DESCRIPTION
We sometimes deploy API services on network hosts to provide then with external connectivity. Where this is the case, backend TLS files need to be generated for these hosts.