### PR TITLE
ci-multinode: Change storage-mgmt subnet to avoid collision

### DIFF
--- a/etc/kayobe/environments/ci-multinode/networks.yml
+++ b/etc/kayobe/environments/ci-multinode/networks.yml
@@ -107,10 +107,11 @@ storage_allocation_pool_end: 192.168.41.254
 storage_vlan: 105
 
 # Storage management network
-storage_mgmt_cidr: 192.168.42.0/24
+# NOTE: Skipping the .42 subnet to avoid a collision with a popular number.
+storage_mgmt_cidr: 192.168.43.0/24
 storage_mgmt_mtu: "{{ ansible_facts.default_ipv4.mtu - 50 }}"
-storage_mgmt_allocation_pool_start: 192.168.42.3
-storage_mgmt_allocation_pool_end: 192.168.42.254
+storage_mgmt_allocation_pool_start: 192.168.43.3
+storage_mgmt_allocation_pool_end: 192.168.43.254
 storage_mgmt_vlan: 106
 
 # Provision overcloud network


### PR DESCRIPTION
The .42 subnet was in use in some of our infrastructure and resulted in
weird behaviour.
