### PR TITLE
CI: Fix failure condition for container image builds when all images are dirty

### DIFF
--- a/.github/workflows/stackhpc-container-image-build.yml
+++ b/.github/workflows/stackhpc-container-image-build.yml
@@ -232,7 +232,7 @@ jobs:
         run: mv image-scan-output image-build-logs/image-scan-output
 
       - name: Fail if no images have passed scanning
-        run: if [ $(wc -l < image-build-logs/image-scan-output/clean-images.txt) -le 0 ]; then exit 1; fi
+        run: if [ $(wc -l < image-build-logs/image-scan-output/critical-images.txt) -eq 0 ]; then exit 1; fi
         if: ${{ !inputs.push-dirty }}
 
       - name: Copy clean images to push-attempt-images list


### PR DESCRIPTION
In the case where all images contain HIGH CVEs, but none contain
CRITICAL CVEs, we should not fail the build. However the condition
previously failed if there were no images without any CVEs. This change
modifies the condition to fail only when there are CRITICAL CVEs.
