### PR TITLE
CIS: Remove always tag from include_role tasks

### DIFF
--- a/etc/kayobe/ansible/cis.yml
+++ b/etc/kayobe/ansible/cis.yml
@@ -32,14 +32,11 @@
     - include_role:
         name: ansible-lockdown.rhel8_cis
       when: ansible_facts.os_family == 'RedHat' and ansible_facts.distribution_major_version == '8'
-      tags: always
 
     - include_role:
         name: ansible-lockdown.rhel9_cis
       when: ansible_facts.os_family == 'RedHat' and ansible_facts.distribution_major_version == '9'
-      tags: always
 
     - include_role:
         name: ansible-lockdown.ubuntu22_cis
       when: ansible_facts.distribution == 'Ubuntu' and ansible_facts.distribution_major_version == '22'
-      tags: always


### PR DESCRIPTION
If we have the CIS hardening hook enabled and run a command such as the
following:

  kayobe overcloud host configure -t foo

where 'cis' is not in the specified tags, we see the following error:

  PLAY [Security hardening] *****************************************
  TASK [include_role : ansible-lockdown.rhel9_cis] ******************
  fatal: [controller-01]: FAILED! =>
    msg: |-
      The conditional check 'ansible_facts.os_family == 'RedHat' and
      ansible_facts.distribution_major_version == '9'' failed. The error
      was: error while evaluating conditional (ansible_facts.os_family
      == 'RedHat' and ansible_facts.distribution_major_version == '9'):
      'dict object' has no attribute 'os_family'. 'dict object' has no
      attribute 'os_family'

      The error appears to be in 'etc/kayobe/ansible/cis.yml': line 35,
      column 7, but may be elsewhere in the file depending on the exact
      syntax problem.

      The offending line appears to be:

          - include_role:
            ^ here

This is because the include_role task has the 'always' tag, so runs
despite no facts having been gathered.

The always tag is not required for this task - specifying the 'cis' tag
causes the role to be included. This change fixes the issue by removing
the always tags from these tasks.
