### PR TITLE
Actually check key type

### DIFF
--- a/etc/kayobe/ansible/cis.yml
+++ b/etc/kayobe/ansible/cis.yml
@@ -6,12 +6,19 @@
   tasks:
     # TODO: Remove this when Red Hat FIPS policy has been updated to allow ed25519 keys.
     # https://gitlab.com/gitlab-org/gitlab/-/issues/367429#note_1840422075
-    - name: Assert that we are using a supported SSH key
-      assert:
-        that:
-          - ssh_key_type != 'ed25519'
-        fail_msg: FIPS policy does not currently support ed25519 SSH keys on RHEL family systems
-      when: ansible_facts.os_family == 'RedHat'
+    - when: ansible_facts.os_family == 'RedHat'
+      block:
+       - name: Check type of key using the file command
+         raw: file {{ ssh_private_key_path }}
+         delegate_to: localhost
+         changed_when: false
+         register: ssh_key_check
+
+       - name: Assert that we are using a supported SSH key
+         assert:
+            that:
+              - ssh_key_check.stdout | regex_search('ed25519', ignorecase=true)
+            fail_msg: FIPS policy does not currently support ed25519 SSH keys on RHEL family systems
 
     - name: Ensure the cron package is installed on ubuntu
       package:


### PR DESCRIPTION
Don't assume that users won't lie to you. I actually hit this when following the terraform multinode README. My version of openssh will generate ed25519 keys by default and the example command in the README names this id_rsa[1]. This of course ends up locking you out of the system.

[1] https://github.com/stackhpc/terraform-kayobe-multinode/blob/a3e72a90c8ce835cc2bb4cbda83e79b0c32afdde/README.rst#L73