### PR TITLE
fix blackbox exporter config for opensearch dashboards

### DIFF
--- a/etc/kayobe/kolla/config/prometheus/prometheus-blackbox-exporter.yml
+++ b/etc/kayobe/kolla/config/prometheus/prometheus-blackbox-exporter.yml
@@ -27,7 +27,7 @@ modules:
       - expect: "^SSH-2.0-"
   icmp:
     prober: icmp
-  http_2xx_os_dashboards:
+  http_2xx_opensearch_dashboards:
     prober: http
     timeout: 5s
     http:

--- a/releasenotes/notes/fix-blackbox-opensearch-dashboard-d973b43c557c8103.yaml
+++ b/releasenotes/notes/fix-blackbox-opensearch-dashboard-d973b43c557c8103.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed incorrect Opensearch Dashboards Prometheus Blackbox Exporter
+    configuration.


### PR DESCRIPTION
to be consistent with https://github.com/stackhpc/stackhpc-kayobe-config/blob/dc6e0234a611be0029c96c976dc8527bfbccb4d9/etc/kayobe/kolla/inventory/group_vars/prometheus-blackbox-exporter#L117

without it prometheus can't scrape properly blackbox exporter endpoint for openserch dashboards:

```
server returned HTTP status 400 Bad Request
```