### PR TITLE
CI: Bump AIO root volume size to 40GB

### DIFF
--- a/terraform/aio/vm.tf
+++ b/terraform/aio/vm.tf
@@ -35,7 +35,7 @@ variable "aio_vm_subnet" {
 
 variable "aio_vm_volume_size" {
   type = number
-  default = 35
+  default = 40
 }
 
 variable "aio_vm_tags" {


### PR DESCRIPTION
Tempest fails in some situations when a 35GB root disk is allocated to the AIO instance. Increase the root disk size to 40GB by default, as this is commonly overridden to be 40GB+ anyway.