### PR TITLE
feat: add `ceph-mon` service to `osds` hosts firewall

### DIFF
--- a/etc/kayobe/inventory/group_vars/all/firewall
+++ b/etc/kayobe/inventory/group_vars/all/firewall
@@ -232,7 +232,7 @@ stackhpc_ceph_firewalld_rules_template:
         state: enabled
       - service: ceph-mon
         network: "{{ storage_net_name }}"
-        state: "{{ 'enabled' if 'mons' in group_names else 'disabled' }}"
+        state: "{{ 'enabled' if ('mons' in group_names or 'osds' in group_names) else 'disabled' }}"
       - port: "{{ stackhpc_ceph_firewalld_radosgw_port }}/tcp"
         network: "{{ storage_net_name }}"
         state: "{{ 'enabled' if 'rgws' in group_names else 'disabled' }}"

--- a/releasenotes/notes/add-ceph-mon-firewall-to-osds-fc6233b3db6ade7a.yaml
+++ b/releasenotes/notes/add-ceph-mon-firewall-to-osds-fc6233b3db6ade7a.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add ``ceph-mon`` as a ``firewalld`` service rule to hosts of ``osds``.


### PR DESCRIPTION
Hosts that carry just `OSDs` appear to require `ceph-mon` service firewalls to ensure communication for `Ceph MDS` connectivity.