### PR TITLE
Restore old UUID of the Redfish dashboard

### DIFF
--- a/etc/kayobe/kolla/config/grafana/dashboards/openstack/redfish.json
+++ b/etc/kayobe/kolla/config/grafana/dashboards/openstack/redfish.json
@@ -3927,7 +3927,7 @@
   },
   "timezone": "",
   "title": "Redfish exporter",
-  "uid": "redfish",
+  "uid": "b02mElQGX",
   "version": 1,
   "weekStart": ""
 }

--- a/releasenotes/notes/redfish-uuid-grafana-2f50c76bbff6eba9.yaml
+++ b/releasenotes/notes/redfish-uuid-grafana-2f50c76bbff6eba9.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixes a bug where the Redfish Dashboard's UUID changed, causing Grafana to
+    fail to update the dashboard on deployment where the old dashboard UUID had
+    been used previously.


### PR DESCRIPTION
The redfish dashboard was updated to use a new UUID, however this caused errors in the Grafana logs and Grafana didn't update the dashboard. Reverting this to the old UUID fixes the issue.