### PR TITLE
Add auto-label bot initial config

### DIFF
--- a/.github/auto-label.yaml
+++ b/.github/auto-label.yaml
@@ -1,0 +1,26 @@
+---
+path:
+  pullrequest: true
+  paths:
+    doc: 'documentation'
+    .github: 'workflows'
+    terraform: 'workflows'
+    etc:
+      kayobe:
+        enviromnents:
+          ci-aio: 'workflows'
+          ci-builder: 'workflows'
+          ci-multinode: 'workflows'
+        trivy: 'workflows'
+        ansible: 'ansible'
+        kolla:
+          config:
+            grafana: "monitoring"
+            prometheus: "monitoring"
+            fluentd: "monitoring"
+
+staleness:
+  pullrequest: true
+
+requestsize:
+  enabled: true


### PR DESCRIPTION
Adds initial configuration for auto-labeling bot: https://github.com/googleapis/repo-automation-bots/tree/main/packages/auto-label
Currently based on change size, filepaths changed, and PR age

The file path configuration could be greatly expanded, but I want to make sure the concept works at a smaller scale before investing more time