### PR TITLE
Bump Caracal prometheus-blackbox-exporter

### DIFF
--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -15,5 +15,5 @@ kolla_image_tags:
   bifrost_deploy:
     rocky-9: 2024.1-rocky-9-20240725T165045
   prometheus:
-    rocky-9: 2024.1-rocky-9-20240909T143450
-    ubuntu-jammy: 2024.1-ubuntu-jammy-20240909T143450
+    rocky-9: 2024.1-rocky-9-20240910T072617
+    ubuntu-jammy: 2024.1-ubuntu-jammy-20240910T072617

--- a/etc/kayobe/kolla/kolla-build.conf
+++ b/etc/kayobe/kolla/kolla-build.conf
@@ -19,6 +19,10 @@ reference = stackhpc/{{ openstack_release }}
 version = 2.54.1
 sha256 = amd64:31715ef65e8a898d0f97c8c08c03b6b9afe485ac84e1698bcfec90fc6e62924f,arm64:3d9946ca730f2679bbd63e9d40e559a0ba227a638d237e723af1a99bd7098263
 
+[prometheus-blackbox-exporter]
+version = 0.25.0
+sha256 = amd64:c651ced6405c5e0cd292a400f47ae9b34f431f16c7bb098afbcd38f710144640,arm64:46ec5a54a41dc1ea8a8cecee637e117de4807d3b0976482a16596e82e79ac484
+
 [prometheus-memcached-exporter]
 version = 0.14.4
 sha256 = amd64:e61b9f15959218a38c49b9ba919fca0a3e36e7edf9c607aabcf1ccbbd3b8cc59,arm64:9a28b57bd217e80acd1cdc86cef97e32058f3b2cce75f79baa13b42a27b7291a


### PR DESCRIPTION
It was found that blackbox exporter version also goes backward when upgrading from Antelope to Caracal.
Rebuilt blackbox exporter image with version 0.25.0