### PR TITLE
OC host image modifications

### DIFF
--- a/etc/kayobe/pulp-host-image-versions.yml
+++ b/etc/kayobe/pulp-host-image-versions.yml
@@ -1,5 +1,5 @@
 ---
 # Overcloud host image versioning tags
 # These images must be in SMS, since they are used by our AIO CI runners
-stackhpc_rocky_9_overcloud_host_image_version: "2024.1-20240912T145502"
-stackhpc_ubuntu_jammy_overcloud_host_image_version: "2024.1-20240911T124950"
+stackhpc_rocky_9_overcloud_host_image_version: "2024.1-20241209T151515"
+stackhpc_ubuntu_jammy_overcloud_host_image_version: "2024.1-20250116T133659"

--- a/etc/kayobe/stackhpc-overcloud-dib.yml
+++ b/etc/kayobe/stackhpc-overcloud-dib.yml
@@ -37,7 +37,9 @@ stackhpc_overcloud_dib_elements:
 stackhpc_overcloud_dib_env_vars:
   DIB_BLOCK_DEVICE_CONFIG: "{{ stackhpc_overcloud_dib_block_device_config_uefi_lvm }}"
   DIB_BOOTLOADER_DEFAULT_CMDLINE: "nofb nomodeset gfxpayload=text net.ifnames=1 rd.auto"
-  DIB_CLOUD_INIT_DATASOURCES: "ConfigDrive"
+  DIB_GRUB_TIMEOUT: "5"
+  DIB_GRUB_TIMEOUT_STYLE: "countdown"
+  DIB_CLOUD_INIT_DATASOURCES: "OpenStack, ConfigDrive"
   DIB_CONTAINERFILE_RUNTIME: "docker"
   DIB_CONTAINERFILE_NETWORK_DRIVER: "host"
   DIB_CONTAINERFILE_DOCKERFILE: "/opt/kayobe/src/stackhpc-image-elements/elements/rocky-container-stackhpc/containerfiles/9-stackhpc"

--- a/etc/kayobe/stackhpc-overcloud-dib.yml
+++ b/etc/kayobe/stackhpc-overcloud-dib.yml
@@ -38,7 +38,7 @@ stackhpc_overcloud_dib_env_vars:
   DIB_BLOCK_DEVICE_CONFIG: "{{ stackhpc_overcloud_dib_block_device_config_uefi_lvm }}"
   DIB_BOOTLOADER_DEFAULT_CMDLINE: "nofb nomodeset gfxpayload=text net.ifnames=1 rd.auto"
   DIB_GRUB_TIMEOUT: "5"
-  DIB_GRUB_TIMEOUT_STYLE: "countdown"
+  DIB_GRUB_TIMEOUT_STYLE: "menu"
   DIB_CLOUD_INIT_DATASOURCES: "OpenStack, ConfigDrive"
   DIB_CONTAINERFILE_RUNTIME: "docker"
   DIB_CONTAINERFILE_NETWORK_DRIVER: "host"

--- a/releasenotes/notes/grub_timeout_values-c39b8b1a2c34a602.yaml
+++ b/releasenotes/notes/grub_timeout_values-c39b8b1a2c34a602.yaml
@@ -1,0 +1,8 @@
+---
+upgrade:
+  - |
+    Change default values for ``DIB_GRUB_TIMEOUT_STYLE`` and
+    ``DIB_GRUB_TIMEOUT``. The default value for ``DIB_GRUB_TIMEOUT_STYLE``
+    will be ``menu`` and for ``DIB_GRUB_TIMEOUT`` will be ``5``.
+    Adding ConfigDrive to ``DIB_CLOUD_INIT_DATASOURCES`` var list to fix
+    cloud-init issue.


### PR DESCRIPTION
- grub timeout should always be there to troubleshoot if needed
- Openstack data source fixed cloud-init issues