### PR TITLE
INFRA-871 Remove angular plugins from Grafana

### DIFF
--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -45,3 +45,6 @@ kolla_image_tags:
   letsencrypt:
     rocky-9: 2024.1-rocky-9-20241206T090120
     ubuntu-jammy: 2024.1-ubuntu-jammy-20241206T090120
+  grafana:
+    rocky-9: 2024.1-rocky-9-20241128T123708
+    ubuntu-jammy: 2024.1-ubuntu-jammy-20241128T123708

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -339,9 +339,7 @@ kolla_build_blocks:
     ENV TOX_CONSTRAINTS_FILE=/requirements/upper-constraints.txt
   grafana_plugins_install: |
     RUN grafana-cli plugins install vonage-status-panel \
-        && grafana-cli plugins install grafana-piechart-panel \
-        && grafana-cli plugins install grafana-opensearch-datasource \
-        && grafana-cli plugins install gnocchixyz-gnocchi-datasource
+        && grafana-cli plugins install grafana-opensearch-datasource
   ironic_inspector_header: |
     ADD additions-archive /
   magnum_base_footer: |

--- a/etc/kayobe/trivy/allowed-vulnerabilities.yml
+++ b/etc/kayobe/trivy/allowed-vulnerabilities.yml
@@ -14,6 +14,9 @@
 #   - CVE-2023-31047
 fluentd_allowed_vulnerabilities:
   - CVE-2024-27280
+grafana_allowed_vulnerabilities:
+  - CVE-2024-8986
+
 
 ###############################################################################
 # Dummy variable to allow Ansible to accept this file.

--- a/releasenotes/notes/grafana-remove-angular-plugins-1c10e83ddb6556f4.yaml
+++ b/releasenotes/notes/grafana-remove-angular-plugins-1c10e83ddb6556f4.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Grafana now refuses to load AngularJS plugins. As such the
+    ``grafana-piechart-panel`` and ``gnocchixyz-gnocchi-datasource`` plugins
+    have been removed from the Grafana image.


### PR DESCRIPTION
We are seeing these in the Grafana logs

```
logger=plugins.validation t=2024-11-27T15:55:24.742127289+02:00 level=error msg="Plugin validation failed" pluginId=grafana-piechart-panel error="angular plugins are not supported"

logger=plugins.validation t=2024-11-27T15:55:24.578288183+02:00 level=error msg="Plugin validation failed" pluginId=gnocchixyz-gnocchi-datasource error="angular plugins are not supported"
```

This PR removes the offending plugins.