### PR TITLE
CI: Add a periodic multinode job

### DIFF
--- a/.github/workflows/multinode-inputs.py
+++ b/.github/workflows/multinode-inputs.py
@@ -1,0 +1,80 @@
+# Generate inputs for the reusable multinode.yml workflow.
+# The test scenario is randomly selected.
+# The inputs are printed to stdout in GitHub step output key=value format.
+
+from dataclasses import dataclass
+import random
+import typing as t
+
+
+@dataclass
+class OSRelease:
+    distribution: str
+    release: str
+    ssh_username: str
+
+
+@dataclass
+class OpenStackRelease:
+    version: str
+    previous_version: str
+    os_releases: t.List[OSRelease]
+
+
+@dataclass
+class Scenario:
+    openstack_release: OpenStackRelease
+    os_release: OSRelease
+    neutron_plugin: str
+    upgrade: bool
+
+
+ROCKY_9 = OSRelease("rocky", "9", "cloud-user")
+UBUNTU_JAMMY = OSRelease("ubuntu", "jammy", "ubuntu")
+# NOTE(upgrade): Add supported releases here.
+OPENSTACK_RELEASES = [
+    OpenStackRelease("2023.1", "zed", [ROCKY_9, UBUNTU_JAMMY])
+]
+NEUTRON_PLUGINS = ["ovs", "ovn"]
+
+
+def main() -> None:
+    scenario = random_scenario()
+    inputs = generate_inputs(scenario)
+    for name, value in inputs.items():
+        write_output(name, value)
+
+
+def random_scenario() -> Scenario:
+    openstack_release = random.choice(OPENSTACK_RELEASES)
+    os_release = random.choice(openstack_release.os_releases)
+    neutron_plugin = random.choice(NEUTRON_PLUGINS)
+    upgrade = random.random() > 0.6
+    return Scenario(openstack_release, os_release, neutron_plugin, upgrade)
+
+
+def generate_inputs(scenario: Scenario) -> t.Dict[str, str]:
+    branch = get_branch(scenario.openstack_release.version)
+    previous_branch = get_branch(scenario.openstack_release.previous_version)
+    inputs = {
+        "os_distribution": scenario.os_release.distribution,
+        "os_release": scenario.os_release.release,
+        "ssh_username": scenario.os_release.ssh_username,
+        "neutron_plugin": scenario.neutron_plugin,
+        "upgrade": str(scenario.upgrade).lower(),
+        "stackhpc_kayobe_config_version": branch,
+        "stackhpc_kayobe_config_previous_version": previous_branch,
+    }
+    return inputs
+
+
+def get_branch(version: str) -> str:
+    return f"stackhpc/{version}"
+
+
+def write_output(name: str, value: str) -> None:
+    print(f"{name}={value}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/stackhpc-multinode-scheduled.yml
+++ b/.github/workflows/stackhpc-multinode-scheduled.yml
@@ -1,0 +1,49 @@
+---
+# This workflow provides a periodic deploy of a multi-node test cluster.
+# The test scenario is randomly selected.
+
+name: Multinode periodic
+'on':
+  schedule:
+    # Runs nightly at 2:42 AM.
+    - cron: "42 2 * * *"
+jobs:
+  generate-inputs:
+    name: Generate inputs
+    runs-on: ubuntu-latest
+    outputs:
+      os_distribution: ${{ steps.generate-inputs.outputs.os_distribution }}
+      os_release: ${{ steps.generate-inputs.outputs.os_release }}
+      ssh_username: ${{ steps.generate-inputs.outputs.ssh_username }}
+      neutron_plugin: ${{ steps.generate-inputs.outputs.neutron_plugin }}
+      upgrade: ${{ steps.generate-inputs.outputs.upgrade }}
+      stackhpc_kayobe_config_version: ${{ steps.generate-inputs.outputs.stackhpc_kayobe_config_version }}
+      stackhpc_kayobe_config_previous_version: ${{ steps.generate-inputs.outputs.stackhpc_kayobe_config_previous_version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Generate inputs for multinode workflow
+        id: generate-inputs
+        run: |
+          python3 .github/workflows/multinode-inputs.py >> $GITHUB_OUTPUT
+
+      - name: Display generated inputs
+        run: |
+          echo '${{ toJSON(steps.generate-inputs.outputs) }}'
+  multinode:
+    name: Multinode periodic
+    needs:
+      - generate-inputs
+    uses: stackhpc/stackhpc-openstack-gh-workflows/.github/workflows/multinode.yml@main
+    with:
+      multinode_name: mn-prdc-${{ github.run_id }}
+      os_distribution: ${{ needs.generate-inputs.outputs.os_distribution }}
+      os_release: ${{ needs.generate-inputs.outputs.os_release }}
+      ssh_username: ${{ needs.generate-inputs.outputs.ssh_username }}
+      neutron_plugin: ${{ needs.generate-inputs.outputs.neutron_plugin }}
+      upgrade: ${{ needs.generate-inputs.outputs.upgrade == 'true' }}
+      stackhpc_kayobe_config_version: ${{ needs.generate-inputs.outputs.stackhpc_kayobe_config_version }}
+      stackhpc_kayobe_config_previous_version: ${{ needs.generate-inputs.outputs.stackhpc_kayobe_config_previous_version }}
+      enable_slack_alert: true
+    secrets: inherit


### PR DESCRIPTION
The job runs nightly at 2:42 AM and runs a test of a randomly selected
test scenario from a list of supported combinations.

Note that scheduled workflows must live in the default branch of the
repository.
