### PR TITLE
Update docs for client.cinder to support COW snapshots

### DIFF
--- a/doc/source/configuration/cephadm.rst
+++ b/doc/source/configuration/cephadm.rst
@@ -259,6 +259,25 @@ for Cinder, Cinder backup, Glance, and Nova in Kolla Ansible.
          mgr: "profile rbd pool=images"
        state: present
 
+.. note::
+
+   By default, the ``client.cinder`` user is configured with read-only access
+   to the ``images`` pool. However, to support copy-on-write (COW) snapshots,
+   configure read-write access to the ``images`` pool by changing ``profile
+   rbd-read-only pool=images`` to ``profile rbd pool=images``:
+
+   .. code:: yaml
+
+      cephadm_keys:
+        - name: client.cinder
+          caps:
+            mon: "profile rbd"
+            osd: "profile rbd pool=volumes, profile rbd pool=vms, profile rbd pool=images"
+            mgr: "profile rbd pool=volumes, profile rbd pool=vms"
+
+   For more details on enabling and configuring COW optimisations, see the
+   :ref:`ceph-cow-optimisations` section.
+
 Ceph Commands
 ~~~~~~~~~~~~~
 
@@ -552,3 +571,88 @@ committed to the configuration.
 
 This configuration will be used during
 ``kayobe overcloud service deploy``.
+
+OpenStack integration
+=====================
+
+.. _ceph-cow-optimisations:
+
+Copy on write optimisations
+---------------------------
+
+Copy on write optimisations are currently disabled by default due to
+`security concerns <https://bugs.launchpad.net/kolla-ansible/+bug/1992153>`__.
+To enable them, set ``stackhpc_enable_ceph_cow_optimisations`` to ``true`` in
+``etc/kayobe/stackhpc.yml``. Setting this flag to ``true`` causes Kayobe to
+render a `glance.conf` file with the following content:
+
+.. code:: ini
+
+  [DEFAULT]
+  show_multiple_locations = true
+  show_image_direct_url = true
+
+  [glance_store]
+  rbd_thin_provisioning = true
+
+.. warning::
+
+   Enabling ``show_image_direct_url`` allows Glance to return the RADOS location
+   (pool and image name) for each image. Although this does not expose any Ceph
+   credentials, it can be considered an information leak in some environments.
+   There are plans in kolla-ansible to deploy a separate ``glance-api`` instance
+   for the internal endpoint, which would allow this to be enabled for the
+   internal endpoint only.
+
+Verify that the Cinder user has read-write access to the images pool by running:
+
+.. code:: console
+
+   ceph auth get client.cinder
+
+If the output includes `profile rbd-read-only pool=images`, update the caps using:
+
+.. code:: console
+
+   ceph auth caps client.cinder mon 'profile rbd' osd 'profile rbd pool=volumes, profile rbd pool=vms, profile rbd pool=images' mgr 'profile rbd pool=volumes, profile rbd pool=vms'
+
+Be sure to keep any existing capabilities and only change the capabilities on the
+images pool from `profile rbd-read-only pool=images` to
+`profile rbd pool=images`. Then re-run the verification command to confirm the
+change.
+
+The Ceph keyrings under the Cinder and Nova configurations should also be
+updated to remove the read-only flag (e.g. remove `readonly` from the caps
+lines in `etc/kayobe/kolla/config/cinder/ceph.client.cinder.keyring` and
+`etc/kayobe/kolla/config/nova/ceph.client.cinder.keyring`).
+
+Example (before / after):
+
+.. code:: ini
+
+   [client.cinder]
+           key = redacted
+           caps mgr = "profile rbd pool=volumes, profile rbd pool=vms"
+           caps mon = "profile rbd"
+           caps osd = "profile rbd pool=volumes, profile rbd pool=vms, profile rbd-read-only pool=images"
+
+.. code:: ini
+
+   [client.cinder]
+           key = redacted
+           caps mgr = "profile rbd pool=volumes, profile rbd pool=vms"
+           caps mon = "profile rbd"
+           caps osd = "profile rbd pool=volumes, profile rbd pool=vms, profile rbd pool=images"
+
+If you had to change the keyrings, you will need to reconfigure glance, nova and cinder:
+
+.. code:: console
+
+   kayobe overcloud service deploy -kt glance,nova,cinder
+
+otherwise, just reconfigure glance:
+
+.. code:: console
+
+   kayobe overcloud service deploy -kt glance
+

--- a/etc/kayobe/environments/aufn-ceph/cephadm.yml
+++ b/etc/kayobe/environments/aufn-ceph/cephadm.yml
@@ -46,7 +46,7 @@ cephadm_keys:
   - name: client.cinder
     caps:
       mon: "profile rbd"
-      osd: "profile rbd pool=volumes, profile rbd pool=vms, profile rbd-read-only pool=images"
+      osd: "profile rbd pool=volumes, profile rbd pool=vms, profile rbd pool=images"
       mgr: "profile rbd pool=volumes, profile rbd pool=vms"
     state: present
   - name: client.cinder-backup

--- a/etc/kayobe/environments/aufn-ceph/stackhpc.yml
+++ b/etc/kayobe/environments/aufn-ceph/stackhpc.yml
@@ -13,3 +13,8 @@ pulp_password: 9e4bfa04-9d9d-493d-9473-ba92e4361dae
 
 # Whether or not to download overcloud host images from Ark
 stackhpc_download_overcloud_host_images: true
+
+###############################################################################
+# Feature flags
+
+stackhpc_enable_ceph_glance_cow_optimisations: true

--- a/etc/kayobe/environments/ci-multinode/cephadm.yml
+++ b/etc/kayobe/environments/ci-multinode/cephadm.yml
@@ -47,7 +47,7 @@ cephadm_keys:
   - name: client.cinder
     caps:
       mon: "profile rbd"
-      osd: "profile rbd pool=volumes, profile rbd pool=vms, profile rbd-read-only pool=images"
+      osd: "profile rbd pool=volumes, profile rbd pool=vms, profile rbd pool=images"
       mgr: "profile rbd pool=volumes, profile rbd pool=vms"
     state: present
   - name: client.cinder-backup

--- a/etc/kayobe/environments/ci-multinode/stackhpc.yml
+++ b/etc/kayobe/environments/ci-multinode/stackhpc.yml
@@ -1,3 +1,6 @@
 ---
+###############################################################################
+# Feature flags
 
 stackhpc_enable_cis_benchmark_hardening_hook: true
+stackhpc_enable_ceph_glance_cow_optimisations: true

--- a/etc/kayobe/kolla/config/glance.conf
+++ b/etc/kayobe/kolla/config/glance.conf
@@ -1,0 +1,10 @@
+[DEFAULT]
+{% if stackhpc_enable_ceph_glance_cow_optimisations | bool %}
+show_image_direct_url = true
+show_multiple_locations = true
+{% endif %}
+
+[glance_store]
+{% if stackhpc_enable_ceph_glance_cow_optimisations | bool %}
+rbd_thin_provisioning = true
+{% endif %}

--- a/etc/kayobe/stackhpc.yml
+++ b/etc/kayobe/stackhpc.yml
@@ -229,6 +229,11 @@ stackhpc_docker_registry_password: "{{ pulp_stack_password if pulp_stack_passwor
 ###############################################################################
 # Feature flags
 
+# Whether to enable copy on write optimisations for Ceph in the Glance image
+# store. Defaults to false as there an information disclosure vulnerability
+# with the current kolla-ansible setup when enabling show_direct_url in glance.
+stackhpc_enable_ceph_glance_cow_optimisations: false
+
 # Whether or not to run CIS benchmark hardening playbooks. Default is false.
 #stackhpc_enable_cis_benchmark_hardening_hook:
 

--- a/releasenotes/notes/adjust-ceph-permissions-on-images-for-cinder-user-3154b995916ee27e.yaml
+++ b/releasenotes/notes/adjust-ceph-permissions-on-images-for-cinder-user-3154b995916ee27e.yaml
@@ -1,0 +1,11 @@
+---
+features:
+  - |
+    Adds a ``stackhpc_enable_ceph_cow_optimisations`` feature flag to enable
+    copy on write optimisations when using Ceph. Please see the ``Copy on write
+    optimisations`` section under `Configuraton Guide` > `Cephadm and Kayobe`
+    in the documentation.
+
+    The feature is currently opt-in. Note the documented permissions for the
+    images pool for the Cinder user have been adjusted to make this easier to
+    apply for future deployments.


### PR DESCRIPTION
This is to support copy on write snapshots:

```
Performing standard snapshot because direct snapshot failed: no write permission on storage pool images: nova.exception.Forbidden: no write permission on storage pool images
```

when using ceph for nova ephemeral storage. My preferrence is for a standardised configuration rather than another if you use this feature, do this.