### PR TITLE
Fixing wazuh password generation

### DIFF
--- a/etc/kayobe/ansible/templates/wazuh-secrets.yml.j2
+++ b/etc/kayobe/ansible/templates/wazuh-secrets.yml.j2
@@ -7,7 +7,7 @@ secrets_wazuh:
   # Strengthen default wazuh api user pass
   wazuh_api_users:
     - username: "wazuh"
-      password: "{{ secrets_wazuh.wazuh_api_users[0].password | default(lookup('community.general.random_string', min_lower=1, min_upper=1, min_special=1, min_numeric=1, length=30)) }}"
+      password: "{{ secrets_wazuh.wazuh_api_users[0].password | default(lookup('community.general.random_string', min_lower=1, min_upper=1, min_special=1, min_numeric=1, length=30, override_special=override_special_characters)) }}"
   # OpenSearch 'admin' user pass
   opendistro_admin_password: "{{ secrets_wazuh.opendistro_admin_password | default(lookup('password', '/dev/null'), true) }}"
   # OpenSearch 'kibanaserver' user pass

--- a/etc/kayobe/ansible/wazuh-secrets.yml
+++ b/etc/kayobe/ansible/wazuh-secrets.yml
@@ -3,6 +3,7 @@
   gather_facts: false
   vars:
     wazuh_secrets_path: "{{ kayobe_env_config_path }}/wazuh-secrets.yml"
+    override_special_characters: '"#$%&()*+,-./:;<=>?@[\]^_{|}~'
   tasks:
     - name: install passlib[bcrypt]
       pip:


### PR DESCRIPTION
Defining set of special characters to omit "`" and "'" which, if being part of generated password leads to issues 
Fixes: https://github.com/stackhpc/stackhpc-kayobe-config/issues/1226