### PR TITLE
yoga: Reduce multinode LVM volume sizes

### DIFF
--- a/etc/kayobe/environments/ci-multinode/inventory/group_vars/compute/lvm.yml
+++ b/etc/kayobe/environments/ci-multinode/inventory/group_vars/compute/lvm.yml
@@ -10,25 +10,25 @@ stackhpc_lvm_group_rootvg_lvs_extra:
 stackhpc_lvm_lv_swap_size: 1g
 
 # StackHPC LVM lv_root LV size.
-stackhpc_lvm_lv_root_size: 10g
+stackhpc_lvm_lv_root_size: 5g
 
 # StackHPC LVM lv_tmp LV size.
-stackhpc_lvm_lv_tmp_size: 10g
+stackhpc_lvm_lv_tmp_size: 5g
 
 # StackHPC LVM lv_var LV size.
-stackhpc_lvm_lv_var_size: 20g
+stackhpc_lvm_lv_var_size: 2g
 
 # StackHPC LVM lv_var_tmp LV size.
-stackhpc_lvm_lv_var_tmp_size: 5g
+stackhpc_lvm_lv_var_tmp_size: 1g
 
 # StackHPC LVM lv_log LV size.
 stackhpc_lvm_lv_log_size: 10g
 
 # StackHPC LVM lv_audit LV size.
-stackhpc_lvm_lv_audit_size: 5g
+stackhpc_lvm_lv_audit_size: 2g
 
 # StackHPC LVM lv_home LV size.
 stackhpc_lvm_lv_home_size: 5g
 
 # StackHPC LVM lv_docker LV size.
-stackhpc_lvm_lv_docker_size: 75%FREE
+stackhpc_lvm_lv_docker_size: 95%FREE

--- a/etc/kayobe/environments/ci-multinode/inventory/group_vars/controllers/lvm.yml
+++ b/etc/kayobe/environments/ci-multinode/inventory/group_vars/controllers/lvm.yml
@@ -10,13 +10,13 @@ stackhpc_lvm_group_rootvg_lvs_extra:
 stackhpc_lvm_lv_swap_size: 1g
 
 # StackHPC LVM lv_root LV size.
-stackhpc_lvm_lv_root_size: 10g
+stackhpc_lvm_lv_root_size: 5g
 
 # StackHPC LVM lv_tmp LV size.
-stackhpc_lvm_lv_tmp_size: 10g
+stackhpc_lvm_lv_tmp_size: 5g
 
 # StackHPC LVM lv_var LV size.
-stackhpc_lvm_lv_var_size: 20g
+stackhpc_lvm_lv_var_size: 2g
 
 # StackHPC LVM lv_var_tmp LV size.
 stackhpc_lvm_lv_var_tmp_size: 5g
@@ -31,4 +31,4 @@ stackhpc_lvm_lv_audit_size: 5g
 stackhpc_lvm_lv_home_size: 5g
 
 # StackHPC LVM lv_docker LV size.
-stackhpc_lvm_lv_docker_size: 75%FREE
+stackhpc_lvm_lv_docker_size: 100%FREE

--- a/etc/kayobe/environments/ci-multinode/inventory/group_vars/controllers/lvm.yml
+++ b/etc/kayobe/environments/ci-multinode/inventory/group_vars/controllers/lvm.yml
@@ -19,16 +19,16 @@ stackhpc_lvm_lv_tmp_size: 5g
 stackhpc_lvm_lv_var_size: 2g
 
 # StackHPC LVM lv_var_tmp LV size.
-stackhpc_lvm_lv_var_tmp_size: 5g
+stackhpc_lvm_lv_var_tmp_size: 1g
 
 # StackHPC LVM lv_log LV size.
 stackhpc_lvm_lv_log_size: 10g
 
 # StackHPC LVM lv_audit LV size.
-stackhpc_lvm_lv_audit_size: 5g
+stackhpc_lvm_lv_audit_size: 2g
 
 # StackHPC LVM lv_home LV size.
 stackhpc_lvm_lv_home_size: 5g
 
 # StackHPC LVM lv_docker LV size.
-stackhpc_lvm_lv_docker_size: 100%FREE
+stackhpc_lvm_lv_docker_size: 95%FREE

--- a/etc/kayobe/environments/ci-multinode/inventory/group_vars/storage/lvm.yml
+++ b/etc/kayobe/environments/ci-multinode/inventory/group_vars/storage/lvm.yml
@@ -10,13 +10,13 @@ stackhpc_lvm_group_rootvg_lvs_extra:
 stackhpc_lvm_lv_swap_size: 1g
 
 # StackHPC LVM lv_root LV size.
-stackhpc_lvm_lv_root_size: 8g
+stackhpc_lvm_lv_root_size: 5g
 
 # StackHPC LVM lv_tmp LV size.
 stackhpc_lvm_lv_tmp_size: 2g
 
 # StackHPC LVM lv_var LV size.
-stackhpc_lvm_lv_var_size: 12g
+stackhpc_lvm_lv_var_size: 2g
 
 # StackHPC LVM lv_var_tmp LV size.
 stackhpc_lvm_lv_var_tmp_size: 1g
@@ -31,4 +31,4 @@ stackhpc_lvm_lv_audit_size: 1g
 stackhpc_lvm_lv_home_size: 2g
 
 # StackHPC LVM lv_docker LV size.
-stackhpc_lvm_lv_docker_size: 75%FREE
+stackhpc_lvm_lv_docker_size: 95%FREE


### PR DESCRIPTION
- **Changing LVM layout for controllers. We've been running out of space when testing upgrades in Multinode.**
- **ci-multinode: Further reduce LVM volumes**
