### PR TITLE
Fix CVE-2024-40767

### DIFF
--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -40,9 +40,9 @@ kayobe_image_tags:
     rocky: yoga-20240105T120257
     ubuntu: yoga-20231114T125927
   nova:
-    centos: yoga-20240702T105751
-    rocky: yoga-20240702T105751
-    ubuntu: yoga-20240702T105751
+    centos: yoga-20240724T085253
+    rocky: yoga-20240724T085253
+    ubuntu: yoga-20240724T085253
   nova_libvirt:
     centos: yoga-20231113T171023
     rocky: yoga-20240105T120257

--- a/releasenotes/notes/fix-cve-2024-40767-24b9b3c35f61a0c8.yaml
+++ b/releasenotes/notes/fix-cve-2024-40767-24b9b3c35f61a0c8.yaml
@@ -1,0 +1,6 @@
+---
+critical:
+  - |
+    Fixes `CVE-2024-40767
+    <https://security.openstack.org/ossa/OSSA-2024-002.html>`_ with updated
+    container images for Nova services.


### PR DESCRIPTION
Fixes CVE-2024-40767 [1] with updated container images for Nova services.

[1] https://security.openstack.org/ossa/OSSA-2024-002.html