### PR TITLE
Support synchronising custom container images

### DIFF
--- a/doc/source/configuration/release-train.rst
+++ b/doc/source/configuration/release-train.rst
@@ -153,6 +153,33 @@ By default, HashiCorp images (Consul and Vault) are not synced from Docker Hub
 to the local Pulp. To sync these images, set ``stackhpc_sync_hashicorp_images``
 to ``true``.
 
+Custom container images
+-----------------------
+
+A custom list of container images can be synced to the local Pulp using the
+``stackhpc_pulp_repository_container_repos_extra`` and
+``stackhpc_pulp_distribution_container_extra`` variables.
+
+.. code-block:: yaml
+
+   # List of extra container image repositories.
+   stackhpc_pulp_repository_container_repos_extra:
+     - name: "certbot/certbot"
+       url: "https://registry-1.docker.io"
+       policy: on_demand
+       proxy_url: "{{ pulp_proxy_url }}"
+       state: present
+       include_tags: "nightly"
+       required: True
+
+   # List of extra container image distributions.
+   stackhpc_pulp_distribution_container_extra:
+     - name: certbot
+       repository: certbot/certbot
+       base_path: certbot/certbot
+       state: present
+       required: True
+
 Usage
 =====
 

--- a/etc/kayobe/pulp.yml
+++ b/etc/kayobe/pulp.yml
@@ -821,14 +821,22 @@ stackhpc_pulp_distribution_container_hashicorp:
     state: present
     required: "{{ stackhpc_sync_hashicorp_images | bool }}"
 
+# List of extra container image repositories.
+stackhpc_pulp_repository_container_repos_extra: []
+
+# List of extra container image distributions.
+stackhpc_pulp_distribution_container_extra: []
+
 # List of container image repositories.
 stackhpc_pulp_repository_container_repos: >-
   {{ (stackhpc_pulp_repository_container_repos_kolla +
       stackhpc_pulp_repository_container_repos_ceph +
-      stackhpc_pulp_repository_container_repos_hashicorp) | selectattr('required') }}
+      stackhpc_pulp_repository_container_repos_hashicorp +
+      stackhpc_pulp_repository_container_repos_extra) | selectattr('required') }}
 
 # List of container image distributions.
 stackhpc_pulp_distribution_container: >-
   {{ (stackhpc_pulp_distribution_container_kolla +
       stackhpc_pulp_distribution_container_ceph +
-      stackhpc_pulp_distribution_container_hashicorp) | selectattr('required') }}
+      stackhpc_pulp_distribution_container_hashicorp +
+      stackhpc_pulp_distribution_container_extra) | selectattr('required') }}

--- a/releasenotes/notes/pulp-container-extra-9379806192900d22.yaml
+++ b/releasenotes/notes/pulp-container-extra-9379806192900d22.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Allows to synchronise a custom list of containers to Pulp using the
+    ``stackhpc_pulp_repository_container_repos_extra`` and
+    ``stackhpc_pulp_distribution_container_extra`` variables.


### PR DESCRIPTION
A custom list of container images can be synced to the local Pulp using the `stackhpc_pulp_repository_container_repos_extra` and `stackhpc_pulp_distribution_container_extra` variables.