### PR TITLE
Run StackHPC OpenStack tests in aio CI

### DIFF
--- a/.github/workflows/stackhpc-all-in-one.yml
+++ b/.github/workflows/stackhpc-all-in-one.yml
@@ -383,7 +383,7 @@ jobs:
       - name: Upload test result artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: test-results-${{ inputs.os_distribution }}-${{ inputs.os_release }}-${{ inputs.neutron_plugin }}${{ inputs.upgrade && '-upgrade' }}
+          name: test-results-${{ inputs.os_distribution }}-${{ inputs.os_release }}-${{ inputs.neutron_plugin }}${{ inputs.upgrade && '-upgrade' || '' }}
           path: |
             tempest-artifacts/
             sot-results/

--- a/.github/workflows/stackhpc-all-in-one.yml
+++ b/.github/workflows/stackhpc-all-in-one.yml
@@ -366,15 +366,38 @@ jobs:
         env:
           KAYOBE_AUTOMATION_SSH_PRIVATE_KEY: ${{ steps.ssh_key.outputs.ssh_key }}
 
+      - name: StackHPC OpenStack tests
+        id: stackhpc-openstack-tests
+        continue-on-error: true
+        run: |
+          mkdir -p sot-results
+          docker run -t --rm \
+            -v $(pwd):/stack/kayobe-automation-env/src/kayobe-config \
+            -v $(pwd)/sot-results:/stack/sot-results \
+            -e KAYOBE_ENVIRONMENT -e KAYOBE_VAULT_PASSWORD -e KAYOBE_AUTOMATION_SSH_PRIVATE_KEY \
+            $KAYOBE_IMAGE \
+            /stack/kayobe-automation-env/src/kayobe-config/.automation/pipeline/playbook-run.sh '$KAYOBE_CONFIG_PATH/ansible/stackhpc-openstack-tests.yml'
+        env:
+          KAYOBE_AUTOMATION_SSH_PRIVATE_KEY: ${{ steps.ssh_key.outputs.ssh_key }}
+
       - name: Upload test result artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: tempest-results-${{ inputs.os_distribution }}-${{ inputs.os_release }}-${{ inputs.neutron_plugin }}${{ inputs.upgrade && '-upgrade' }}
-          path: tempest-artifacts/*
+          name: test-results-${{ inputs.os_distribution }}-${{ inputs.os_release }}-${{ inputs.neutron_plugin }}${{ inputs.upgrade && '-upgrade' }}
+          path: |
+            tempest-artifacts/
+            sot-results/
 
       - name: Fail if any Tempest tests failed
         run: |
           test $(wc -l < tempest-artifacts/failed-tests) -lt 1
+
+      - name: Fail if any StackHPC OpenStack tests failed
+        run: |
+          echo "Some StackHPC OpenStack tests failed."
+          echo "See HTML results artifact (sot-results) for details."
+          exit 1
+        if: steps.stackhpc-openstack-tests.outcome == 'failure'
 
       - name: Destroy
         run: terraform destroy -auto-approve

--- a/etc/kayobe/ansible/stackhpc-openstack-tests.yml
+++ b/etc/kayobe/ansible/stackhpc-openstack-tests.yml
@@ -1,0 +1,96 @@
+---
+- name: Run StackHPC OpenStack tests
+  hosts: tempest_runner
+  tags:
+    - stackhpc-openstack-tests
+  vars:
+    sot_venv: "{{ virtualenv_path }}/sot-venv"
+    sot_repo: "https://github.com/stackhpc/stackhpc-openstack-tests"
+    sot_version: "v0.0.1"
+    sot_timeout: 30
+    results_path_local: "{{ lookup('env', 'HOME') }}/sot-results"
+  tasks:
+    - block:
+        - name: Create a temporary directory for tests repo
+          ansible.builtin.tempfile:
+            state: directory
+            suffix: sot-repo
+          register: repo_tmpdir
+
+        - name: Create a temporary directory for results
+          ansible.builtin.tempfile:
+            state: directory
+            suffix: sot-results
+          register: results_tmpdir
+
+        - name: Clone the StackHPC OpenStack tests repository
+          ansible.builtin.git:
+            repo: "{{ sot_repo }}"
+            version: "{{ sot_version }}"
+            dest: "{{ repo_tmpdir.path }}"
+            depth: 1
+            single_branch: true
+
+        - name: Ensure the latest versions of pip and setuptools are installed # noqa package-latest
+          ansible.builtin.pip:
+            name: "{{ item.name }}"
+            state: latest
+            virtualenv: "{{ sot_venv }}"
+            virtualenv_command: "python3 -m venv"
+          with_items:
+            - { name: pip }
+            - { name: setuptools }
+
+        - name: Ensure required Python packages are installed
+          ansible.builtin.pip:
+            name:
+              - "{{ repo_tmpdir.path }}"
+              - "-r{{ repo_tmpdir.path }}/requirements.txt"
+              - pytest-html
+              - pytest-timeout
+            virtualenv: "{{ sot_venv }}"
+
+        - name: Include Kolla Ansible passwords
+          ansible.builtin.include_vars:
+            file: "{{ kayobe_env_config_path }}/kolla/passwords.yml"
+            name: kolla_passwords
+
+        - name: Run StackHPC OpenStack tests
+          ansible.builtin.command:
+            cmd: >
+              {{ sot_venv }}/bin/py.test
+              --html={{ results_tmpdir.path }}/stackhpc-openstack-tests.html
+              --self-contained-html
+              --pyargs stackhpc_openstack_tests
+              --timeout {{ sot_timeout }}
+              -vv
+          environment:
+            OPENSEARCH_HOSTS: "{{ sot_opensearch_hosts }}"
+            OPENSEARCH_PORT: "{{ sot_opensearch_port }}"
+            OPENSEARCH_TLS: "{{ sot_opensearch_tls }}"
+            PROMETHEUS_URL: "{{ sot_prometheus_url }}"
+            PROMETHEUS_USERNAME: "{{ sot_prometheus_username }}"
+            PROMETHEUS_PASSWORD: "{{ sot_prometheus_password }}"
+          vars:
+            kolla_external_scheme: "{{ 'https' if kolla_enable_tls_external | bool else 'http' }}"
+            kolla_internal_scheme: "{{ 'https' if kolla_enable_tls_internal | bool else 'http' }}"
+            sot_opensearch_hosts: "{{ kolla_internal_fqdn }}"
+            sot_opensearch_port: 9200
+            sot_opensearch_tls: false
+            sot_prometheus_url: "{{ kolla_internal_scheme }}://{{ kolla_internal_fqdn }}:9091"
+            sot_prometheus_username: "admin"
+            sot_prometheus_password: "{{ kolla_passwords.prometheus_password }}"
+      always:
+        - name: Fetch results
+          ansible.builtin.fetch:
+            src: "{{ results_tmpdir.path }}/stackhpc-openstack-tests.html"
+            dest: "{{ results_path_local }}/"
+            flat: true
+
+        - name: Clean up temporary directory
+          ansible.builtin.file:
+            path: "{{ item }}"
+            state: absent
+          loop:
+            - "{{ repo_tmpdir.path }}"
+            - "{{ results_tmpdir.path }}"

--- a/releasenotes/notes/stackhpc-openstack-tests-0224908453ae72cc.yaml
+++ b/releasenotes/notes/stackhpc-openstack-tests-0224908453ae72cc.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Adds a new ``stackhpc-openstack-tests.yml`` playbook that executes tests in
+    the `StackHPC OpenStack Tests
+    <https://github.com/stackhpc/stackhpc-openstack-tests>`__ repository. Both
+    the playbook and tests are currently experimental, and are currently
+    targeting only an all-in-one CI use case.


### PR DESCRIPTION
This change adds a new playbook, stackhpc-openstack-tests.yml, that uses
the new stackhpc-openstack-tests repository to perform testing of the
deployment that is not covered by Rally or Tempest. Currently this
includes Prometheus and OpenSearch.

The all-in-one CI test has been updated to run this new test suite, and
the results are included in the test results artifact.
