### PR TITLE
Update Blazar image

### DIFF
--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -8,6 +8,8 @@ kolla_image_tags:
     ubuntu-jammy: 2023.1-ubuntu-jammy-20240621T104542
   bifrost_deploy:
     ubuntu-jammy: 2023.1-ubuntu-jammy-20240423T125905
+  blazar:
+    rocky-9: 2023.1-rocky-9-20241002T133312
   cinder:
     ubuntu-jammy: 2023.1-ubuntu-jammy-20240701T123544
   glance:

--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -9,7 +9,8 @@ kolla_image_tags:
   bifrost_deploy:
     ubuntu-jammy: 2023.1-ubuntu-jammy-20240423T125905
   blazar:
-    rocky-9: 2023.1-rocky-9-20241002T133312
+    rocky-9: 2023.1-rocky-9-20241107T140552
+    ubuntu-jammy: 2023.1-ubuntu-jammy-20241107T140552
   cinder:
     ubuntu-jammy: 2023.1-ubuntu-jammy-20240701T123544
   glance:

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -159,6 +159,10 @@ kolla_sources:
     type: git
     location: https://github.com/stackhpc/octavia.git
     reference: stackhpc/{{ openstack_release }}
+  blazar-base:
+    type: git
+    location: https://github.com/stackhpc/blazar
+    reference: flavor-based-reservation5
 
 ###############################################################################
 # Kolla image build configuration.

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -162,7 +162,7 @@ kolla_sources:
   blazar-base:
     type: git
     location: https://github.com/stackhpc/blazar
-    reference: flavor-based-reservation5
+    reference: stackhpc/master
 
 ###############################################################################
 # Kolla image build configuration.

--- a/releasenotes/notes/update-blazar-image-d176c27d55716469.yaml
+++ b/releasenotes/notes/update-blazar-image-d176c27d55716469.yaml
@@ -1,5 +1,5 @@
 ---
 features:
   - |
-    Use the stackhpc fork for building Blazar images with customizations to support
+    Use the StackHPC fork for building Blazar images with customizations to support
     flavor-based reservation.

--- a/releasenotes/notes/update-blazar-image-d176c27d55716469.yaml
+++ b/releasenotes/notes/update-blazar-image-d176c27d55716469.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Use the stackhpc fork for building Blazar images with customizations to support
+    flavor-based reservation.


### PR DESCRIPTION
Update Blazar image to include upstream and WIP flavor reservation patches to be used with coral credits.