### PR TITLE
CIS: Stop recursively setting permissions on logs files

### DIFF
--- a/etc/kayobe/inventory/group_vars/cis-hardening/cis
+++ b/etc/kayobe/inventory/group_vars/cis-hardening/cis
@@ -51,6 +51,9 @@ rhel9cis_rule_6_1_15: false
 # filesystem.  We do not want to change /var/lib/docker permissions.
 rhel9cis_no_world_write_adjust: false
 
+# Prevent hardening from recursivley changing permissions on log files
+rhel9cis_rule_4_2_3: false
+
 # Configure log rotation to prevent audit logs from filling the disk
 rhel9cis_auditd:
   space_left_action: syslog
@@ -152,6 +155,9 @@ ubtu22cis_no_group_adjust: false
 ubtu22cis_no_owner_adjust: false
 ubtu22cis_no_world_write_adjust: false
 ubtu22cis_suid_adjust: false
+
+# Prevent hardening from recursivley changing permissions on log files
+ubtu22cis_rule_4_2_3: false
 
 # Configure log rotation to prevent audit logs from filling the disk
 ubtu22cis_auditd:

--- a/releasenotes/notes/cis-hardening-no-longer-sets-permissions-on-logs-81a48ab8ed2d6b5f.yaml
+++ b/releasenotes/notes/cis-hardening-no-longer-sets-permissions-on-logs-81a48ab8ed2d6b5f.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    The CIS hardening scripts no longer change permissions of log files by
+    default. It is preferred to configure these permissions at source i.e on
+    whatever is creating the files. It also suffered from a time-of-check to
+    time-of-use race condition. If you want the old behaviour you can change
+    ``rhel9cis_rule_4_2_3`` and/or ``ubtu22cis_rule_4_2_3`` to ``true``.


### PR DESCRIPTION
This suffers from a time-of-check to time-of-use race condition and in general recursively setting file permissions seems to be a bad idea.