### PR TITLE
fix!: manage the `physical` interface in `ci-aio`

### DIFF
--- a/.github/workflows/stackhpc-all-in-one.yml
+++ b/.github/workflows/stackhpc-all-in-one.yml
@@ -225,21 +225,12 @@ jobs:
       - name: Write Terraform network config
         run: |
           cat << EOF > etc/kayobe/environments/$KAYOBE_ENVIRONMENT/tf-networks.yml
-
-          admin_oc_net_name: admin
-          admin_cidr: "{{ access_cidr.value }}"
-          admin_allocation_pool_start: 0.0.0.0
-          admin_allocation_pool_end: 0.0.0.0
-          admin_gateway: "{{ access_gw.value }}"
-          admin_bootproto: dhcp
-          admin_ips:
+          admin_oc_net_name: ethernet
+          ethernet_cidr: "{{ access_cidr.value }}"
+          ethernet_allocation_pool_start: 0.0.0.0
+          ethernet_allocation_pool_end: 0.0.0.0
+          ethernet_ips:
             controller0: "{{ access_ip_v4.value }}"
-          EOF
-
-      - name: Write Terraform network interface config
-        run: |
-          cat << EOF > etc/kayobe/environments/$KAYOBE_ENVIRONMENT/inventory/group_vars/controllers/tf-network-interfaces
-          admin_interface: "{{ access_interface.value }}"
           EOF
 
       - name: Write all-in-one scenario config

--- a/etc/kayobe/environments/ci-aio/automated-setup.sh
+++ b/etc/kayobe/environments/ci-aio/automated-setup.sh
@@ -72,10 +72,6 @@ fi
 sudo ip l set dummy1 up
 sudo ip l set dummy1 master breth1
 
-if type apt; then
-    sudo cp /run/systemd/network/* /etc/systemd/network
-fi
-
 export KAYOBE_VAULT_PASSWORD=$(cat $BASE_PATH/vault-pw)
 pushd $BASE_PATH/src/kayobe-config
 source kayobe-env --environment ci-aio

--- a/etc/kayobe/environments/ci-aio/controllers.yml
+++ b/etc/kayobe/environments/ci-aio/controllers.yml
@@ -6,6 +6,9 @@
 # to setup the Kayobe user account. Default is {{ os_distribution }}.
 controller_bootstrap_user: "{{ os_distribution if os_distribution == 'ubuntu' else 'cloud-user' }}"
 
+controller_extra_network_interfaces:
+  - ethernet
+
 # Controller lvm configuration. See intentory/group_vars/controllers/lvm.yml
 # for the exact configuration.
 controller_lvm_groups:

--- a/etc/kayobe/environments/ci-aio/inventory/group_vars/controllers/network-interfaces
+++ b/etc/kayobe/environments/ci-aio/inventory/group_vars/controllers/network-interfaces
@@ -2,6 +2,11 @@
 ###############################################################################
 # Network interface definitions for the controller group.
 
+# Ethernet interface is the `primary` or `physical` interface associated
+# with the instance that the AIO deployment runs inside of. It is the interface used
+# to reach the instance.
+ethernet_interface: "{{ ansible_facts['default_ipv4']['interface'] }}"
+
 # Controller interface on all-in-one network.
 aio_interface: breth1
 # Use dummy1 if it exists, otherwise the bridge will have no ports.

--- a/etc/kayobe/environments/ci-aio/networks.yml
+++ b/etc/kayobe/environments/ci-aio/networks.yml
@@ -80,6 +80,12 @@ cleaning_net_name: aio
 ###############################################################################
 # Network definitions.
 
+# This network is required to be defined within `ci-aio` environment to ensure that
+# the network interface files are created appropriately and to provide easy inclusion
+# within the firewall configuration.
+ethernet_bootproto: dhcp
+ethernet_zone: trusted
+
 # All-in-one network.
 aio_cidr: 192.168.33.0/24
 aio_allocation_pool_start: 192.168.33.3


### PR DESCRIPTION
Treat the physical interface as network interface inside of the `ci-aio` environment. This is to ensure the network interface files are created correctly with the appropriate permissions otherwise we will lose connection after the DHCP lease expires. Also this approach enables us to include the interface within the firewall configuration ensuring we maintain SSH access through the firewall via this interface.