### PR TITLE
INFRA-841 add tags for updated `Ironic` containers

### DIFF
--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -15,14 +15,14 @@ kolla_image_tags:
   haproxy_ssh:
     ubuntu-jammy: 2023.1-ubuntu-jammy-20240509T102329
   ironic:
-    rocky-9: 2023.1-rocky-9-20240906T144646
-    ubuntu-jammy: 2023.1-ubuntu-jammy-20240906T144646
+    rocky-9: 2023.1-rocky-9-20241022T090717
+    ubuntu-jammy: 2023.1-ubuntu-jammy-20241022T090717
   ironic_dnsmasq:
-    rocky-9: 2023.1-rocky-9-20240709T132012
-    ubuntu-jammy: 2023.1-ubuntu-jammy-20240621T104542
+    rocky-9: 2023.1-rocky-9-20241022T090717
+    ubuntu-jammy: 2023.1-ubuntu-jammy-20241022T090717
   ironic_neutron_agent:
-    rocky-9: 2023.1-rocky-9-20240916T114629
-    ubuntu-jammy: 2023.1-ubuntu-jammy-20240916T114629
+    rocky-9: 2023.1-rocky-9-20241022T090717
+    ubuntu-jammy: 2023.1-ubuntu-jammy-20241022T090717
   kolla_toolbox:
     rocky-9: 2023.1-rocky-9-20240809T102431
   letsencrypt:

--- a/releasenotes/notes/fix-ossa-2024-004-f732e58c12e26785.yaml
+++ b/releasenotes/notes/fix-ossa-2024-004-f732e58c12e26785.yaml
@@ -1,0 +1,6 @@
+---
+security:
+  - |
+    Fixes `OSSA-2024-004
+    <https://security.openstack.org/ossa/OSSA-2024-004.html>`_ with updated
+    container images for Ironic.


### PR DESCRIPTION
The Ironic containers been rebuilt with the latest sync which includes patches for the vulnerability `OSSA-2024-004`.