### PR TITLE
Build neutron-mlnx-agent kolla container

### DIFF
--- a/etc/kayobe/pulp.yml
+++ b/etc/kayobe/pulp.yml
@@ -477,6 +477,7 @@ stackhpc_pulp_images_kolla:
   - neutron-dhcp-agent
   - neutron-l3-agent
   - neutron-metadata-agent
+  - neutron-mlnx-agent
   - neutron-openvswitch-agent
   - neutron-server
   - neutron-sriov-agent


### PR DESCRIPTION
Enabling building of neutron-mlnx-agent kolla container for Infiniband VF support.
This container is also pulled for neutron-eswitchd, another requirement for Infiniband VF support.