### PR TITLE
Pin Magnum to Antelope for both Ubuntu and Rocky

### DIFF
--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -23,7 +23,12 @@ kolla_image_tags:
 {{ lookup('pipe', 'python3 ' ~ kayobe_config_path ~ '/../../tools/kolla-images.py list-tag-vars') }}
 
 # FIXME: Pin to Antelope Magnum until it is working again upstream
-magnum_tag: 2023.1-rocky-9-20240821T102442
+kayobe_image_tags:
+  magnum:
+    rocky: 2023.1-rocky-9-20240821T102442
+    ubuntu: 2023.1-ubuntu-jammy-20240821T102442
+
+magnum_tag: "{% raw %}{{ kayobe_image_tags['magnum'][kolla_base_distro] }}{% endraw %}"
 #############################################################################
 # Monitoring and alerting related settings
 


### PR DESCRIPTION
Only Magnum for Rocky Linux was pinned on
https://github.com/stackhpc/stackhpc-kayobe-config/pull/1339