### PR TITLE
Q2 2024 yoga security patch

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -419,6 +419,13 @@ kolla_build_blocks:
     {% set magnum_capi_packages = ['git+https://github.com/stackhpc/magnum-capi-helm.git@v0.11.0'] %}
     RUN {{ macros.install_pip(magnum_capi_packages | customizable("pip_packages")) }}
     {% endraw %}
+  prometheus_msteams_repository_version: | # Yoga kolla has 1.5.0
+    {% raw %}
+    ARG prometheus_msteams_version=1.5.2
+    ARG prometheus_msteams_sha256sum=0f4df9ee31e655d1ec876ea2c53ab5ae5b07143ef21b9190e61b4d52839e135c
+    ARG prometheus_msteams_url=https://github.com/prometheus-msteams/prometheus-msteams/releases/download/v${prometheus_msteams_version}/prometheus-msteams-linux-{{debian_arch}}
+    {% endraw %}
+
 # Dict mapping image customization variable names to their values.
 # Each variable takes the form:
 # <image name>_<customization>_<operation>

--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -44,6 +44,7 @@ magnum_tag: "{% raw %}{{ kayobe_image_tags['magnum'][kolla_base_distro] }}{% end
 neutron_tag: "{% raw %}{{ kayobe_image_tags['neutron'][kolla_base_distro] }}{% endraw %}"
 nova_tag: "{% raw %}{{ kayobe_image_tags['nova'][kolla_base_distro] }}{% endraw %}"
 opensearch_tag: yoga-20231219T221916
+prometheus_tag: yoga-20240510T145442
 
 # These overrides are currently redundant, but are kept because it's not obvious that you need them if setting haproxy_tag
 glance_tls_proxy_tag: "{% raw %}{{ haproxy_tag | default(openstack_tag) }}{% endraw %}"

--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -37,6 +37,7 @@ kayobe_image_tags:
     ubuntu: yoga-20231103T161400
 
 cloudkitty_tag: "{% raw %}{{ kayobe_image_tags['cloudkitty'][kolla_base_distro] }}{% endraw %}"
+grafana_tag: yoga-20240510T114335
 heat_tag: "{% raw %}{{ kayobe_image_tags['heat'][kolla_base_distro] }}{% endraw %}"
 horizon_tag: yoga-20240510T114335
 magnum_tag: "{% raw %}{{ kayobe_image_tags['magnum'][kolla_base_distro] }}{% endraw %}"

--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -38,6 +38,7 @@ kayobe_image_tags:
 
 cloudkitty_tag: "{% raw %}{{ kayobe_image_tags['cloudkitty'][kolla_base_distro] }}{% endraw %}"
 heat_tag: "{% raw %}{{ kayobe_image_tags['heat'][kolla_base_distro] }}{% endraw %}"
+horizon_tag: yoga-20240510T114335
 magnum_tag: "{% raw %}{{ kayobe_image_tags['magnum'][kolla_base_distro] }}{% endraw %}"
 neutron_tag: "{% raw %}{{ kayobe_image_tags['neutron'][kolla_base_distro] }}{% endraw %}"
 nova_tag: "{% raw %}{{ kayobe_image_tags['nova'][kolla_base_distro] }}{% endraw %}"

--- a/releasenotes/notes/bump-horizon-grafana-prometheus-to-fix-critical-cve-5983cb1d1f6f3ceb.yaml
+++ b/releasenotes/notes/bump-horizon-grafana-prometheus-to-fix-critical-cve-5983cb1d1f6f3ceb.yaml
@@ -1,0 +1,12 @@
+---
+features:
+  - |
+    Bumped Horizon kolla image
+    Bumped Grafana from 10.1.5-1 to 10.4.2-1 (CentOS & Rocky Linux)
+    Bumped Grafana from 10.4.1 to 10.4.2 (Ubuntu)
+    Bumped Prometheus-msteams from 1.5.0 to 1.5.2
+security:
+  - |
+    Fixed CVE-2023-31047 for Horizon.
+    Fixed CVE-2023-49569 for Grafana.
+    Fixed CVE-2022-40083 and CVE-2021-4238 for Prometheus-msteams.


### PR DESCRIPTION
Kolla images for Horizon, Grafana and Prometheus services are bumped.
For horizon bump, custom requirements from https://github.com/stackhpc/requirements/pull/18
It can be a good idea to merge the PR above to retain the requirements change.

This update fixes
Horizon
- CVE-2023-31047 

Grafana
- CVE-2023-49569

Prometheus-msteams
- CVE-2022-40083
- CVE-2021-4238