### PR TITLE
enable extra ipa collectors only when building ipa

### DIFF
--- a/etc/kayobe/ipa.yml
+++ b/etc/kayobe/ipa.yml
@@ -119,10 +119,7 @@ ipa_build_dib_elements_extra:
 #ipa_collectors_default:
 
 # List of additional inspection collectors to run.
-ipa_collectors_extra:
-  - "dmi-decode"
-  - "extra-hardware"
-  - "numa-topology"
+ipa_collectors_extra: "{{ ['dmi-decode', 'extra-hardware', 'numa-topology'] if ipa_build_images else [] }}"
 
 # List of inspection collectors to run.
 #ipa_collectors:


### PR DESCRIPTION

current configuration will fail, as ipa_build_images is disabled by default

```
2024-12-02 13:13:07.567 2684 ERROR ironic_inspector.utils [-] [node: MAC 0c:42:a1:1f:a2:76 BMC 10.1.1.1] The following failures happened during running pre-processing hooks:
Preprocessing hook ramdisk_error: Ramdisk reported error: The following errors were encountered:
* failed to run hardware-detect utility: [Errno 2] No such file or directory: 'hardware-detect'
Node not found hook failed: Node 189839b8-6d2b-40e1-a89d-3b507bf426cf already has BMC address 10.129.131.4
2024-12-02 13:13:07.567 2684 DEBUG ironic_inspector.main [None req-3cad5ce2-7648-4a7b-85fd-e6f66b80ab7f - - - - - -] Returning error to client: The following failures happened during running pre-processing hooks:
Preprocessing hook ramdisk_error: Ramdisk reported error: The following errors were encountered:
* failed to run hardware-detect utility: [Errno 2] No such file or directory: 'hardware-detect'
Node not found hook failed: Node 189839b8-6d2b-40e1-a89d-3b507bf426cf already has BMC address 10.1.1.1 error_response /var/lib/kolla/venv/lib64/python3.9/site-packages/ironic_inspector/main.py:141
```