### PR TITLE
Enable SELinux in permissive mode in overcloud host images

### DIFF
--- a/etc/kayobe/environments/ci-aio/globals.yml
+++ b/etc/kayobe/environments/ci-aio/globals.yml
@@ -56,10 +56,5 @@ os_release: >-
              (lookup('pipe', '. /etc/os-release && echo $VERSION_ID') | trim | split('.') | first) if os_distribution == 'rocky' }}
 
 ###############################################################################
-
-# Avoid a reboot.
-selinux_state: disabled
-
-###############################################################################
 # Dummy variable to allow Ansible to accept this file.
 workaround_ansible_issue_8743: yes

--- a/etc/kayobe/environments/ci-aio/inventory/group_vars/controllers/selinux
+++ b/etc/kayobe/environments/ci-aio/inventory/group_vars/controllers/selinux
@@ -1,4 +1,0 @@
----
-# Configure SELinux to be disabled in all cases. This is a short term fix, we
-# want RL9 hosts to be be permissive but our host images need to be rebuilt.
-selinux_state: "disabled"

--- a/etc/kayobe/environments/ci-builder/globals.yml
+++ b/etc/kayobe/environments/ci-builder/globals.yml
@@ -7,9 +7,3 @@
 # OS distribution name. Valid options are "rocky", "ubuntu". Default is
 # "rocky".
 os_distribution: "{{ lookup('pipe', '. /etc/os-release && echo $ID') | trim }}"
-
-###############################################################################
-# SELinux.
-
-# Avoid a reboot.
-selinux_state: disabled

--- a/etc/kayobe/environments/ci-multinode/globals.yml
+++ b/etc/kayobe/environments/ci-multinode/globals.yml
@@ -61,10 +61,5 @@ stackhpc_write_barbican_role_id_to_file: true
 stackhpc_barbican_role_id_file_path: "/tmp/barbican-role-id"
 
 ###############################################################################
-
-# Avoid a reboot.
-selinux_state: disabled
-
-###############################################################################
 # Dummy variable to allow Ansible to accept this file.
 workaround_ansible_issue_8743: yes

--- a/etc/kayobe/pulp-host-image-versions.yml
+++ b/etc/kayobe/pulp-host-image-versions.yml
@@ -1,5 +1,6 @@
 ---
 # Overcloud host image versioning tags
 # These images must be in SMS, since they are used by our AIO CI runners
+# TODO: Rebuild with SELinux enabled
 stackhpc_rocky_9_overcloud_host_image_version: "2023.1-20240126T093158"
 stackhpc_ubuntu_jammy_overcloud_host_image_version: "2023.1-20240325T130221"

--- a/etc/kayobe/stackhpc-overcloud-dib.yml
+++ b/etc/kayobe/stackhpc-overcloud-dib.yml
@@ -23,7 +23,7 @@ stackhpc_overcloud_dib_name: "deployment_image"
 stackhpc_overcloud_dib_elements:
   - "{{ os_distribution }}-{% if os_distribution == 'rocky' %}container-stackhpc{% else %}minimal{% endif %}"
   - "cloud-init-datasources"
-  - "{% if os_distribution == 'rocky' %}disable-selinux{% endif %}"
+  - "{% if os_distribution == 'rocky' %}selinux-permissive{% endif %}"
   - "enable-serial-console"
   - "{% if kayobe_environment == 'ci-builder' %}etc-hosts{% endif %}"
   - "vm"

--- a/releasenotes/notes/selinux-host-image-ff0fed2583cae7b0.yaml
+++ b/releasenotes/notes/selinux-host-image-ff0fed2583cae7b0.yaml
@@ -1,0 +1,5 @@
+---
+upgrade:
+  - |
+    Enables SELinux in permissive mode in the overcloud host image. This
+    matches the default configuration for SELinux in StackHPC Kayobe Configuration.


### PR DESCRIPTION
This matches our current defaults.
