### PR TITLE
Redfish exporter: Fixes scrape group

### DIFF
--- a/etc/kayobe/kolla/config/prometheus/prometheus.yml.d/60-redfish.yml
+++ b/etc/kayobe/kolla/config/prometheus/prometheus.yml.d/60-redfish.yml
@@ -15,13 +15,11 @@ scrape_configs:
        replacement: "{{ lookup('vars', admin_oc_net_name ~ '_ips')[groups.seed.0] }}:9610"
     static_configs:
 {% for host in groups.get('redfish_exporter_targets', []) %}
-{% if hostvars[host]["redfish_exporter_scrape_group"] | default('overcloud') == 'overcloud' %}
       - targets:
           - '{{ hostvars[host]["redfish_exporter_target_address"] }}'
         labels:
           server: '{{ host }}'
           env: "{{ kayobe_environment | default('openstack') }}"
           group: "{{ hostvars[host]['redfish_exporter_scrape_group'] | default('overcloud') }}"
-{% endif %}
 {% endfor %}
 {% endif %}

--- a/releasenotes/notes/fix-issue-with-redfish-exporter-scrape-group-b10eaac6ee1e6af3.yaml
+++ b/releasenotes/notes/fix-issue-with-redfish-exporter-scrape-group-b10eaac6ee1e6af3.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixes an issue where setting ``redfish_exporter_scrape_group`` to a value
+    other than ``overcloud`` would exclude those nodes from the redfish
+    exporter scrapes.


### PR DESCRIPTION
We were only including the scrape group `overcloud` in the prometheus config. This change allows the scrape group to work as intended.