### PR TITLE
Fix Debian Ceph Reef repo names to match Release Train

### DIFF
--- a/etc/kayobe/pulp.yml
+++ b/etc/kayobe/pulp.yml
@@ -122,12 +122,12 @@ stackhpc_pulp_deb_repos:
     components: "stable"
     required: "{{ stackhpc_pulp_sync_ubuntu_jammy | bool }}"
 
-  - name: "Docker CE for Ubuntu Jammy"
+  - name: "Ceph Reef for Debian"
     url: "{{ stackhpc_release_pulp_content_url }}/ceph/debian-reef/{{ stackhpc_pulp_repo_ceph_reef_debian_version }}"
-    distribution_name: "docker-ce-for-ubuntu-jammy-"
-    base_path: "docker-ce/ubuntu-jammy/"
+    distribution_name: "ceph-reef-debian-"
+    base_path: "ceph/debian-reef/"
     distributions: "jammy"
-    components: "stable"
+    components: "main"
     required: "{{ stackhpc_pulp_sync_ubuntu_jammy | bool }}"
 
 # Publication format is a subset of distribution.


### PR DESCRIPTION
Ceph Reef for Debian package repository fails to be promoted.
The mismatch on names is likely to causing it.