### PR TITLE
Pinning kolla, kolla-ansible and kayobe in caracal

### DIFF
--- a/etc/kayobe/stackhpc.yml
+++ b/etc/kayobe/stackhpc.yml
@@ -141,15 +141,11 @@ stackhpc_repo_elrepo_9_version: "{{ stackhpc_repo_distribution }}"
 
 # Kolla source repository.
 stackhpc_kolla_source_url: "https://github.com/stackhpc/kolla"
-stackhpc_kolla_source_version: "stackhpc/{{ openstack_release }}"
+stackhpc_kolla_source_version: "stackhpc/18.1.0.2"
 
 # Kolla Ansible source repository.
 stackhpc_kolla_ansible_source_url: "https://github.com/stackhpc/kolla-ansible"
-# FIXME: Waiting for
-# https://review.opendev.org/c/openstack/kolla-ansible/+/926198 to merge and
-# sync to stackhpc/2024.1
-# stackhpc_kolla_ansible_source_version: "stackhpc/{{ openstack_release }}"
-stackhpc_kolla_ansible_source_version: "fix-prometheus"
+stackhpc_kolla_ansible_source_version: "stackhpc/18.1.0.2"
 
 ###############################################################################
 # Container image registry

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-kayobe@git+https://github.com/stackhpc/kayobe@stackhpc/2024.1
+kayobe@git+https://github.com/stackhpc/kayobe@stackhpc/16.1.0.1
 ansible-modules-hashivault>=5.2.1
 jmespath


### PR DESCRIPTION
Pinned Kolla, Kolla-Ansible and Kayobe to tags - Caracal:
 - Kolla pinned to stackhpc/18.1.0.2
 - Kolla-Ansible pinned to stackhpc/18/1/0/2
 - Kayobe pinned to stackhpc/16.1.0.1
 
 To be merged after @Alex-Welsh merges https://review.opendev.org/c/openstack/kolla-ansible/+/926618
