### PR TITLE
Bump RMQ tag for multiple versions

### DIFF
--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -37,3 +37,6 @@ kolla_image_tags:
     rocky-9: 2023.1-rocky-9-20240809T102431
   ovn:
     rocky-9: 2023.1-rocky-9-20240809T102431
+  rabbitmq:
+    rocky-9: 2023.1-rocky-9-20240823T101942
+    ubuntu-jammy: 2023.1-ubuntu-jammy-20240823T101942

--- a/releasenotes/notes/add-rabbitmq-multiple-versions-7c6fdb470092409b.yaml
+++ b/releasenotes/notes/add-rabbitmq-multiple-versions-7c6fdb470092409b.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Adds alternative RabbitMQ container images for versions 3.11, 3.12 and
+    3.13. This allows us to perform intermediary RabbitMQ upgrades prior to a
+    SLURP upgrade to Caracal. See the Kolla docs for more details:
+    https://docs.openstack.org/kolla-ansible/latest/reference/message-queues/rabbitmq.html#slurp


### PR DESCRIPTION
Allows up to run the intermediary RabbitMQ version upgrades before a SLURP upgrade to Caracal.