### PR TITLE
Refer to internal docs for building amphora images

### DIFF
--- a/doc/source/operations/octavia.rst
+++ b/doc/source/operations/octavia.rst
@@ -2,6 +2,8 @@
 Octavia
 =======
 
+.. _Amphora image:
+
 Building and rotating amphora images
 ====================================
 

--- a/doc/source/operations/upgrading.rst
+++ b/doc/source/operations/upgrading.rst
@@ -975,9 +975,8 @@ scope of the upgrade:
 Updating the Octavia Amphora Image
 ----------------------------------
 
-If using Octavia with the Amphora driver, you may want to `build a new amphora
-image
-<https://docs.openstack.org/octavia/latest/admin/guides/operator-maintenance.html#rotating-the-amphora-images>`__.
+If using Octavia with the Amphora driver, you should :ref:`build a new amphora
+image <Amphora image>`.
 
 Testing
 -------


### PR DESCRIPTION
Easy to miss that these exist without a direct link. The original [PR](https://github.com/stackhpc/stackhpc-kayobe-config/pull/1100) targeted zed so I've updated that branch, but we should be careful not to forget to port this forward to the current docs.