### PR TITLE
Add hooks for fixing hostname bug in Multinode for Caracal upgrade job

### DIFF
--- a/etc/kayobe/ansible/fix-hostname.yml
+++ b/etc/kayobe/ansible/fix-hostname.yml
@@ -21,3 +21,9 @@
         cmd: hostnamectl set-hostname "{{ inventory_hostname }}"
       when: current_hostname.stdout != inventory_hostname
       become: true
+
+- name: Reboot hosts
+  import_playbook: "{{ playbook_dir | realpath }}/reboot.yml"
+  vars:
+    reboot_hosts: fix-hostname
+  when: current_hostname.stdout != inventory_hostname

--- a/etc/kayobe/ansible/reboot.yml
+++ b/etc/kayobe/ansible/reboot.yml
@@ -1,6 +1,6 @@
 ---
 - name: Reboot the host
-  hosts: seed-hypervisor:seed:overcloud:infra-vms
+  hosts: "{{ reboot_hosts | default('seed-hypervisor:seed:overcloud:infra-vms') }}"
   serial: "{{ lookup('env', 'ANSIBLE_SERIAL') | default(1, true) }}"
   gather_facts: false
   vars:

--- a/etc/kayobe/environments/ci-multinode/hooks/overcloud-host-configure/pre.d/10-fix-hostname.yml
+++ b/etc/kayobe/environments/ci-multinode/hooks/overcloud-host-configure/pre.d/10-fix-hostname.yml
@@ -1,0 +1,1 @@
+../../../../../ansible/fix-hostname.yml

--- a/etc/kayobe/environments/ci-multinode/inventory/groups
+++ b/etc/kayobe/environments/ci-multinode/inventory/groups
@@ -5,4 +5,4 @@
 controllers
 
 [fix-hostname:children]
-storage
+overcloud

--- a/etc/kayobe/environments/ci-multinode/reboot.yml
+++ b/etc/kayobe/environments/ci-multinode/reboot.yml
@@ -1,0 +1,3 @@
+---
+# Ensure that the reboot playbook is always executed using the boostrap user
+reboot_with_bootstrap_user: true


### PR DESCRIPTION
Upgrades in Multinodes in Caracal will currently fail in CI upgrade jobs because they are deployed with FQDNs in Antelope. This change hooks in the fix-hostname and reboot playbooks to make sure they are fixed before any openstack services get deployed