### PR TITLE
Do not disable IPV6 by default

### DIFF
--- a/etc/kayobe/inventory/group_vars/overcloud/cis
+++ b/etc/kayobe/inventory/group_vars/overcloud/cis
@@ -133,4 +133,10 @@ ubtu22cis_max_log_file_size: 1024
 # ubtu22cis_bootloader_password_hash
 ubtu22cis_rule_1_4_1: false
 ubtu22cis_rule_1_4_3: false
+
+# The way this is disabled currently breaks kolla's IPV6 check, see:
+# https://bugs.launchpad.net/kolla-ansible/+bug/2071443
+# Also matches RHEL hardening behavior.
+ubtu22cis_ipv6_required: true
+
 ##############################################################################

--- a/releasenotes/notes/cis-do-not-disable-ipv6-98bd79ad86555f51.yaml
+++ b/releasenotes/notes/cis-do-not-disable-ipv6-98bd79ad86555f51.yaml
@@ -1,0 +1,12 @@
+---
+fixes:
+  - |
+    IPV6 is no longer disabled by default in the Ubuntu CIS hardening.  If
+    using the old behaviour you may hit `2071443
+    <https://bugs.launchpad.net/kolla-ansible/+bug/2071443>`.
+upgrade:
+  - |
+    To match the new CIS benchmark defaults on Ubuntu, you should remove
+    the ``ipv6.disable=1`` kernel command line option. If you wish to carry
+    on with the current settings, change ``ubtu22cis_ipv6_required`` to
+    ``false``.


### PR DESCRIPTION
We are currently prevented in doing so by:

https://bugs.launchpad.net/kolla-ansible/+bug/2071443

You only hit this issue after a reboot.