### PR TITLE
Backport: Fix rabbitmq-reset.yml trying to restart wrong services

### DIFF
--- a/etc/kayobe/ansible/rabbitmq-reset.yml
+++ b/etc/kayobe/ansible/rabbitmq-reset.yml
@@ -68,4 +68,4 @@
     # The following services use RabbitMQ.
     - name: Restart OpenStack services
       shell: >-
-        systemctl -a | egrep '(barbican|blazar|cinder|cloudkitty|designate|heat|ironic|keystone|magnum|manila|neutron|nova|octavia)' | awk '{ print $1 }' | xargs systemctl restart
+        systemctl -a | egrep 'kolla-(barbican|blazar|cinder|cloudkitty|designate|heat|ironic|keystone|magnum|manila|neutron|nova|octavia)' | awk '{ print $1 }' | xargs systemctl restart


### PR DESCRIPTION
Fixes egrep passed to systemctl attempting to restart other services containing nova in the name:

```
  stderr: |-
    Failed to restart dev-disk-byx2did-dmx2dnamex2drootvgx2dlv_nova.device: Job type restart is not applicable for unit dev-disk-byx2did-dmx2dnamex2drootvgx2dlv_nova.device.
    Failed to restart dev-mapper-rootvgx2dlv_nova.device: Job type restart is not applicable for unit dev-mapper-rootvgx2dlv_nova.device.
    Failed to restart dev-rootvg-lv_nova.device: Job type restart is not applicable for unit dev-rootvg-lv_nova.device.
```