### PR TITLE
[Backport] enable extra ipa collectors only when building ipa

### DIFF
--- a/etc/kayobe/ipa.yml
+++ b/etc/kayobe/ipa.yml
@@ -117,10 +117,7 @@ ipa_build_dib_elements_extra:
 #ipa_collectors_default:
 
 # List of additional inspection collectors to run.
-ipa_collectors_extra:
-  - "dmi-decode"
-  - "extra-hardware"
-  - "numa-topology"
+ipa_collectors_extra: "{{ ['dmi-decode', 'extra-hardware', 'numa-topology'] if ipa_build_images else [] }}"
 
 # List of inspection collectors to run.
 #ipa_collectors:


### PR DESCRIPTION
Backported from: https://github.com/stackhpc/stackhpc-kayobe-config/pull/1395