### PR TITLE
vault: Reference controller IP for backend TLS certificates

### DIFF
--- a/etc/kayobe/ansible/vault-generate-backend-tls.yml
+++ b/etc/kayobe/ansible/vault-generate-backend-tls.yml
@@ -18,7 +18,7 @@
 - name: Generate backend API certificates
   hosts: controllers:network
   vars:
-    vault_api_addr: "https://{{ internal_net_name | net_ip }}:8200"
+    vault_api_addr: "https://{{ internal_net_name | net_ip(groups['controllers'][0]) }}:8200"
     vault_intermediate_ca_name: "OS-TLS-INT"
   tasks:
     - name: Set a fact about the virtualenv on the remote system


### PR DESCRIPTION
change [1] introduced regression for fix made in [2], as vault is not running on network nodes


[1] https://github.com/stackhpc/stackhpc-kayobe-config/commit/f593df758ae09c9356ec8b04432ab7b65fb0f28e#diff-75d94f901ed6a58cc592a524e6d2ecc9c1ad2826f3f7c6ebaf95a0aa045d8d71R21
[2] https://github.com/stackhpc/stackhpc-kayobe-config/commit/af0d0138d7d660626aa87ef44bdef2ec642dc8a6