### PR TITLE
Revert to upstream ovn-octavia-provider

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -147,14 +147,6 @@ kolla_sources:
     type: git
     location: https://github.com/stackhpc/networking-generic-switch.git
     reference: stackhpc/{{ openstack_release }}
-  octavia-api-plugin-ovn-octavia-provider:
-    type: git
-    location: https://github.com/stackhpc/ovn-octavia-provider.git
-    reference: stackhpc/{{ openstack_release }}
-  octavia-driver-agent-plugin-ovn-octavia-provider:
-    type: git
-    location: https://github.com/stackhpc/ovn-octavia-provider.git
-    reference: stackhpc/{{ openstack_release }}
 
 ###############################################################################
 # Kolla image build configuration.


### PR DESCRIPTION
The bug fix we were using in our fork was backported upstream [1].

[1] https://review.opendev.org/c/openstack/ovn-octavia-provider/+/926715