### PR TITLE
CI: Bump AIO root volume size to 50GB

### DIFF
--- a/terraform/aio/vm.tf
+++ b/terraform/aio/vm.tf
@@ -35,7 +35,7 @@ variable "aio_vm_subnet" {
 
 variable "aio_vm_volume_size" {
   type = number
-  default = 40
+  default = 50
 }
 
 variable "aio_vm_tags" {


### PR DESCRIPTION
Tempest test on https://github.com/stackhpc/stackhpc-kayobe-config/actions/runs/11516474614/job/32145413990?pr=1312 is keep failing because the aio is running out of space. Bumping it to 50 GB.