### PR TITLE
Add alertmanager rules for Docker

### DIFF
--- a/etc/kayobe/inventory/group_vars/all/docker
+++ b/etc/kayobe/inventory/group_vars/all/docker
@@ -1,0 +1,3 @@
+---
+# Address for prometheus metrics endpoint
+docker_metrics_addr: "{{ internal_net_name | net_ip + ':9323'}}"

--- a/etc/kayobe/kolla/config/prometheus/docker.rules
+++ b/etc/kayobe/kolla/config/prometheus/docker.rules
@@ -1,0 +1,33 @@
+
+{% raw %}
+
+groups:
+- name: Docker
+  rules:
+
+  - alert: DockerContainerStopped
+    expr: 'engine_daemon_container_states_containers{state="stopped"} > 0'
+    labels:
+      severity: warning
+    annotations:
+      summary: "Containers not running (instance {{ $labels.instance }})"
+      description: "One or more container are stopped"
+
+  - alert: DockerContainerPaused
+    expr: 'engine_daemon_container_states_containers{state="paused"} > 0'
+    labels:
+      severity: warning
+    annotations:
+      summary: "Containers not running (instance {{ $labels.instance }})"
+      description: "One or more container are stopped"
+
+  - alert: DockerContainerHealthCheckFail
+    expr: rate(engine_daemon_health_checks_failed_total[1m]) > 1
+    labels:
+      severity: warning
+    annotations:
+      summary: "Containers health check failed (instance {{ $labels.instance }})"
+      description: "One or more container health checks failed"
+
+{% endraw %}
+

--- a/releasenotes/notes/docker-alerts-30e8d870f25e500b.yaml
+++ b/releasenotes/notes/docker-alerts-30e8d870f25e500b.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Added new default alerting rules for containers being unhealthy or stopped.


### PR DESCRIPTION
Docker has a builtin prometheus exporter that we currently don't have enabled. This change adds alerts for stopped/paused containers and failed healthchecks.

Depends on:
kayobe: https://review.opendev.org/c/openstack/kayobe/+/936746
kolla-ansible: https://review.opendev.org/c/openstack/kolla-ansible/+/936742
ansible-collection-kolla: https://review.opendev.org/c/openstack/ansible-collection-kolla/+/936717