### PR TITLE
Update template for friendly network name to Caracal

### DIFF
--- a/etc/kayobe/ansible/prometheus.yml.j2
+++ b/etc/kayobe/ansible/prometheus.yml.j2
@@ -273,9 +273,9 @@ scrape_configs:
 
 alerting:
   alertmanagers:
-  - static_configs:
-    - targets:
+    - static_configs:
 {% for host in groups["prometheus-alertmanager"] %}
+      - targets:
         - '{{ 'api' | kolla_address(host) | put_address_in_context('url') }}:{{ hostvars[host]['prometheus_alertmanager_port'] }}'
 {% if hostvars[host].prometheus_instance_label | default(false, true) %}
         labels:


### PR DESCRIPTION
Updated using ``prometheus.yml`` from stackhpc/kolla-ansible