### PR TITLE
yoga: Backport Add workaround for rc: -13 (#1108)

### DIFF
--- a/etc/kayobe/ansible.cfg
+++ b/etc/kayobe/ansible.cfg
@@ -17,3 +17,4 @@ any_unparsed_is_failed = True
 
 [ssh_connection]
 pipelining = True
+ssh_extra_args = -o ControlPersist=1h


### PR DESCRIPTION
I've commonly hit this when configuring prometheus:

```
TASK [prometheus : Get container facts] *************************************************************************************************************************************
Monday 24 June 2024  11:09:37 +0000 (0:00:08.528)       0:01:31.707 ***********
fatal: [will-compute-01]: FAILED! => changed=false
  module_stderr: ''
  module_stdout: ''
  msg: |-
    MODULE FAILURE
    See stdout/stderr for the exact error
  rc: -13
fatal: [will-compute-02]: FAILED! => changed=false
  module_stderr: ''
  module_stdout: ''
  msg: |-
    MODULE FAILURE
    See stdout/stderr for the exact error
  rc: -13
```

The ControlPersist  workaround is documented in these bug reports:

- https://github.com/ansible/ansible/issues/78344
- https://github.com/ansible/ansible/issues/81777

From the comments, It seems like this does not completely resolve the
issue, but does decrease the frequency that you hit this.

The Prometheus tasks seem particuarly susceptible as they run on
every host.

(cherry picked from commit 699769ce3756c6dc80c1183e1c87f730ff05bb80)
