### PR TITLE
INFRA-841 add tags for updated `Ironic` containers

### DIFF
--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -28,3 +28,12 @@ kolla_image_tags:
     ubuntu-jammy: 2024.1-ubuntu-jammy-20240910T072617
   rabbitmq:
     rocky-9: 2024.1-rocky-9-20240927T152945
+  ironic:
+    rocky-9: 2024.1-rocky-9-20241022T090648
+    ubuntu-jammy: 2024.1-ubuntu-jammy-20241022T090648
+  ironic_dnsmasq:
+    rocky-9: 2024.1-rocky-9-20241022T090648
+    ubuntu-jammy: 2024.1-ubuntu-jammy-20241022T090648
+  ironic_neutron_agent:
+    rocky-9: 2024.1-rocky-9-20241022T090648
+    ubuntu-jammy: 2024.1-ubuntu-jammy-20241022T090648

--- a/releasenotes/notes/fix-ossa-2024-004-f732e58c12e26785.yaml
+++ b/releasenotes/notes/fix-ossa-2024-004-f732e58c12e26785.yaml
@@ -1,0 +1,6 @@
+---
+security:
+  - |
+    Fixes `OSSA-2024-004
+    <https://security.openstack.org/ossa/OSSA-2024-004.html>`_ with updated
+    container images for Ironic.


### PR DESCRIPTION
The Ironic containers been rebuilt with the latest sync which includes patches for the vulnerability `OSSA-2024-004`.