### PR TITLE
Aio Improvements

### DIFF
--- a/doc/source/contributor/environments/ci-aio.rst
+++ b/doc/source/contributor/environments/ci-aio.rst
@@ -43,14 +43,21 @@ Run the setup script:
    ./automated-setup.sh
 
 The script will pull the current version of Kayobe and this repository, and
-then run the manual setup steps below. The script can be easily edited to use a
-different branch of Kayobe or this repository. The script will assume that your
-image is LVM-based and will expand the volume sizes to allow ansible
-dependencies to install correctly. If it is not, set ``KAYOBE_AIO_LVM`` to
-false.
+then run the manual setup steps below. The script can be easily edited with the
+following options:
 
-The deployment can be paused after cloning your Kayobe configuration to allow
-for custom edits, by setting ``KAYOBE_CONFIG_EDIT_PAUSE`` to ``true``.
+* ``BASE_PATH`` (default: ``~``) - Directory to deploy from. The directory must
+  exist before running the script.
+* ``KAYOBE_BRANCH`` (default: ``stackhpc/2023.1``) - The branch of Kayobe
+  source code to use.
+* ``KAYOBE_CONFIG_BRANCH`` (default: ``stackhpc/2023.1``) - The branch of
+  ``stackhpc-kayobe-config`` to use.
+* ``KAYOBE_AIO_LVM`` (default: ``true``) - Whether the image uses LVM.
+* ``KAYOBE_CONFIG_EDIT_PAUSE`` (default: ``false``) - Option to pause
+  deployment after cloning the kayobe-config branch, so the environment can be
+  customised before continuing.
+* ``AIO_RUN_TEMPEST`` (default: ``false``) - Whether to run Tempest Refstack
+  after deployment instead of the default VM smoke test.
 
 Manual Setup
 ============

--- a/doc/source/contributor/environments/ci-aio.rst
+++ b/doc/source/contributor/environments/ci-aio.rst
@@ -10,11 +10,6 @@ automates the manual setup steps below, and is recommended for most users.
 The manual setup steps are provided for reference, and for users who wish to
 make changes to the setup process.
 
-.. warning::
-
-    This guide was written for the Yoga release and has not been validated for
-    Antelope. Proceed with caution.
-
 Prerequisites
 =============
 
@@ -48,10 +43,14 @@ Run the setup script:
    ./automated-setup.sh
 
 The script will pull the current version of Kayobe and this repository, and
-then run the manual setup steps below. The script can be easily edited to use
-a different branch of Kayobe or this repository. The script will automatically
-determine whether your image is LVM based, if so, it will expand the volume sizes
-to allow ansible dependencies to install correctly.
+then run the manual setup steps below. The script can be easily edited to use a
+different branch of Kayobe or this repository. The script will assume that your
+image is LVM-based and will expand the volume sizes to allow ansible
+dependencies to install correctly. If it is not, set ``KAYOBE_AIO_LVM`` to
+false.
+
+The deployment can be paused after cloning your Kayobe configuration to allow
+for custom edits, by setting ``KAYOBE_CONFIG_EDIT_PAUSE`` to ``true``.
 
 Manual Setup
 ============

--- a/etc/kayobe/environments/ci-aio/automated-setup.sh
+++ b/etc/kayobe/environments/ci-aio/automated-setup.sh
@@ -6,6 +6,7 @@ BASE_PATH=~
 KAYOBE_BRANCH=stackhpc/2023.1
 KAYOBE_CONFIG_BRANCH=stackhpc/2023.1
 KAYOBE_AIO_LVM=true
+KAYOBE_CONFIG_EDIT_PAUSE=false
 
 if [[ ! -f $BASE_PATH/vault-pw ]]; then
     echo "Vault password file not found at $BASE_PATH/vault-pw"
@@ -39,6 +40,12 @@ pushd src
 [[ -d kayobe ]] || git clone https://github.com/stackhpc/kayobe.git -b $KAYOBE_BRANCH
 [[ -d kayobe-config ]] || git clone https://github.com/stackhpc/stackhpc-kayobe-config kayobe-config -b $KAYOBE_CONFIG_BRANCH
 popd
+
+if $KAYOBE_CONFIG_EDIT_PAUSE; then
+   echo "Deployment is paused, edit configuration in another terminal"
+   echo "Press enter to continue"
+   read -s
+fi
 
 if ! sudo vgdisplay | grep -q lvm2; then
    rm $BASE_PATH/src/kayobe-config/etc/kayobe/environments/ci-aio/inventory/group_vars/controllers/lvm.yml


### PR DESCRIPTION
Updated the Docs and added two new options:
`KAYOBE_CONFIG_EDIT_PAUSE` will pause the deployment after the kayobe-config branch has been pulled, so you can make custom changes to the config
`AIO_RUN_TEMPEST` will run tempest refstack after deploying services, rather than just VM