### PR TITLE
Remove CentOS AIO CI tests

### DIFF
--- a/.github/workflows/stackhpc-all-in-one.yml
+++ b/.github/workflows/stackhpc-all-in-one.yml
@@ -14,7 +14,7 @@ on:
       os_distribution:
         description: Host OS distribution
         type: string
-        default: centos
+        default: rocky
       os_release:
         description: Host OS release
         type: string

--- a/.github/workflows/stackhpc-pull-request.yml
+++ b/.github/workflows/stackhpc-pull-request.yml
@@ -76,34 +76,6 @@ jobs:
       if: ${{ needs.check-changes.outputs.aio == 'true' }}
     if: github.repository == 'stackhpc/stackhpc-kayobe-config'
 
-  all-in-one-centos-ovs:
-    name: aio (CentOS OVS)
-    needs:
-      - check-changes
-      - build-kayobe-image
-    uses: ./.github/workflows/stackhpc-all-in-one.yml
-    with:
-      kayobe_image: ${{ needs.build-kayobe-image.outputs.kayobe_image }}
-      neutron_plugin: ovs
-      OS_CLOUD: openstack
-      if: ${{ needs.check-changes.outputs.aio == 'true' }}
-    secrets: inherit
-    if: ${{ ! failure() && ! cancelled() && github.repository == 'stackhpc/stackhpc-kayobe-config' }}
-
-  all-in-one-centos-ovn:
-    name: aio (CentOS OVN)
-    needs:
-      - check-changes
-      - build-kayobe-image
-    uses: ./.github/workflows/stackhpc-all-in-one.yml
-    with:
-      kayobe_image: ${{ needs.build-kayobe-image.outputs.kayobe_image }}
-      neutron_plugin: ovn
-      OS_CLOUD: openstack
-      if: ${{ needs.check-changes.outputs.aio == 'true' }}
-    secrets: inherit
-    if: ${{ ! failure() && ! cancelled() && github.repository == 'stackhpc/stackhpc-kayobe-config' }}
-
   all-in-one-rocky-8-ovs:
     name: aio (Rocky OVS)
     needs:


### PR DESCRIPTION
CentOS AIOs are now failing. The benefit they bring is outweighed by the cost of maintenance at this point. This PR removes them.

See also https://github.com/stackhpc/stackhpc-release-train/pull/307