### PR TITLE
Add Ansible's YAML callback plugin configuration

### DIFF
--- a/etc/kayobe/ansible.cfg
+++ b/etc/kayobe/ansible.cfg
@@ -10,6 +10,10 @@ inject_facts_as_vars = False
 callbacks_enabled = ansible.posix.profile_tasks
 # Silence warning about invalid characters found in group names
 force_valid_group_names = ignore
+# Use the YAML callback plugin.
+stdout_callback = yaml
+# Use the stdout_callback when running ad-hoc commands.
+bin_ansible_callbacks = True
 
 [inventory]
 # Fail when any inventory source cannot be parsed.


### PR DESCRIPTION
Added Ansible's YAML callback plugin to Ansible configuration to make errors (finally) more digestible.