### PR TITLE
Support Nova images built from Rocky Linux 9.3

### DIFF
--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -22,6 +22,12 @@ kolla_image_tags:
 # Variables defining which tag to use for each container's image.
 {{ lookup('pipe', 'python3 ' ~ kayobe_config_path ~ '/../../tools/kolla-images.py list-tag-vars') }}
 
+# NOTE(priteau): Nova container images can use Rocky Linux 9.3 to avoid
+# Libvirt/QEMU version bump.
+{% if stackhpc_pulp_repo_rocky_9_minor_version < 4 %}
+nova_tag: 2023.1-rocky-9-20240725T200915
+{% endif %}
+
 #############################################################################
 # RabbitMQ
 


### PR DESCRIPTION
Set the stackhpc_pulp_repo_rocky_9_minor_version variable to 3 or lower to use these images.