### PR TITLE
Set selinux_do_reboot to true for ci-multinode

### DIFF
--- a/etc/kayobe/environments/ci-multinode/globals.yml
+++ b/etc/kayobe/environments/ci-multinode/globals.yml
@@ -60,6 +60,9 @@ os_release: >-
 stackhpc_write_barbican_role_id_to_file: true
 stackhpc_barbican_role_id_file_path: "/tmp/barbican-role-id"
 
+# Enable rebooting to update SELinux state
+selinux_do_reboot: true
+
 ###############################################################################
 # Dummy variable to allow Ansible to accept this file.
 workaround_ansible_issue_8743: yes


### PR DESCRIPTION
``selinux_do_reboot`` is false by default in Kayobe. This causes multinode automation to fail in host configure because SELinux state is updated but reboot is not allowed.

This allows reboot so, host configure can run without failure.