### PR TITLE
Provide support for `ssh-sk` for `Nova`

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -346,6 +346,11 @@ kolla_build_blocks:
         && grafana-cli plugins install grafana-opensearch-datasource
   ironic_inspector_header: |
     ADD additions-archive /
+  nova_base_footer: |
+    {% raw %}
+    RUN {{ macros.upper_constraints_version_change('cryptography', '42.*', '43.0.3') }}
+    RUN {{ macros.upper_constraints_version_change('eventlet', '0.35.*', '0.36.1') }}
+    {% endraw %}
 
 # Dict mapping image customization variable names to their values.
 # Each variable takes the form:

--- a/releasenotes/notes/add-sk-support-for-nova-42679a8f04225b90.yaml
+++ b/releasenotes/notes/add-sk-support-for-nova-42679a8f04225b90.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Add support for using `ssh-sk` key types within Nova providing
+    users with the option of improving security of SSH access to
+    their instances.
+


### PR DESCRIPTION
Provide `ssh-sk` based keys for use within `Nova` providing users with the ability to further secure `SSH` access to their instances.

This has been achieved with by bumping the `cryptography` package to version `43.0.0` which includes https://github.com/pyca/cryptography/pull/10608.