### PR TITLE
Build Horizon from stackhpc fork

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -121,6 +121,10 @@ kolla_sources:
     type: git
     location: https://github.com/stackhpc/cloudkitty.git
     reference: stackhpc/{{ openstack_release }}
+  horizon:
+    type: git
+    location: https://github.com/stackhpc/horizon.git
+    reference: stackhpc/{{ openstack_release }}
   horizon-plugin-cloudkitty-dashboard:
     type: git
     location: https://github.com/stackhpc/cloudkitty-dashboard.git


### PR DESCRIPTION
This is to revert the placement tab from the Hypervisors panel.