### PR TITLE
CI: Increase upgrade job volume size to 55GB

### DIFF
--- a/.github/workflows/stackhpc-all-in-one.yml
+++ b/.github/workflows/stackhpc-all-in-one.yml
@@ -167,7 +167,7 @@ jobs:
           VM_NETWORK: ${{ inputs.vm_network }}
           VM_SUBNET: ${{ inputs.vm_subnet }}
           VM_INTERFACE: ${{ inputs.vm_interface }}
-          VM_VOLUME_SIZE: ${{ inputs.upgrade && '50' || '40' }}
+          VM_VOLUME_SIZE: ${{ inputs.upgrade && '55' || '40' }}
           VM_TAGS: '["skc-ci-aio", "PR=${{ github.event.number }}"]'
 
       - name: Terraform Plan


### PR DESCRIPTION
Since enabling CIS hardening the storage requirements have increased.
