### PR TITLE
Fix falsy in octavia-amphora-image-build.yml

### DIFF
--- a/etc/kayobe/ansible/octavia-amphora-image-build.yml
+++ b/etc/kayobe/ansible/octavia-amphora-image-build.yml
@@ -10,7 +10,7 @@
       become: true
       when:
         - ansible_facts.os_family == "RedHat"
-        - dnf_custom_repos | falsy
+        - dnf_custom_repos is falsy
 
     - name: Ensure packages are installed
       become: true


### PR DESCRIPTION
Fixes the following error:

The conditional check 'dnf_custom_repos | falsy' failed. The error was: template error while templating string: Could not load "falsy"