### PR TITLE
CI: Show Rally logs on failure for ci-aio and ci-multinode environments

### DIFF
--- a/.github/workflows/stackhpc-all-in-one.yml
+++ b/.github/workflows/stackhpc-all-in-one.yml
@@ -378,7 +378,7 @@ jobs:
             -v $(pwd)/tempest-artifacts:/stack/tempest-artifacts \
             -e KAYOBE_ENVIRONMENT -e KAYOBE_VAULT_PASSWORD -e KAYOBE_AUTOMATION_SSH_PRIVATE_KEY \
             $KAYOBE_IMAGE \
-            /stack/kayobe-automation-env/src/kayobe-config/.automation/pipeline/tempest.sh -e ansible_user=stack -e rally_no_sensitive_log=false
+            /stack/kayobe-automation-env/src/kayobe-config/.automation/pipeline/tempest.sh -e ansible_user=stack
         env:
           KAYOBE_AUTOMATION_SSH_PRIVATE_KEY: ${{ steps.ssh_key.outputs.ssh_key }}
 

--- a/etc/kayobe/environments/ci-aio/tempest.yml
+++ b/etc/kayobe/environments/ci-aio/tempest.yml
@@ -1,0 +1,3 @@
+---
+# Show Rally output on failure.
+rally_no_sensitive_log: false

--- a/etc/kayobe/environments/ci-multinode/tempest.yml
+++ b/etc/kayobe/environments/ci-multinode/tempest.yml
@@ -1,3 +1,6 @@
 ---
+# Show Rally output on failure.
+rally_no_sensitive_log: false
+
 # Add the Vault CA certificate to the rally container when running tempest.
 tempest_cacert: "{{ kayobe_env_config_path }}/kolla/certificates/ca/vault.crt"


### PR DESCRIPTION
Without this it is difficult to diagnose a failure to run Tempest.
