### PR TITLE
Further fixes to Prometheus blackbox exporter endpoints

### DIFF
--- a/etc/kayobe/kolla/inventory/group_vars/prometheus-blackbox-exporter
+++ b/etc/kayobe/kolla/inventory/group_vars/prometheus-blackbox-exporter
@@ -149,7 +149,7 @@ heat_cfn_internal_base_endpoint: "{{ heat_cfn_internal_fqdn | kolla_url(internal
 heat_cfn_public_base_endpoint: "{{ heat_cfn_external_fqdn | kolla_url(public_protocol, heat_api_cfn_public_port) }}"
 heat_internal_base_endpoint: "{{ heat_internal_fqdn | kolla_url(internal_protocol, heat_api_port) }}"
 heat_public_base_endpoint: "{{ heat_external_fqdn | kolla_url(public_protocol, heat_api_public_port) }}"
-horizon_public_endpoint: "{{ horizon_external_fqdn | kolla_url(public_protocol, horizon_listen_port) }}"
+horizon_public_endpoint: "{{ horizon_external_fqdn | kolla_url(public_protocol, horizon_tls_port if kolla_enable_tls_external | bool else horizon_port) }}"
 ironic_inspector_internal_endpoint: "{{ ironic_inspector_internal_fqdn | kolla_url(internal_protocol, ironic_inspector_port) }}"
 ironic_inspector_public_endpoint: "{{ ironic_inspector_external_fqdn | kolla_url(public_protocol, ironic_inspector_public_port) }}"
 magnum_internal_base_endpoint: "{{ magnum_internal_fqdn | kolla_url(internal_protocol, magnum_api_port) }}"

--- a/etc/kayobe/kolla/inventory/group_vars/prometheus-blackbox-exporter
+++ b/etc/kayobe/kolla/inventory/group_vars/prometheus-blackbox-exporter
@@ -6,13 +6,16 @@
 # prometheus_blackbox_exporter_endpoints_kayobe is another set of default
 # endpoints that are templated by Kayobe rather than Kolla Ansible. See
 # kolla/globals.yml for more details.
-prometheus_blackbox_exporter_endpoints: >-
-  {{ (prometheus_blackbox_exporter_endpoints_kayobe | default([]) +
-  prometheus_blackbox_exporter_endpoints_default) |
-  selectattr('enabled', 'true') |
-  map(attribute='endpoints') | flatten |
-  union(prometheus_blackbox_exporter_endpoints_custom) |
-  unique | select | list }}
+prometheus_blackbox_exporter_endpoints: |
+  {% set endpoints = [] %}
+  {% for dict_item in (prometheus_blackbox_exporter_endpoints_kayobe | default([]) + prometheus_blackbox_exporter_endpoints_default) %}
+  {% if dict_item.enabled | bool %}
+  {% for endpoint in dict_item.endpoints %}
+  {% set _ = endpoints.append(endpoint) %}
+  {% endfor %}
+  {% endif %}
+  {% endfor %}
+  {{ (endpoints + prometheus_blackbox_exporter_endpoints_custom) | unique | list }}
 
 # A list of custom prometheus Blackbox exporter endpoints. Each element should
 # have the following format:

--- a/etc/kayobe/kolla/inventory/group_vars/prometheus-blackbox-exporter
+++ b/etc/kayobe/kolla/inventory/group_vars/prometheus-blackbox-exporter
@@ -15,7 +15,7 @@ prometheus_blackbox_exporter_endpoints: |
   {% endfor %}
   {% endif %}
   {% endfor %}
-  {{ (endpoints + prometheus_blackbox_exporter_endpoints_custom) | unique | list }}
+  {{ (endpoints + prometheus_blackbox_exporter_endpoints_custom) | unique | select | list }}
 
 # A list of custom prometheus Blackbox exporter endpoints. Each element should
 # have the following format:

--- a/etc/kayobe/kolla/inventory/group_vars/prometheus-blackbox-exporter
+++ b/etc/kayobe/kolla/inventory/group_vars/prometheus-blackbox-exporter
@@ -128,7 +128,7 @@ prometheus_blackbox_exporter_endpoints_default:
   - endpoints:
       - "prometheus_alertmanager:http_2xx_alertmanager:{{ prometheus_alertmanager_public_endpoint if enable_prometheus_alertmanager_external else prometheus_alertmanager_internal_endpoint }}"
     enabled: "{{ enable_prometheus_alertmanager | bool }}"
-  - endpoints: "{% set rabbitmq_endpoints = [] %}{% for host in groups.get('rabbitmq', []) %}{{ rabbitmq_endpoints.append('rabbitmq_' + host.replace('-', '') + (':tls_connect:' if rabbitmq_enable_tls else ':tcp_connect:') + ('api' | kolla_address(host) | put_address_in_context('url')) + ':' + hostvars[host]['rabbitmq_port'] ) }}{% endfor %}{{ rabbitmq_endpoints }}"
+  - endpoints: "{% set rabbitmq_endpoints = [] %}{% for host in groups.get('rabbitmq', []) %}{{ rabbitmq_endpoints.append('rabbitmq_' + host.replace('-', '') + (':tls_connect:' if rabbitmq_enable_tls | bool else ':tcp_connect:') + ('api' | kolla_address(host) | put_address_in_context('url')) + ':' + hostvars[host]['rabbitmq_port'] ) }}{% endfor %}{{ rabbitmq_endpoints }}"
     enabled: "{{ enable_rabbitmq | bool }}"
   - endpoints: "{% set redis_endpoints = [] %}{% for host in groups.get('redis', []) %}{{ redis_endpoints.append('redis_' + host.replace('-', '') + ':tcp_connect:' + ('api' | kolla_address(host) | put_address_in_context('url')) + ':' + hostvars[host]['redis_port']) }}{% endfor %}{{ redis_endpoints }}"
     enabled: "{{ enable_redis | bool }}"


### PR DESCRIPTION
Enabled items under prometheus_blackbox_exporter_endpoints_kayobe were not picked up because the attribute gets set to `enabled: 'True'`, rather the than `enabled: true` that the default values get. Likely a similar issue to this:
https://github.com/ansible/ansible/issues/11905#issuecomment-130496173