### PR TITLE
Use default crypto policy in AIOs for ed25519

### DIFF
--- a/etc/kayobe/environments/ci-aio/inventory/group_vars/cis-hardening/cis
+++ b/etc/kayobe/environments/ci-aio/inventory/group_vars/cis-hardening/cis
@@ -1,0 +1,3 @@
+---
+# Don't use FIPS since it blocks ed25519 keys
+rhel9cis_crypto_policy: DEFAULT


### PR DESCRIPTION
AIOs are usually their own ansible control host, so CIS hardening can cut off user access when using ed25519 keys. This change sets the crypto policy back to DEFAULT.