### PR TITLE
zed: ci-multinode: Add Kolla Ansible TLS config to globals.yml

### DIFF
--- a/etc/kayobe/environments/ci-multinode/kolla/globals.yml
+++ b/etc/kayobe/environments/ci-multinode/kolla/globals.yml
@@ -1,3 +1,4 @@
+# yamllint disable-file
 ---
 # Most development environments will use nested virtualisation, and we can't
 # guarantee that nested KVM support is available. Use QEMU as a lowest common

--- a/etc/kayobe/environments/ci-multinode/kolla/globals.yml
+++ b/etc/kayobe/environments/ci-multinode/kolla/globals.yml
@@ -44,3 +44,15 @@ designate_ns_record:
 designate_backend: "bind9"
 designate_recursion: "yes"
 designate_forwarders_addresses: "1.1.1.1; 8.8.8.8"
+
+{% if kolla_enable_tls_internal | bool %}
+############################################################################
+# Internal and backend TLS configuration
+
+# Copy the self-signed CA into the kolla containers
+kolla_copy_ca_into_containers: "yes"
+openstack_cacert: "{{ '/etc/pki/tls/certs/ca-bundle.crt' if os_distribution == 'rocky' else '/etc/ssl/certs/ca-certificates.crt' }}"
+kolla_enable_tls_backend: "yes"
+rabbitmq_enable_tls: "yes"
+
+{% endif %}


### PR DESCRIPTION
Previously we provided an additional file, globals-tls-config.yml, which
would be appended to globals.yml at an appropriate point during
multinode deployment. This could result in a merge conflict, which
cannot be resolved by an automated process such as a GitHub Actions
workflow.

This change adds the TLS config to globals.yml conditionally, based on
whether internal TLS is enabled.

We are not removing globals-tls-config.yml for now, since it is used in
the terraform-kayobe-multinode repo as a proxy for internal TLS support.
The file has already been removed in the Antelope branch.
