### PR TITLE
Install openssh-client in AIO workflow

### DIFF
--- a/.github/workflows/stackhpc-all-in-one.yml
+++ b/.github/workflows/stackhpc-all-in-one.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Install Package
         uses: ConorMacBride/install-package@main
         with:
-          apt: git unzip nodejs
+          apt: git unzip nodejs openssh-client
 
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Fixes `ssh-keygen: command not found` in pull requests workflows.