### PR TITLE
Build nova from our fork

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -151,6 +151,10 @@ kolla_sources:
     type: git
     location: https://github.com/stackhpc/networking-generic-switch.git
     reference: stackhpc/{{ openstack_release }}
+  nova-base:
+    type: git
+    location: https://github.com/stackhpc/nova.git
+    reference: stackhpc/{{ openstack_release }}
 
 ###############################################################################
 # Kolla image build configuration.


### PR DESCRIPTION
This is necessary to address OSSA-2024-002 [1] until patches are merged upstream.

[1] https://security.openstack.org/ossa/OSSA-2024-002.html