### PR TITLE
[2023.1] Fix eswitchd and neutron_mlnx_agent not using our fork

### DIFF
--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -33,8 +33,8 @@ kolla_image_tags:
   manila:
     rocky-9: 2023.1-rocky-9-20240809T102431
   neutron:
-    rocky-9: 2023.1-rocky-9-20241011T094404
-    ubuntu-jammy: 2023.1-ubuntu-jammy-20241011T094404
+    rocky-9: 2023.1-rocky-9-20241011T174500
+    ubuntu-jammy: 2023.1-ubuntu-jammy-20241011T174500
   nova:
     rocky-9: 2023.1-rocky-9-20240926T151818
     ubuntu-jammy: 2023.1-ubuntu-jammy-20240926T151818

--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -33,8 +33,8 @@ kolla_image_tags:
   manila:
     rocky-9: 2023.1-rocky-9-20240809T102431
   neutron:
-    rocky-9: 2023.1-rocky-9-20241011T174500
-    ubuntu-jammy: 2023.1-ubuntu-jammy-20241011T174500
+    rocky-9: 2023.1-rocky-9-20241011T212435
+    ubuntu-jammy: 2023.1-ubuntu-jammy-20241011T212435
   nova:
     rocky-9: 2023.1-rocky-9-20240926T151818
     ubuntu-jammy: 2023.1-ubuntu-jammy-20240926T151818

--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -33,8 +33,8 @@ kolla_image_tags:
   manila:
     rocky-9: 2023.1-rocky-9-20240809T102431
   neutron:
-    rocky-9: 2023.1-rocky-9-20240926T151818
-    ubuntu-jammy: 2023.1-ubuntu-jammy-20240926T151818
+    rocky-9: 2023.1-rocky-9-20241011T094404
+    ubuntu-jammy: 2023.1-ubuntu-jammy-20241011T094404
   nova:
     rocky-9: 2023.1-rocky-9-20240926T151818
     ubuntu-jammy: 2023.1-ubuntu-jammy-20240926T151818

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -456,6 +456,8 @@ kolla_build_customizations_common:
   nova_compute_packages_append:
     - python3-libvirt
     - python3-ethtool
+  neutron_mlnx_agent_pip_packages_override:
+    - networking-mlnx@git+https://github.com/stackhpc/networking-mlnx@stackhpc/{{ openstack_release }}
 
 kolla_build_customizations_rocky:
   kolla_toolbox_packages_remove:


### PR DESCRIPTION
The neutron_mlnx_agent based containers are not using the neutron plugins, so we need to customize the pip package directly.