### PR TITLE
Explicitly set rabbit flags for MN-CI upgrades

### DIFF
--- a/etc/kayobe/environments/ci-multinode/kolla/globals.yml
+++ b/etc/kayobe/environments/ci-multinode/kolla/globals.yml
@@ -60,3 +60,10 @@ designate_ns_record:
 designate_backend: "bind9"
 designate_recursion: "yes"
 designate_forwarders_addresses: "1.1.1.1; 8.8.8.8"
+
+############################################################################
+# RabbitMQ
+
+# Ensure Rabbit is deployed with HA rather than quorum queues (to test migrations)
+om_enable_rabbitmq_high_availability: true
+om_enable_rabbitmq_quorum_queues: false


### PR DESCRIPTION
See https://github.com/stackhpc/stackhpc-kayobe-config/blob/7daaead629796270f183f801c4ec5929eff7796d/etc/kayobe/environments/ci-aio/kolla/globals.yml#L18
for the same format in ci-aio