### PR TITLE
Update Horizon container images to fix bug 2055784

### DIFF
--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -24,7 +24,8 @@ kolla_image_tags:
     rocky-9: 2024.1-rocky-9-20241004T094540
     ubuntu-jammy: 2024.1-ubuntu-jammy-20241004T094540
   horizon:
-    rocky-9: 2024.1-rocky-9-20240909T144917
+    rocky-9: 2024.1-rocky-9-20241202T210927
+    ubuntu-jammy: 2024.1-ubuntu-jammy-20241202T210927
   bifrost:
     rocky-9: 2024.1-rocky-9-20241128T162336
     ubuntu-jammy: 2024.1-ubuntu-jammy-20241128T162336


### PR DESCRIPTION
This bug would cause Horizon to be unable to retrieve resource providers statistics in deployments with VGPU resources.

The original commit 2dff7bdf64e179cf2d170f0c79bd1d2130ede953 was accidently reverted in #1392.