### PR TITLE
Update Cinder container images to fix bug 1823445

### DIFF
--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -9,6 +9,9 @@ kolla_image_tags:
   blazar:
     rocky-9: 2024.1-rocky-9-20241125T093138
     ubuntu-jammy: 2024.1-ubuntu-jammy-20241125T093138
+  cinder:
+    rocky-9: 2024.1-rocky-9-20241204T081836
+    ubuntu-jammy: 2024.1-ubuntu-jammy-20241204T081836
   heat:
     rocky-9: 2024.1-rocky-9-20240805T142526
   nova:

--- a/releasenotes/notes/cinder-bug-1823445-5d07997488bc2416.yaml
+++ b/releasenotes/notes/cinder-bug-1823445-5d07997488bc2416.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Updates Cinder container images to fix `bug 1823445
+    <https://bugs.launchpad.net/cinder/+bug/1823445>`__
+    (``cinder.exception.MetadataCopyFailure``).


### PR DESCRIPTION
This should fix the following issue:

    cinder.exception.MetadataCopyFailure: Failed to copy metadata to
    volume: Glance metadata cannot be updated, key signature_verified
    exists for volume id <volume-id>