### PR TITLE
Rebuilt Neutron containers to fix OSSA-2024-005

### DIFF
--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -18,8 +18,8 @@ kolla_image_tags:
     rocky-9: 2024.1-rocky-9-20241004T094540
     ubuntu-jammy: 2024.1-ubuntu-jammy-20241004T094540
   neutron:
-    rocky-9: 2024.1-rocky-9-20241025T090323
-    ubuntu-jammy: 2024.1-ubuntu-jammy-20241025T090323
+    rocky-9: 2024.1-rocky-9-20241203T232519
+    ubuntu-jammy: 2024.1-ubuntu-jammy-20241203T232519
   octavia:
     rocky-9: 2024.1-rocky-9-20241004T094540
     ubuntu-jammy: 2024.1-ubuntu-jammy-20241004T094540

--- a/releasenotes/notes/OSSA-2024-005-74fc3c536cde645f.yaml
+++ b/releasenotes/notes/OSSA-2024-005-74fc3c536cde645f.yaml
@@ -1,0 +1,7 @@
+---
+security:
+  - |
+    Rebuilt Neutron containers to include fixes for `OSSA-2024-005
+    <https://security.openstack.org/ossa/OSSA-2024-005.html>`_. The
+    vulnerability allows unauthorised users to change tags on networks in
+    Neutron.


### PR DESCRIPTION
Added new tags for Neutron containers to fix OSSA-2024-005 [1]

[1] https://security.openstack.org/ossa/OSSA-2024-005.html