### PR TITLE
Alert rule for active routers on ML2/OVS

### DIFF
--- a/etc/kayobe/kolla/config/prometheus/openstack.rules
+++ b/etc/kayobe/kolla/config/prometheus/openstack.rules
@@ -19,6 +19,6 @@ groups:
       labels:
         severity: alert
       annotations:
-        summary: "The router {{ $labels.router_id }} is not active on eactly one agent"
-        description: "The router {{ $labels.router_id }} should be active on exactly one agent. It can either active on multiple agents or not active at all."
+        summary: "The router {{ $labels.router_id }} is not active on exactly one agent"
+        description: "The router {{ $labels.router_id }} should be active on exactly one agent. It can either be active on multiple agents or not active at all."
 {% endraw %}

--- a/etc/kayobe/kolla/config/prometheus/openstack.rules
+++ b/etc/kayobe/kolla/config/prometheus/openstack.rules
@@ -11,5 +11,14 @@ groups:
     annotations:
       summary: "{{ $labels.service }} at {{ $labels.hostname }} is down"
       description: "OpenStack service {{ $labels.service }} at {{ $labels.hostname }} is down"
-
+- name: Routers
+  rules:
+    - alert: OpenStackRouterDown
+      expr: count by (router_id) (openstack_neutron_l3_agent_of_router{ha_state="active"}) != 1
+      for: 1m
+      labels:
+        severity: alert
+      annotations:
+        summary: "The router {{ $labels.router_id }} is not active on eactly one agent"
+        description: "The router {{ $labels.router_id }} should be active on exactly one agent. It can either active on multiple agents or not active at all."
 {% endraw %}

--- a/releasenotes/notes/adds-alert-for-active-routers-91281912213692c9.yaml
+++ b/releasenotes/notes/adds-alert-for-active-routers-91281912213692c9.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Adds an alert to check that there is at least one active router on ML2/OVS based
+    deployments.

--- a/releasenotes/notes/adds-alert-for-active-routers-91281912213692c9.yaml
+++ b/releasenotes/notes/adds-alert-for-active-routers-91281912213692c9.yaml
@@ -1,5 +1,5 @@
 ---
 features:
   - |
-    Adds an alert to check that there is at least one active router on ML2/OVS based
+    Adds an alert to check that there is exactly one active router on ML2/OVS based
     deployments.


### PR DESCRIPTION
Can detect issues with HA routers on an ML2/OVS deployment. On OVN deployments we shouldn't have these metrics so the alert will have no effect.