### PR TITLE
feat: bump `multinode` workflow

### DIFF
--- a/.github/workflows/stackhpc-multinode-periodic.yml
+++ b/.github/workflows/stackhpc-multinode-periodic.yml
@@ -35,7 +35,7 @@ jobs:
     name: Multinode periodic
     needs:
       - generate-inputs
-    uses: stackhpc/stackhpc-openstack-gh-workflows/.github/workflows/multinode.yml@1.1.0
+    uses: stackhpc/stackhpc-openstack-gh-workflows/.github/workflows/multinode.yml@1.2.0
     with:
       multinode_name: mn-prdc-${{ github.run_id }}
       os_distribution: ${{ needs.generate-inputs.outputs.os_distribution }}

--- a/.github/workflows/stackhpc-multinode.yml
+++ b/.github/workflows/stackhpc-multinode.yml
@@ -52,7 +52,7 @@ name: Multinode
 jobs:
   multinode:
     name: Multinode
-    uses: stackhpc/stackhpc-openstack-gh-workflows/.github/workflows/multinode.yml@1.1.0
+    uses: stackhpc/stackhpc-openstack-gh-workflows/.github/workflows/multinode.yml@1.2.0
     with:
       multinode_name: ${{ inputs.multinode_name }}
       os_distribution: ${{ inputs.os_distribution }}


### PR DESCRIPTION
The reusuable workflow needs bumping to ensure that `openssh-client` is installed otherwise `ssh-keygen` is missing from the host preventing the workflow from proceeding.