### PR TITLE
Correct redfish_exporter_default_username

### DIFF
--- a/etc/kayobe/stackhpc-monitoring.yml
+++ b/etc/kayobe/stackhpc-monitoring.yml
@@ -49,7 +49,7 @@ stackhpc_os_capacity_openstack_verify: true
 stackhpc_enable_redfish_exporter: false
 
 # Credentials
-redfish_exporter_default_username: "{{ ipmi_user }}"
+redfish_exporter_default_username: "{{ ipmi_username }}"
 redfish_exporter_default_password: "{{ ipmi_password }}"
 
 # The address of the BMC that is used to query redfish metrics.


### PR DESCRIPTION
Backported from: https://github.com/stackhpc/stackhpc-kayobe-config/pull/1401