### PR TITLE
Improve rabbitmq reset playbook matching

### DIFF
--- a/etc/kayobe/ansible/rabbitmq-reset.yml
+++ b/etc/kayobe/ansible/rabbitmq-reset.yml
@@ -68,4 +68,4 @@
     # The following services use RabbitMQ.
     - name: Restart OpenStack services
       shell: >-
-        systemctl -a | egrep '(barbican|blazar|cinder|cloudkitty|designate|heat|ironic|keystone|magnum|manila|neutron|nova|octavia)' | awk '{ print $1 }' | xargs systemctl restart
+        systemctl list-units --type=service | tr ' ' '\n' | egrep '^kolla-(barbican|blazar|cinder|cloudkitty|designate|heat|ironic|keystone|magnum|manila|neutron|nova|octavia).*-container\.service' | uniq | xargs systemctl restart


### PR DESCRIPTION
Two issues were picked up during the Sussex deployment. The original command matched against the correct lines but also these:
```
ceph-42b27b44-271a-11ef-8338-58a2e1dff6f2@mds.manila-cephfs.artemis-cp-01.rygqwc.service
●
●
●
```
The first issue is that it was matching against ceph containers which happen to have ```manila``` in the name
The second was that it was matching against failed units, which show up in the list like this:
```
kolla-haproxy-container.service      loaded    active   running   docker kolla-haproxy-container.service
● kolla-heat_api-container.service      loaded    failed   failed    docker kolla-heat_api-container.service
```
So it's matching against the dot
Stopped containers don't need to be stopped and restarted so we should only match against running units