### PR TITLE
yoga: Stop building cinder from StackHPC fork

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -117,10 +117,6 @@ kolla_sources:
     type: git
     location: https://github.com/stackhpc/stackhpc-inspector-plugins.git
     reference: 1.3.0
-  cinder-base:
-    type: git
-    location: https://github.com/stackhpc/cinder.git
-    reference: stackhpc/{{ openstack_release }}
   cloudkitty-base:
     type: git
     location: https://github.com/stackhpc/cloudkitty.git


### PR DESCRIPTION
Upstream cinder has merged all the security patches for the CVE-2024-32498 QCOW vulnerability.