### PR TITLE
yoga: Bump stackhpc.hashicorp & multinode skip lists

### DIFF
--- a/.automation.conf/config.sh
+++ b/.automation.conf/config.sh
@@ -24,6 +24,7 @@ if [ ! -z ${KAYOBE_ENVIRONMENT:+x} ]; then
     # SMSLab is currently running with 1G switches. This causes tests using volumes and images to fail if
     # the concurrency is set too high.
     export TEMPEST_CONCURRENCY=1
+    export KAYOBE_AUTOMATION_TEMPEST_SKIPLIST="ci-multinode-platform.2022.11"
     # Uncomment this to perform a full tempest test
     # export KAYOBE_AUTOMATION_TEMPEST_LOADLIST=tempest-full
     # export KAYOBE_AUTOMATION_TEMPEST_SKIPLIST=ci-multinode-tempest-full

--- a/.automation.conf/tempest/skip-lists/ci-multinode-platform.2022.11
+++ b/.automation.conf/tempest/skip-lists/ci-multinode-platform.2022.11
@@ -1,3 +1,2 @@
 tempest.api.volume.test_volumes_list.VolumesListTestJSON.test_volume_list_pagination: "Fails without public TLS"
 tempest.api.volume.test_volumes_list.VolumesListTestJSON.test_volume_list_details_pagination: "Fails without public TLS"
-tempest.scenario.test_network_basic_ops.TestNetworkBasicOps.test_subnet_details.*: "Cirros image doesn't have '/var/run/udhcpc.eth0.pid"

--- a/etc/kayobe/ansible/requirements.yml
+++ b/etc/kayobe/ansible/requirements.yml
@@ -9,7 +9,7 @@ collections:
   - name: stackhpc.pulp
     version: 0.4.1
   - name: stackhpc.hashicorp
-    version: 2.4.0
+    version: 2.5.0
   - name: stackhpc.kayobe_workflows
     version: 1.0.3
 roles:

--- a/releasenotes/notes/hcp-2.5.0-8e30c7b1910f2bd2.yaml
+++ b/releasenotes/notes/hcp-2.5.0-8e30c7b1910f2bd2.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Updates the ``stackhpc.hashicorp`` Ansible collection to 2.5.0. This brings
+    in an idempotency fix for generating certificates.


### PR DESCRIPTION
- **ci-multinode: Add failing refstack tests to skip list**
- **Bump stackhpc.hashicorp role to 2.5.0**
