### PR TITLE
Add condition to ensure swap is not zero for swap alert

### DIFF
--- a/etc/kayobe/kolla/config/prometheus/system.rules
+++ b/etc/kayobe/kolla/config/prometheus/system.rules
@@ -25,7 +25,7 @@ groups:
       description: "Available memory is {{ $value }} GiB."
 
   - alert: LowSwapSpace
-    expr: (node_memory_SwapFree_bytes / node_memory_SwapTotal_bytes) < {% endraw %}{{ alertmanager_node_free_swap_warning_threshold_ratio }}{% raw %}
+    expr: node_memory_SwapTotal_bytes > 0 and (node_memory_SwapFree_bytes / node_memory_SwapTotal_bytes) < {% endraw %}{{ alertmanager_node_free_swap_warning_threshold_ratio }}{% raw %}
     for: 1m
     labels:
       severity: warning
@@ -34,7 +34,7 @@ groups:
       description: "Available swap space is {{ $value | humanizePercentage }}. Running out of swap space causes OOM Kills."
 
   - alert: LowSwapSpace
-    expr: (node_memory_SwapFree_bytes / node_memory_SwapTotal_bytes) < {% endraw %}{{ alertmanager_node_free_swap_critical_threshold_ratio }}{% raw %}
+    expr: node_memory_SwapTotal_bytes > 0 and (node_memory_SwapFree_bytes / node_memory_SwapTotal_bytes) < {% endraw %}{{ alertmanager_node_free_swap_critical_threshold_ratio }}{% raw %}
     for: 1m
     labels:
       severity: critical


### PR DESCRIPTION
I thought I introduced divide by zero situation even though Prometheus can handle zero denominator with NaN. Let's add condition explicitly checking if swap space is not zero for humans.