### PR TITLE
Build Octavia from StackHPC fork

### DIFF
--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -39,8 +39,8 @@ kolla_image_tags:
     rocky-9: 2023.1-rocky-9-20240926T151818
     ubuntu-jammy: 2023.1-ubuntu-jammy-20240926T151818
   octavia:
-    rocky-9: 2023.1-rocky-9-20240730T090421
-    ubuntu-jammy: 2023.1-ubuntu-jammy-20240730T090421
+    rocky-9: 2023.1-rocky-9-20241015T100903
+    ubuntu-jammy: 2023.1-ubuntu-jammy-20241015T100903
   opensearch:
     ubuntu-jammy: 2023.1-ubuntu-jammy-20240509T094444
   openvswitch:

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -155,6 +155,10 @@ kolla_sources:
     type: git
     location: https://github.com/stackhpc/networking-mlnx
     reference: stackhpc/{{ openstack_release }}
+  octavia-base:
+    type: git
+    location: https://github.com/stackhpc/octavia.git
+    reference: stackhpc/{{ openstack_release }}
 
 ###############################################################################
 # Kolla image build configuration.

--- a/releasenotes/notes/fix-octavia-tls-terminated-pkcs12-4f7e32a6f5ca0143.yaml
+++ b/releasenotes/notes/fix-octavia-tls-terminated-pkcs12-4f7e32a6f5ca0143.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes creation and failover of Octavia TLS-terminated load balancers when
+    storing the certificate and key as a PKCS12 bundle in Barbican.


### PR DESCRIPTION
This fixes issues with creation and failover of TLS-terminated Octavia load balancers following our bump of pyOpenSSL [1] because of the removal of load_pkcs12 [2].

[1] https://github.com/stackhpc/requirements/pull/20
[2] https://bugs.launchpad.net/octavia/+bug/2042787