### PR TITLE
Prevent some prometheus versions go backward with Caracal

### DIFF
--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -11,3 +11,6 @@ kolla_image_tags:
     ubuntu-jammy: 2024.1-ubuntu-jammy-20240805T142526
   bifrost_deploy:
     rocky-9: 2024.1-rocky-9-20240725T165045
+  prometheus:
+    rocky-9: 2024.1-rocky-9-20240909T143450
+    ubuntu-jammy: 2024.1-ubuntu-jammy-20240909T143450

--- a/etc/kayobe/kolla/kolla-build.conf
+++ b/etc/kayobe/kolla/kolla-build.conf
@@ -14,3 +14,11 @@ build_args = {{ (kolla_build_args | default({})).items() | map('join', ':') | jo
 type = git
 location = https://github.com/stackhpc/requirements
 reference = stackhpc/{{ openstack_release }}
+
+[prometheus-v2-server]
+version = 2.54.1
+sha256 = amd64:31715ef65e8a898d0f97c8c08c03b6b9afe485ac84e1698bcfec90fc6e62924f,arm64:3d9946ca730f2679bbd63e9d40e559a0ba227a638d237e723af1a99bd7098263
+
+[prometheus-memcached-exporter]
+version = 0.14.4
+sha256 = amd64:e61b9f15959218a38c49b9ba919fca0a3e36e7edf9c607aabcf1ccbbd3b8cc59,arm64:9a28b57bd217e80acd1cdc86cef97e32058f3b2cce75f79baa13b42a27b7291a


### PR DESCRIPTION
Built prometheus-v2-server and prometheus-memcached-exporter with explicitly set versions and sha256.

prometheus-v2-server version: 2.54.1
prometheus-memcached-exporter version: 0.14.4