### PR TITLE
Fix CVE-2024-44082 / OSSA-2024-003

### DIFF
--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -14,6 +14,9 @@ kolla_image_tags:
     ubuntu-jammy: 2023.1-ubuntu-jammy-20240701T123544
   haproxy_ssh:
     ubuntu-jammy: 2023.1-ubuntu-jammy-20240509T102329
+  ironic:
+    rocky-9: 2023.1-rocky-9-20240906T144646
+    ubuntu-jammy: 2023.1-ubuntu-jammy-20240906T144646
   kolla_toolbox:
     rocky-9: 2023.1-rocky-9-20240809T102431
   letsencrypt:

--- a/releasenotes/notes/fix-cve-2024-44082-122ef225f674d864.yaml
+++ b/releasenotes/notes/fix-cve-2024-44082-122ef225f674d864.yaml
@@ -1,0 +1,12 @@
+---
+security:
+  - |
+    Fixes `CVE-2024-44082
+    <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-44082>`_ with updated
+    container images for Ironic services. Note that Ironic Python Agent images
+    also need to be updated to fully fix this vulnerability. If this is not
+    possible, a new configuration option
+    ``[conductor]conductor_always_validates_images`` is available. See the
+    `OSSA-2024-003 description
+    <https://security.openstack.org/ossa/OSSA-2024-003.html>`_ for more
+    details.


### PR DESCRIPTION
Fixes CVE-2024-44082 [1] with updated container images for Ironic services.

Note that Ironic Python Agent images also need to be updated to fully fix this vulnerability. If this is not possible, a new configuration option ``[conductor]conductor_always_validates_images`` is available. See the OSSA-2024-003 announcement [2] for more details.

[1] https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-44082
[2] https://security.openstack.org/ossa/OSSA-2024-003.html