### PR TITLE
2023.1: Tempest docs fixes

### DIFF
--- a/doc/source/operations/tempest.rst
+++ b/doc/source/operations/tempest.rst
@@ -70,7 +70,7 @@ Installing Docker on Rocky:
 .. code-block:: bash
 
     sudo dnf install -y dnf-utils
-    sudo dnf-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+    sudo dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
     sudo dnf install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
 Ensure Docker is running & enabled:

--- a/doc/source/operations/tempest.rst
+++ b/doc/source/operations/tempest.rst
@@ -101,7 +101,7 @@ Build a Kayobe automation image:
     git submodule update
     # If running on Ubuntu, the fact cache can confuse Kayobe in the Rocky-based container
     mv etc/kayobe/facts{,-old}
-    sudo DOCKER_BUILDKIT=1 docker build --build-arg BASE_IMAGE=rockylinux:9 --file .automation/docker/kayobe/Dockerfile --tag kayobe:latest .
+    sudo DOCKER_BUILDKIT=1 docker build --network host --build-arg BASE_IMAGE=rockylinux:9 --file .automation/docker/kayobe/Dockerfile --tag kayobe:latest .
 
 Configuration
 =============


### PR DESCRIPTION
- **docs: Fix dnf config-manager command**
- **docs: Use host networking for building a kayobe image for tempest**
