### PR TITLE
Update Horizon container images to fix bug 2055784

### DIFF
--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -21,7 +21,8 @@ kolla_image_tags:
     rocky-9: 2024.1-rocky-9-20241004T094540
     ubuntu-jammy: 2024.1-ubuntu-jammy-20241004T094540
   horizon:
-    rocky-9: 2024.1-rocky-9-20240909T144917
+    rocky-9: 2024.1-rocky-9-20241202T210927
+    ubuntu-jammy: 2024.1-ubuntu-jammy-20241202T210927
   bifrost_deploy:
     rocky-9: 2024.1-rocky-9-20240725T165045
   prometheus:

--- a/releasenotes/notes/fix-horizon-bug-2055784-3bb729919d345e77.yaml
+++ b/releasenotes/notes/fix-horizon-bug-2055784-3bb729919d345e77.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Updates Horizon container images to fix `bug 2055784
+    <https://bugs.launchpad.net/horizon/+bug/2055784>`__, which would cause
+    Horizon to be unable to retrieve resource providers statistics in
+    deployments with VGPU resources.


### PR DESCRIPTION
This bug would cause Horizon to be unable to retrieve resource providers statistics in deployments with VGPU resources.