### PR TITLE
Documentation update

### DIFF
--- a/doc/source/contributor/package-updates.rst
+++ b/doc/source/contributor/package-updates.rst
@@ -237,15 +237,15 @@ Then run Octavia test script:
 https://gist.github.com/MoteHue/ee5990bddea0677f54d8bb93d307aa71#file-octavia_test-sh
 
 
-Attempt to build OFED against the latest kernel
+Attempt to build OFED against the latest kernel in ARK
 ###############################################
 
 Note that this only needs to be performed once.
 
 .. code-block:: console
 
-   kayobe seed host configure -t dnf -kt none
-   kayobe seed host package update --packages "*"
+   kayobe overcloud host configure -t dnf -kt none
+   kayobe overcloud host package update --packages "*"
 
 Then run the OFED test script:
 

--- a/doc/source/contributor/package-updates.rst
+++ b/doc/source/contributor/package-updates.rst
@@ -247,7 +247,7 @@ Note that this only needs to be performed once.
    kayobe overcloud host configure -t dnf
    kayobe overcloud host package update --packages "*"
 
-Then run the OFED test script:
+Then run the OFED test script on one of the upgraded overcloud hosts:
 
 https://gist.github.com/cityofships/b4883ee19f75d14534f04115892b8465
 

--- a/doc/source/contributor/package-updates.rst
+++ b/doc/source/contributor/package-updates.rst
@@ -238,7 +238,7 @@ https://gist.github.com/MoteHue/ee5990bddea0677f54d8bb93d307aa71#file-octavia_te
 
 
 Attempt to build OFED against the latest kernel in ARK
-###############################################
+######################################################
 
 Note that this only needs to be performed once.
 

--- a/doc/source/contributor/package-updates.rst
+++ b/doc/source/contributor/package-updates.rst
@@ -244,7 +244,7 @@ Note that this only needs to be performed once.
 
 .. code-block:: console
 
-   kayobe overcloud host configure -t dnf -kt none
+   kayobe overcloud host configure -t dnf
    kayobe overcloud host package update --packages "*"
 
 Then run the OFED test script:


### PR DESCRIPTION
OFED build needs to happen on one of the overcloud hosts.
-kt option was removed in 2023.1.