### PR TITLE
yoga: fix CentOS Stream 8 container image builds

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -160,6 +160,9 @@ stackhpc_centos_stream_repos:
     tag: "appstream"
   - url: "{{ stackhpc_repo_centos_stream_extras_common_url }}"
     file: "CentOS-Stream-Extras-common.repo"
+    tag: "extras-common"
+  - url: "{{ stackhpc_repo_centos_stream_extras_url }}"
+    file: "CentOS-Stream-Extras.repo"
     tag: "extras"
 
 # List of repositories for EPEL.


### PR DESCRIPTION
With the upstream CS8 repos gone, an issue with the extras & extras-common yum repo setup in our container images was shown. We were relying on the upstream extras repo, rather than the one in release train.