### PR TITLE
trivy: Add more repositories to handle rate limits - 2024.1

### DIFF
--- a/tools/scan-images.sh
+++ b/tools/scan-images.sh
@@ -54,6 +54,10 @@ for image in $images; do
           --severity HIGH,CRITICAL \
           --output image-scan-output/${filename}.json \
           --ignore-unfixed \
+          --db-repository ghcr.io/aquasecurity/trivy-db:2 \
+          --db-repository public.ecr.aws/aquasecurity/trivy-db \
+          --java-db-repository ghcr.io/aquasecurity/trivy-java-db:1 \
+          --java-db-repository public.ecr.aws/aquasecurity/trivy-java-db \
           $image); then
     # Clean up the output file for any images with no vulnerabilities
     rm -f image-scan-output/${filename}.json


### PR DESCRIPTION
More repositories are configured to avoid issues when ghcr.io hits rate limits. If the primary repository fails due to rate limiting, the system will fall back to the public ECR repository [1]

[1] https://github.com/aquasecurity/trivy/discussions/7668#discussioncomment-10892093