### PR TITLE
Q2 2024 zed security patch

### DIFF
--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -12,6 +12,9 @@ kolla_image_tags:
   heat:
     rocky-9: zed-rocky-9-20240320T113114
     ubuntu-jammy: zed-ubuntu-jammy-20240320T113114
+  horizon:
+    rocky-9: zed-rocky-9-20240514T095142
+    ubuntu-jammy: zed-ubuntu-jammy-20240514T092357
   magnum:
     rocky-9: zed-rocky-9-20240301T100039
     ubuntu-jammy: zed-ubuntu-jammy-20240301T100039

--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -9,6 +9,9 @@ kolla_image_tags:
   cloudkitty:
     rocky-9: zed-rocky-9-20240503T150113
     ubuntu-jammy: zed-ubuntu-jammy-20240503T150113
+  grafana:
+    rocky-9: zed-rocky-9-20240514T095142
+    ubuntu-jammy: zed-ubuntu-jammy-20240514T092357
   heat:
     rocky-9: zed-rocky-9-20240320T113114
     ubuntu-jammy: zed-ubuntu-jammy-20240320T113114

--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -24,3 +24,6 @@ kolla_image_tags:
   neutron:
     rocky-9: zed-rocky-9-20240202T141530
     ubuntu-jammy: zed-ubuntu-jammy-20240202T143208
+  prometheus:
+    rocky-9: zed-rocky-9-20240514T095142
+    ubuntu-jammy: zed-ubuntu-jammy-20240514T092357

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -333,6 +333,12 @@ kolla_build_blocks:
     {% set magnum_capi_packages = ['git+https://github.com/stackhpc/magnum-capi-helm.git@v0.11.0'] %}
     RUN {{ macros.install_pip(magnum_capi_packages | customizable("pip_packages")) }}
     {% endraw %}
+  prometheus_msteams_repository_version: | # Zed kolla has 1.5.1
+    {% raw %}
+    ARG prometheus_msteams_version=1.5.2
+    ARG prometheus_msteams_sha256sum=0f4df9ee31e655d1ec876ea2c53ab5ae5b07143ef21b9190e61b4d52839e135c
+    ARG prometheus_msteams_url=https://github.com/prometheus-msteams/prometheus-msteams/releases/download/v${prometheus_msteams_version}/prometheus-msteams-linux-{{debian_arch}}
+    {% endraw %}
 # Dict mapping image customization variable names to their values.
 # Each variable takes the form:
 # <image name>_<customization>_<operation>

--- a/releasenotes/notes/zed-bump-horizon-grafana-prometheus-to-fix-critical-cve-4ebd80b4eb5336c7.yaml
+++ b/releasenotes/notes/zed-bump-horizon-grafana-prometheus-to-fix-critical-cve-4ebd80b4eb5336c7.yaml
@@ -1,0 +1,12 @@
+---
+features:
+  - |
+    Bumped Horizon kolla image
+    Bumped Grafana from 10.1.5-1 to 10.4.2-1 (Rocky Linux)
+    Bumped Grafana from 10.4.1 to 10.4.2 (Ubuntu)
+    Bumped Prometheus-msteams from 1.5.1 to 1.5.2
+security:
+  - |
+    Fixed CVE-2023-31047 for Horizon.
+    Fixed CVE-2023-49569 for Grafana.
+    Fixed CVE-2022-40083 and CVE-2021-4238 for Prometheus-msteams.


### PR DESCRIPTION
Kolla images for Horizon, Grafana and Prometheus services are bumped.
For horizon bump, custom requirements from https://github.com/stackhpc/requirements/pull/17

This update fixes
Horizon
- CVE-2023-31047 

Grafana
- CVE-2023-49569

Prometheus-msteams
- CVE-2022-40083
- CVE-2021-4238