### PR TITLE
Restrict security-common to OpenSSH packages

### DIFF
--- a/etc/kayobe/dnf.yml
+++ b/etc/kayobe/dnf.yml
@@ -122,6 +122,7 @@ dnf_custom_repos_rocky_9:
     file: Rocky-SIG-Security-Common
     gpgkey: "{{ rocky_9_sig_security_gpg_key }}"
     gpgcheck: yes
+    includepkgs: "openssh*"
     username: "{{ stackhpc_repo_mirror_username | default(omit, true) }}"
     password: "{{ stackhpc_repo_mirror_password | default(omit, true) }}"
 

--- a/releasenotes/notes/security-common-openssh-6fbd5a1e95fd66ae.yaml
+++ b/releasenotes/notes/security-common-openssh-6fbd5a1e95fd66ae.yaml
@@ -1,0 +1,6 @@
+---
+security:
+  - |
+    Enables the Rocky Linux 9 SIG Security Common repository, which provides
+    updated OpenSSH packages addressing CVE-2024-6387 (regreSSHion). Other
+    packages available in this repository are currently ignored.


### PR DESCRIPTION
The other updated packages (glibc and microcode_ctl) need more testing.