### PR TITLE
Update Cinder container images to fix bug 1823445

### DIFF
--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -12,7 +12,8 @@ kolla_image_tags:
     rocky-9: 2023.1-rocky-9-20241107T140552
     ubuntu-jammy: 2023.1-ubuntu-jammy-20241107T140552
   cinder:
-    ubuntu-jammy: 2023.1-ubuntu-jammy-20240701T123544
+    rocky-9: 2023.1-rocky-9-20241210T151958
+    ubuntu-jammy: 2023.1-ubuntu-jammy-20241210T151958
   glance:
     ubuntu-jammy: 2023.1-ubuntu-jammy-20240701T123544
   haproxy_ssh:

--- a/releasenotes/notes/cinder-bug-1823445-5d07997488bc2416.yaml
+++ b/releasenotes/notes/cinder-bug-1823445-5d07997488bc2416.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Updates Cinder container images to fix `bug 1823445
+    <https://bugs.launchpad.net/cinder/+bug/1823445>`__
+    (``cinder.exception.MetadataCopyFailure``).


### PR DESCRIPTION
This should fix the following issue:

    cinder.exception.MetadataCopyFailure: Failed to copy metadata to
    volume: Glance metadata cannot be updated, key signature_verified
    exists for volume id <volume-id>

(cherry picked from commit e127ca13b6069dd289cc8c9a15cb050f8d5043a4)