### PR TITLE
2024.1 upgrade doc additions

### DIFF
--- a/doc/source/operations/upgrading-openstack.rst
+++ b/doc/source/operations/upgrading-openstack.rst
@@ -113,6 +113,14 @@ The domain set should be something that is not use anywhere else such as
 The Neuron DNS integration can be disabled by setting
 ``neutron_dns_integration: false`` in ``kolla/globals.yml``
 
+Redis Default User
+------------------
+
+The ``redis_connection_string`` has changed the username used from ``admin``
+to ``default``. Whilst this does not have any negative impact on services
+that utilise Redis it will feature prominently in any preview of the overcloud
+configuration.
+
 Known issues
 ============
 

--- a/doc/source/operations/upgrading-openstack.rst
+++ b/doc/source/operations/upgrading-openstack.rst
@@ -494,7 +494,7 @@ Save the old configuration locally.
 
 .. code-block:: console
 
-   kayobe overcloud service configuration save --node-config-dir /etc/kolla --output-dir ~/kolla-diff/old --limit controllers[0],compute[0],storage[0]
+   kayobe overcloud service configuration save --node-config-dir /etc/kolla --output-dir ~/kolla-diff/old --limit controllers[0],compute[0],storage[0] --exclude ironic-agent.initramfs,ironic-agent.kernel
 
 Generate the new configuration to a tmpdir.
 
@@ -506,7 +506,7 @@ Save the new configuration locally.
 
 .. code-block:: console
 
-   kayobe overcloud service configuration save --node-config-dir /tmp/kolla --output-dir ~/kolla-diff/new --limit controllers[0],compute[0],storage[0]
+   kayobe overcloud service configuration save --node-config-dir /tmp/kolla --output-dir ~/kolla-diff/new --limit controllers[0],compute[0],storage[0] --exclude ironic-agent.initramfs,ironic-agent.kernel
 
 The old and new configuration will be saved to ``~/kolla-diff/old`` and
 ``~/kolla-diff/new`` respectively on the Ansible control host.


### PR DESCRIPTION
Two additions to the documentation for 2024.1 OpenStack upgrade.

- Mention the change to `redis_connection_string` as features a lot when comparing the deployed overcloud configuration with the proposed configuration when using `kayobe overcloud service configuration generate`
- Add `--exclude` on `kayobe overcloud service configuration save` in order to avoid the possibility of downloading `ironic-agent.initramfs` and `ironic-agent.kernel` which has failed to download in a reasonable timeframe and offers no benefit to configuration comparison.