### PR TITLE
Bump Kolla images for CVE-2024-36039

### DIFF
--- a/.github/workflows/stackhpc-all-in-one.yml
+++ b/.github/workflows/stackhpc-all-in-one.yml
@@ -167,7 +167,7 @@ jobs:
           VM_NETWORK: ${{ inputs.vm_network }}
           VM_SUBNET: ${{ inputs.vm_subnet }}
           VM_INTERFACE: ${{ inputs.vm_interface }}
-          VM_VOLUME_SIZE: ${{ inputs.upgrade && '50' || '35' }}
+          VM_VOLUME_SIZE: ${{ inputs.upgrade && '50' || '40' }}
           VM_TAGS: '["skc-ci-aio", "PR=${{ github.event.number }}"]'
 
       - name: Terraform Plan

--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -4,14 +4,14 @@
 # where the key is the OS distro and the value is the tag to deploy.
 kolla_image_tags:
   openstack:
+    rocky-9: 2023.1-rocky-9-20240621T104542
+    ubuntu-jammy: 2023.1-ubuntu-jammy-20240621T104542
+  bifrost_deploy:
     rocky-9: 2023.1-rocky-9-20240423T125905
     ubuntu-jammy: 2023.1-ubuntu-jammy-20240423T125905
   cinder:
     rocky-9: 2023.1-rocky-9-20240701T123544
     ubuntu-jammy: 2023.1-ubuntu-jammy-20240701T123544
-  cloudkitty:
-    rocky-9: 2023.1-rocky-9-20240509T111619
-    ubuntu-jammy: 2023.1-ubuntu-jammy-20240509T111619
   glance:
     rocky-9: 2023.1-rocky-9-20240701T123544
     ubuntu-jammy: 2023.1-ubuntu-jammy-20240701T123544
@@ -21,9 +21,6 @@ kolla_image_tags:
   letsencrypt:
     rocky-9: 2023.1-rocky-9-20240509T102329
     ubuntu-jammy: 2023.1-ubuntu-jammy-20240509T102329
-  magnum:
-    rocky-9: 2023.1-rocky-9-20240607T082105
-    ubuntu-jammy: 2023.1-ubuntu-jammy-20240607T082105
   nova:
     rocky-9: 2023.1-rocky-9-20240702T082319
     ubuntu-jammy: 2023.1-ubuntu-jammy-20240702T082319

--- a/releasenotes/notes/kolla-bump-cve-2024-36039-07f18e18b5c86980.yaml
+++ b/releasenotes/notes/kolla-bump-cve-2024-36039-07f18e18b5c86980.yaml
@@ -1,0 +1,7 @@
+---
+security:
+  - |
+    Addresses critical vulnerability CVE-2024-36039 by
+    bumping the PyMySQL library to 1.1.1 in all affected
+    Kolla images. This vulnerability allows SQL injection 
+    through untrusted JSON objects.


### PR DESCRIPTION
Bump Kolla images to address [CVE-2024-36039](https://github.com/advisories/GHSA-v9hf-5j83-6xpp)