### PR TITLE
feat: update `kayobe-automation` submodule and `workflows`

### DIFF
--- a/.automation.conf/run-books/pulp-sync-content.sh
+++ b/.automation.conf/run-books/pulp-sync-content.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -euE
+set -o pipefail
+
+PARENT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+KAYOBE_AUTOMATION_DIR="$(realpath "${PARENT}/../../.automation")"
+
+function main {
+	if [ "${PULP_DO_CONTAINER_SYNC:-}" = true ]; then
+		${KAYOBE_AUTOMATION_DIR}/scripts/playbook-run.sh '$KAYOBE_CONFIG_PATH/ansible/pulp-container-sync.yml' -e stackhpc_pulp_images_kolla_filter="${PULP_KOLLA_FILTER:-}"
+	fi
+	if [ "${PULP_DO_CONTAINER_PUBLISH:-}" = true ]; then
+		${KAYOBE_AUTOMATION_DIR}/scripts/playbook-run.sh '$KAYOBE_CONFIG_PATH/ansible/pulp-container-publish.yml' -e stackhpc_pulp_images_kolla_filter="${PULP_KOLLA_FILTER:-}"
+	fi
+	if [ "${PULP_DO_REPO_SYNC:-}" = true ]; then
+		${KAYOBE_AUTOMATION_DIR}/scripts/playbook-run.sh '$KAYOBE_CONFIG_PATH/ansible/pulp-repo-sync.yml'
+	fi
+	if [ "${PULP_DO_REPO_PUBLISH:-}" = true ]; then
+		${KAYOBE_AUTOMATION_DIR}/scripts/playbook-run.sh '$KAYOBE_CONFIG_PATH/ansible/pulp-repo-publish.yml'
+	fi
+	if [ "${PULP_DO_REPO_PROMOTE:-}" = true ]; then
+		${KAYOBE_AUTOMATION_DIR}/scripts/playbook-run.sh '$KAYOBE_CONFIG_PATH/ansible/pulp-repo-promote-production.yml'
+	fi
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+	main
+fi

--- a/etc/kayobe/ansible/requirements.yml
+++ b/etc/kayobe/ansible/requirements.yml
@@ -11,7 +11,7 @@ collections:
   - name: stackhpc.hashicorp
     version: 2.5.1
   - name: stackhpc.kayobe_workflows
-    version: 1.0.3
+    version: 1.1.0
 roles:
   - src: stackhpc.vxlan
   - name: ansible-lockdown.ubuntu22_cis

--- a/releasenotes/notes/update-kayobe-automation-55fc9c5c380d819c.yaml
+++ b/releasenotes/notes/update-kayobe-automation-55fc9c5c380d819c.yaml
@@ -1,14 +1,18 @@
 ---
 features:
   - |
-    Upgrades kayobe-automation submodule to ``86b2840``.
+    Upgrades kayobe-automation submodule to ``7676aa8``.
+    
     Upgrades kayobe-workflows collection to ``v1.1.0``.
+
     Kayobe-automation config-diff now runs in parallel and generates both
     the old and new configuration at the same time. This should improve
     config-diff wait times.
+
+    Add support for the `pulp-sync-content` run book.
 deprecations:
   - |
-    Kayobe-automation will now automatically detected vaulted files for the
+    Kayobe-automation will now automatically detect vaulted files for the
     purpose of config-diff therefore, ``KAYOBE_CONFIG_SECRET_PATHS_EXTRA`` and
     ``KAYOBE_CONFIG_VAULTED_FILES_PATHS_EXTRA`` are no longer used
 security:

--- a/releasenotes/notes/update-kayobe-automation-55fc9c5c380d819c.yaml
+++ b/releasenotes/notes/update-kayobe-automation-55fc9c5c380d819c.yaml
@@ -1,0 +1,19 @@
+---
+features:
+  - |
+    Upgrades kayobe-automation submodule to ``86b2840``.
+    Upgrades kayobe-workflows collection to ``v1.1.0``.
+    Kayobe-automation config-diff now runs in parallel and generates both
+    the old and new configuration at the same time. This should improve
+    config-diff wait times.
+deprecations:
+  - |
+    Kayobe-automation will now automatically detected vaulted files for the
+    purpose of config-diff therefore, ``KAYOBE_CONFIG_SECRET_PATHS_EXTRA`` and
+    ``KAYOBE_CONFIG_VAULTED_FILES_PATHS_EXTRA`` are no longer used
+security:
+  - |
+    The upgraded kayobe-workflows collection increases the version of various
+    Actions and containers used within GitHub based workflows, including increasing
+    Docker in Docker to version ``27.3.1`` thus removing the vunerabilities present
+    in ``24.0-git``.


### PR DESCRIPTION
Upgrade both the submodule used by `kayobe-automation` and the workflows collection that can generate `GitHub` workflows.

Changes include:
  - Run config-diff in parallel
  - Automation detect vaulted files for config-diff
  - Add support for running hooks that use roles
  - Improvements to Tempest including the ability to run only failed tests
  - Use less verbose input descriptions
  - Bump up and pin the version of Actions and containers used by the workflows