### PR TITLE
CI: Fix loss of number type when calling reusable workflow

### DIFF
--- a/.github/workflows/stackhpc-multinode.yml
+++ b/.github/workflows/stackhpc-multinode.yml
@@ -61,7 +61,8 @@ jobs:
       neutron_plugin: ${{ inputs.neutron_plugin }}
       upgrade: ${{ inputs.upgrade }}
       break_on: ${{ inputs.break_on }}
-      break_duration: ${{ inputs.break_duration }}
+      # Workaround loss of number type using fromJSON: https://github.com/orgs/community/discussions/67182
+      break_duration: ${{ fromJSON(inputs.break_duration) }}
       ssh_key: ${{ inputs.ssh_key }}
       stackhpc_kayobe_config_version: ${{ github.ref_name }}
       # NOTE(upgrade): Reference the PREVIOUS release here.


### PR DESCRIPTION
The workflow_dispatch break_duration input has a type of 'number', but
this somehow gets lost when calling the reusable workflow. We see the
following error:

  The template is not valid. .github/workflows/stackhpc-multinode.yml
  (Line: 64, Col: 23): Unexpected value '60'

This issue is described in
https://github.com/orgs/community/discussions/67182. We use the fromJSON
workaround in the thread.
