### PR TITLE
Bump Neutron image tags to fix bug 2068644

### DIFF
--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -20,6 +20,9 @@ kolla_image_tags:
   ironic_dnsmasq:
     rocky-9: 2023.1-rocky-9-20240709T132012
     ubuntu-jammy: 2023.1-ubuntu-jammy-20240621T104542
+  ironic_neutron_agent:
+    rocky-9: 2023.1-rocky-9-20240916T114629
+    ubuntu-jammy: 2023.1-ubuntu-jammy-20240916T114629
   kolla_toolbox:
     rocky-9: 2023.1-rocky-9-20240809T102431
   letsencrypt:
@@ -30,8 +33,8 @@ kolla_image_tags:
   manila:
     rocky-9: 2023.1-rocky-9-20240809T102431
   neutron:
-    rocky-9: 2023.1-rocky-9-20240916T114629
-    ubuntu-jammy: 2023.1-ubuntu-jammy-20240916T114629
+    rocky-9: 2023.1-rocky-9-20240923T162134
+    ubuntu-jammy: 2023.1-ubuntu-jammy-20240923T162134
   nova:
     rocky-9: 2023.1-rocky-9-20240916T114629
     ubuntu-jammy: 2023.1-ubuntu-jammy-20240916T114629

--- a/releasenotes/notes/fix-neutron-fip-ovn-lb-attach-1457b0fcc2757ed9.yaml
+++ b/releasenotes/notes/fix-neutron-fip-ovn-lb-attach-1457b0fcc2757ed9.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Bumps Neutron container image tags to fix `bug 2068644
+    <https://bugs.launchpad.net/neutron/+bug/2068644>`__ which could prevent
+    associating floating IPs with OVN-based load balancers.


### PR DESCRIPTION
This bug could prevent associating floating IPs with OVN-based load balancers.