### PR TITLE
Disable Seed firewalld when using OVS

### DIFF
--- a/etc/kayobe/environments/ci-multinode/seed.yml
+++ b/etc/kayobe/environments/ci-multinode/seed.yml
@@ -32,7 +32,7 @@ snat_rules: "{{ snat_rules_default + snat_rules_manila if (kolla_enable_manila |
 # seed node firewalld configuration.
 
 # Whether to install and enable firewalld.
-seed_firewalld_enabled: true
+seed_firewalld_enabled: "{{ kolla_enable_ovn | bool }}"
 
 # A list of zones to create. Each item is a dict containing a 'zone' item.
 seed_firewalld_zones: "{{ stackhpc_firewalld_zones }}"


### PR DESCRIPTION
VMs can't have outbound connection with default SKC firewalld setup when a multinode uses OVS.

Make default Seed firewalld state conditional to avoid having breaking change.