### PR TITLE
CIS - don't shut down when out of space

### DIFF
--- a/etc/kayobe/inventory/group_vars/cis-hardening/cis
+++ b/etc/kayobe/inventory/group_vars/cis-hardening/cis
@@ -55,7 +55,8 @@ rhel9cis_no_world_write_adjust: false
 rhel9cis_auditd:
   space_left_action: syslog
   action_mail_acct: root
-  admin_space_left_action: halt
+  admin_space_left_action: syslog
+  max_log_file: 10
   max_log_file_action: rotate
 
 # Max size of audit logs (MB)
@@ -156,7 +157,7 @@ ubtu22cis_suid_adjust: false
 ubtu22cis_auditd:
   action_mail_acct: root
   space_left_action: syslog
-  admin_space_left_action: halt
+  admin_space_left_action: syslog
   max_log_file_action: rotate
 
 # Max size of audit logs (MB)


### PR DESCRIPTION
Currently, CIS hardening will shut down hosts when they run out of space for logs. They then can't be started again without significant time and effort.

This change will instead make them log warnings instead of shutting down.