### PR TITLE
Prevent Ceph PgsUnclean alert because of backfill

### DIFF
--- a/etc/kayobe/kolla/config/prometheus/ceph.rules
+++ b/etc/kayobe/kolla/config/prometheus/ceph.rules
@@ -117,7 +117,7 @@ groups:
         requests.
 
   - alert: PgsUnclean
-    expr: ceph_pool_metadata * on(pool_id,instance) group_left() (ceph_pg_total - ceph_pg_clean) > 0
+    expr: ceph_pool_metadata * on(pool_id,instance) group_left() (ceph_pg_total - ceph_pg_clean - ceph_pg_backfilling - ceph_pg_backfill_wait) > 0
     for: 15m
     labels:
       severity: warning

--- a/releasenotes/notes/improve-ceph-pgs-unclean-alert-98306d397344b572.yaml
+++ b/releasenotes/notes/improve-ceph-pgs-unclean-alert-98306d397344b572.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Prevents raising a Ceph ``PgsUnclean`` alert because of backfilling which
+    can frequently happen because of normal rebalancing activities, such as use
+    of the Ceph balancer or OSD addition.


### PR DESCRIPTION
A Ceph cluster is often busy backfilling, because of use of the Ceph balancer or OSD addition. It is not helpful to raise the `PgsUnclean` alert because of this activity.