### PR TITLE
INFRA-804: document GRUB boot issue on RL9

### DIFF
--- a/doc/source/operations/upgrading-openstack.rst
+++ b/doc/source/operations/upgrading-openstack.rst
@@ -134,7 +134,8 @@ Known issues
   <https://access.redhat.com/security/cve/CVE-2023-4001>`__, the operating
   system can become unbootable (boot will stop at a ``grub>`` prompt). Remove
   the ``--root-dev-only`` option from ``/boot/efi/EFI/rocky/grub.cfg`` after
-  applying package updates.
+  applying package updates. This will happen automatically as a post hook when
+  running the ``kayobe overcloud host package update`` command.
 
 Security baseline
 =================
@@ -868,6 +869,15 @@ To update all eligible packages, use ``*``, escaping if necessary:
 .. code-block:: console
 
    kayobe overcloud host package update --packages "*" --limit <host>
+
+.. note::
+
+   Due to a `security-related change in the GRUB package on Rocky Linux 9
+   <https://access.redhat.com/security/cve/CVE-2023-4001>`__, the operating
+   system can become unbootable (boot will stop at a ``grub>`` prompt). Remove
+   the ``--root-dev-only`` option from ``/boot/efi/EFI/rocky/grub.cfg`` after
+   applying package updates. This will happen automatically as a post hook when
+   running the ``kayobe overcloud host package update`` command.
 
 If the kernel has been upgraded, reboot the host or batch of hosts to pick up
 the change:

--- a/doc/source/operations/upgrading-openstack.rst
+++ b/doc/source/operations/upgrading-openstack.rst
@@ -130,6 +130,12 @@ Known issues
   around this in custom config, see the SMS PR for an example:
   https://github.com/stackhpc/smslab-kayobe-config/pull/354
 
+* Due to a `security-related change in the GRUB package on Rocky Linux 9
+  <https://access.redhat.com/security/cve/CVE-2023-4001>`__, the operating
+  system can become unbootable (boot will stop at a ``grub>`` prompt). Remove
+  the ``--root-dev-only`` option from ``/boot/efi/EFI/rocky/grub.cfg`` after
+  applying package updates.
+
 Security baseline
 =================
 

--- a/etc/kayobe/ansible/fix-grub-rl9.yml
+++ b/etc/kayobe/ansible/fix-grub-rl9.yml
@@ -1,0 +1,15 @@
+---
+- name: Remove "--root-dev-only" from grub.cfg if OS is Rocky Linux 9
+  hosts: overcloud
+  become: yes
+  gather_facts: true
+
+  tasks:
+    - name: Remove "--root-dev-only" from /boot/efi/EFI/rocky/grub.cfg
+      ansible.builtin.replace:
+        path: /boot/efi/EFI/rocky/grub.cfg
+        regexp: '--root-dev-only\s?'
+        replace: ''
+      when:
+        - ansible_facts['distribution'] == 'Rocky'
+        - ansible_facts['distribution_major_version'] == '9'

--- a/etc/kayobe/hooks/overcloud-host-package-update/post.d/10-fix-grub-rl9.yml
+++ b/etc/kayobe/hooks/overcloud-host-package-update/post.d/10-fix-grub-rl9.yml
@@ -1,0 +1,1 @@
+../../../ansible/fix-grub-rl9.yml


### PR DESCRIPTION
INFRA-804: document GRUB boot issue on RL9 and add hook to automate removal of ``--root-dev-only``.