### PR TITLE
Pin os-capacity to v0.5 release

### DIFF
--- a/etc/kayobe/ansible/deploy-os-capacity-exporter.yml
+++ b/etc/kayobe/ansible/deploy-os-capacity-exporter.yml
@@ -60,7 +60,7 @@
     - name: Ensure os_capacity container is running
       community.docker.docker_container:
         name: os_capacity
-        image: ghcr.io/stackhpc/os-capacity:v0.5
+        image: ghcr.io/stackhpc/os-capacity:{{ stackhpc_os_capacity_version }}
         env:
           OS_CLOUD: openstack
           OS_CLIENT_CONFIG_FILE: /etc/openstack/clouds.yaml

--- a/etc/kayobe/ansible/deploy-os-capacity-exporter.yml
+++ b/etc/kayobe/ansible/deploy-os-capacity-exporter.yml
@@ -57,19 +57,19 @@
           when: stackhpc_os_capacity_openstack_cacert | length > 0
           register: cacert_result
 
-        - name: Ensure os_capacity container is running
-          community.docker.docker_container:
-            name: os_capacity
-            image: ghcr.io/stackhpc/os-capacity:master
-            env:
-              OS_CLOUD: openstack
-              OS_CLIENT_CONFIG_FILE: /etc/openstack/clouds.yaml
-            mounts:
-              - type: bind
-                source: /opt/kayobe/os-capacity/
-                target: /etc/openstack/
-            network_mode: host
-            restart: "{{ clouds_yaml_result is changed or cacert_result is changed }}"
-            restart_policy: unless-stopped
-          become: true
-      when: stackhpc_enable_os_capacity and openrc_file_stat.stat.exists
+    - name: Ensure os_capacity container is running
+      community.docker.docker_container:
+        name: os_capacity
+        image: ghcr.io/stackhpc/os-capacity:v0.5
+        env:
+          OS_CLOUD: openstack
+          OS_CLIENT_CONFIG_FILE: /etc/openstack/clouds.yaml
+        mounts:
+          - type: bind
+            source: /opt/kayobe/os-capacity/
+            target: /etc/openstack/
+        network_mode: host
+        restart: "{{ clouds_yaml_result is changed or cacert_result is changed }}"
+        restart_policy: unless-stopped
+      become: true
+      when: stackhpc_enable_os_capacity

--- a/etc/kayobe/ansible/deploy-os-capacity-exporter.yml
+++ b/etc/kayobe/ansible/deploy-os-capacity-exporter.yml
@@ -57,19 +57,19 @@
           when: stackhpc_os_capacity_openstack_cacert | length > 0
           register: cacert_result
 
-    - name: Ensure os_capacity container is running
-      community.docker.docker_container:
-        name: os_capacity
-        image: ghcr.io/stackhpc/os-capacity:{{ stackhpc_os_capacity_version }}
-        env:
-          OS_CLOUD: openstack
-          OS_CLIENT_CONFIG_FILE: /etc/openstack/clouds.yaml
-        mounts:
-          - type: bind
-            source: /opt/kayobe/os-capacity/
-            target: /etc/openstack/
-        network_mode: host
-        restart: "{{ clouds_yaml_result is changed or cacert_result is changed }}"
-        restart_policy: unless-stopped
-      become: true
-      when: stackhpc_enable_os_capacity
+        - name: Ensure os_capacity container is running
+          community.docker.docker_container:
+            name: os_capacity
+            image: ghcr.io/stackhpc/os-capacity:{{ stackhpc_os_capacity_version }}
+            env:
+              OS_CLOUD: openstack
+              OS_CLIENT_CONFIG_FILE: /etc/openstack/clouds.yaml
+            mounts:
+              - type: bind
+                source: /opt/kayobe/os-capacity/
+                target: /etc/openstack/
+            network_mode: host
+            restart: "{{ clouds_yaml_result is changed or cacert_result is changed }}"
+            restart_policy: unless-stopped
+          become: true
+      when: stackhpc_enable_os_capacity and openrc_file_stat.stat.exists

--- a/etc/kayobe/stackhpc-monitoring.yml
+++ b/etc/kayobe/stackhpc-monitoring.yml
@@ -34,6 +34,9 @@ alertmanager_packet_errors_threshold: 1
 # targets being templated during deployment.
 stackhpc_enable_os_capacity: true
 
+# OpenStack Capacity exporter version
+stackhpc_os_capacity_version: v0.5
+
 # Path to a CA certificate file to trust in the OpenStack Capacity exporter.
 stackhpc_os_capacity_openstack_cacert: ""
 


### PR DESCRIPTION
Version v0.3 was broken an automatically pulled
on a fresh controller. Lets start pinning this version.

Note v0.5 fixes 842 CVEs vs the previous version:
https://github.com/stackhpc/os-capacity/security/code-scanning