### PR TITLE
OS Capacity: Support providing a CA certificate

### DIFF
--- a/doc/source/configuration/monitoring.rst
+++ b/doc/source/configuration/monitoring.rst
@@ -137,6 +137,8 @@ depending on your configuration, you may need set the
 ``kolla_enable_prometheus_ceph_mgr_exporter`` variable to ``true`` in order to
 enable the ceph mgr exporter.
 
+.. _os-capacity:
+
 OpenStack Capacity
 ==================
 
@@ -160,9 +162,19 @@ project domain name in ``stackhpc-monitoring.yml``:
     stackhpc_os_capacity_openstack_region_name: <openstack_region_name>
 
 Additionally, you should ensure these credentials have the correct permissions
-for the exporter. If you are deploying in a cloud with internal TLS, you may be required
-to disable certificate verification for the OpenStack Capacity exporter
-if your certificate is not signed by a trusted CA.
+for the exporter.
+
+If you are deploying in a cloud with internal TLS, you may be required
+to provide a CA certificate for the OpenStack Capacity exporter if your
+certificate is not signed by a trusted CA. For example, to use a CA certificate
+named ``vault.crt`` that is also added to the Kolla containers:
+
+.. code-block:: yaml
+
+    stackhpc_os_capacity_openstack_cacert: "{{ kayobe_env_config_path }}/kolla/certificates/ca/vault.crt"
+
+Alternatively, to disable certificate verification for the OpenStack Capacity
+exporter:
 
 .. code-block:: yaml
 

--- a/doc/source/configuration/vault.rst
+++ b/doc/source/configuration/vault.rst
@@ -196,6 +196,8 @@ Enable the required TLS variables in kayobe and kolla
       # Whether TLS is enabled for the internal API endpoints. Default is 'no'.
       kolla_enable_tls_internal: yes
 
+   See :ref:`os-capacity` for information on adding CA certificates to the trust store when deploying the OpenStack Capacity exporter.
+
 2. Set the following in etc/kayobe/kolla/globals.yml or if environments are being used etc/kayobe/environments/$KAYOBE_ENVIRONMENT/kolla/globals.yml
 
    .. code-block::

--- a/etc/kayobe/ansible/deploy-os-capacity-exporter.yml
+++ b/etc/kayobe/ansible/deploy-os-capacity-exporter.yml
@@ -27,6 +27,7 @@
       delegate_to: localhost
       register: credential
       when: stackhpc_enable_os_capacity
+      changed_when: false
 
     - name: Set facts for admin credentials
       ansible.builtin.set_fact:
@@ -43,6 +44,16 @@
         src: templates/os_capacity-clouds.yml.j2
         dest: /opt/kayobe/os-capacity/clouds.yaml
       when: stackhpc_enable_os_capacity
+      register: clouds_yaml_result
+
+    - name: Copy CA certificate to OpenStack Capacity nodes
+      ansible.builtin.copy:
+        src: "{{ stackhpc_os_capacity_openstack_cacert }}"
+        dest: /opt/kayobe/os-capacity/cacert.pem
+      when:
+        - stackhpc_enable_os_capacity
+        - stackhpc_os_capacity_openstack_cacert | length > 0
+      register: cacert_result
 
     - name: Ensure os_capacity container is running
       community.docker.docker_container:
@@ -56,6 +67,7 @@
             source: /opt/kayobe/os-capacity/
             target: /etc/openstack/
         network_mode: host
+        restart: "{{ clouds_yaml_result is changed or cacert_result is changed }}"
         restart_policy: unless-stopped
       become: true
       when: stackhpc_enable_os_capacity

--- a/etc/kayobe/ansible/templates/os_capacity-clouds.yml.j2
+++ b/etc/kayobe/ansible/templates/os_capacity-clouds.yml.j2
@@ -10,6 +10,9 @@ clouds:
     interface: "internal"
     identity_api_version: 3
     auth_type: "password"
+{% if stackhpc_os_capacity_openstack_cacert | length > 0 %}
+    cacert: /etc/openstack/cacert.pem
+{% endif %}
 {% if not stackhpc_os_capacity_openstack_verify | bool %}
     verify: False
 {% endif %}

--- a/etc/kayobe/environments/ci-multinode/stackhpc-monitoring.yml
+++ b/etc/kayobe/environments/ci-multinode/stackhpc-monitoring.yml
@@ -1,0 +1,3 @@
+---
+# Path to a CA certificate file to trust in the OpenStack Capacity exporter.
+stackhpc_os_capacity_openstack_cacert: "{{ kayobe_env_config_path }}/kolla/certificates/ca/vault.crt"

--- a/etc/kayobe/stackhpc-monitoring.yml
+++ b/etc/kayobe/stackhpc-monitoring.yml
@@ -20,6 +20,9 @@ alertmanager_warn_network_bond_single_link: true
 # targets being templated during deployment.
 stackhpc_enable_os_capacity: true
 
+# Path to a CA certificate file to trust in the OpenStack Capacity exporter.
+stackhpc_os_capacity_openstack_cacert: ""
+
 # Whether TLS certificate verification is enabled for the OpenStack Capacity
 # exporter during Keystone authentication.
 stackhpc_os_capacity_openstack_verify: true

--- a/releasenotes/notes/os-capacity-cacert-8b800b22d84ae0b1.yaml
+++ b/releasenotes/notes/os-capacity-cacert-8b800b22d84ae0b1.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Adds support for providing a CA certificate for OpenStack Capacity exporter.


### PR DESCRIPTION
For clouds that use an internal CA, it is necessary to provide a CA certificate to OS capacity.