### PR TITLE
Disable latest path for Pulp artifacts

### DIFF
--- a/.github/workflows/ipa-image-build.yml
+++ b/.github/workflows/ipa-image-build.yml
@@ -76,7 +76,7 @@ jobs:
           pip install -r ../src/kayobe-config/requirements.txt
 
       - name: Install terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v2
 
       - name: Initialise terraform
         run: terraform init

--- a/.github/workflows/ipa-image-build.yml
+++ b/.github/workflows/ipa-image-build.yml
@@ -206,7 +206,8 @@ jobs:
           kayobe overcloud deployment image build --force-rebuild \
           -e os_distribution="ubuntu" \
           -e os_release="jammy" \
-          -e ipa_ci_builder_distribution="ubuntu"
+          -e ipa_ci_builder_distribution="ubuntu" \
+          -e ipa_ci_builder_release="jammy"
         env:
           KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
         if: inputs.ubuntu-jammy
@@ -264,7 +265,8 @@ jobs:
           kayobe overcloud deployment image build --force-rebuild \
           -e os_distribution="rocky" \
           -e os_release="9" \
-          -e ipa_ci_builder_distribution="rocky"
+          -e ipa_ci_builder_distribution="rocky" \
+          -e ipa_ci_builder_release="9"
         env:
           KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
         if: inputs.rocky9

--- a/etc/kayobe/ansible/pulp-artifact-upload.yml
+++ b/etc/kayobe/ansible/pulp-artifact-upload.yml
@@ -142,21 +142,6 @@
       retries: 3
       delay: 5
 
-    - name: Update distribution for latest version
-      pulp.squeezer.file_distribution:
-        pulp_url: "{{ remote_pulp_url }}"
-        username: "{{ remote_pulp_username }}"
-        password: "{{ remote_pulp_password }}"
-        name: "{{ repository_name }}_latest"
-        base_path: "{{ pulp_base_path }}/latest"
-        publication: "{{ publication_details.publication.pulp_href }}"
-        content_guard: development
-        state: present
-      register: latest_distribution_details
-      until: latest_distribution_details is success
-      retries: 3
-      delay: 5
-
     - name: Create distribution for given version
       pulp.squeezer.file_distribution:
         pulp_url: "{{ remote_pulp_url }}"
@@ -167,7 +152,6 @@
         publication: "{{ publication_details.publication.pulp_href }}"
         content_guard: development
         state: present
-      when: latest_distribution_details.changed
       register: distribution_result
       until: distribution_result is success
       retries: 3
@@ -180,26 +164,11 @@
         {{ artifact_tag }}/{{ found_files.files[0].path | basename }}"
         create: true
 
-    - name: Update new artifacts file with latest path
-      lineinfile:
-        path: /tmp/updated_artifacts.txt
-        line: "{{ remote_pulp_url }}/pulp/content/{{ pulp_base_path }}/\
-        latest/{{ found_files.files[0].path | basename }}"
-      when: latest_distribution_details.changed
-
     - name: Print versioned path
       debug:
         msg: "New versioned path: {{ remote_pulp_url }}/pulp/content/{{ pulp_base_path }}/\
         {{ artifact_tag }}/{{ found_files.files[0].path | basename }}"
-      when: latest_distribution_details.changed
-
-    - name: Print latest path
-      debug:
-        msg: "New latest path: {{ remote_pulp_url }}/pulp/content/{{ pulp_base_path }}/\
-        latest/{{ found_files.files[0].path | basename }}"
-      when: latest_distribution_details.changed
 
     - name: Print version tag
       debug:
         msg: "New tag: {{ artifact_tag }}"
-      when: latest_distribution_details.changed

--- a/etc/kayobe/environments/ci-builder/stackhpc-ci.yml
+++ b/etc/kayobe/environments/ci-builder/stackhpc-ci.yml
@@ -101,6 +101,7 @@ stackhpc_release_pulp_password: "{{ stackhpc_docker_registry_password }}"
 ipa_build_images: true
 ipa_build_dib_env_extra:
   DISTRO_NAME: "{{ ipa_ci_builder_distribution | default('ubuntu') }}"
+  DIB_RELEASE: "{{ os_release }}"
 
 # Ensure Ark repos are disabled during CI runs, this is due to
 # builder being a member of the 'overcloud' group for IPA builds.

--- a/etc/kayobe/environments/ci-builder/stackhpc-ci.yml
+++ b/etc/kayobe/environments/ci-builder/stackhpc-ci.yml
@@ -101,7 +101,7 @@ stackhpc_release_pulp_password: "{{ stackhpc_docker_registry_password }}"
 ipa_build_images: true
 ipa_build_dib_env_extra:
   DISTRO_NAME: "{{ ipa_ci_builder_distribution | default('ubuntu') }}"
-  DIB_RELEASE: "{{ os_release }}"
+  DIB_RELEASE: "{{ ipa_ci_builder_release | default('jammy') }}"
 
 # Ensure Ark repos are disabled during CI runs, this is due to
 # builder being a member of the 'overcloud' group for IPA builds.

--- a/etc/kayobe/pulp-ipa-image-versions.yml
+++ b/etc/kayobe/pulp-ipa-image-versions.yml
@@ -1,4 +1,4 @@
 ---
 # IPA image versioning tags
-stackhpc_rocky_9_ipa_image_version: "2024.1-20241206T160829"
+stackhpc_rocky_9_ipa_image_version: "2024.1-20241231T102920"
 stackhpc_ubuntu_jammy_ipa_image_version: "2024.1-20241206T160829"


### PR DESCRIPTION
- Latest path breaking IPA upload https://github.com/stackhpc/stackhpc-kayobe-config/actions/runs/12357166284/job/34484777121
- Revert to terraform v2
- Ensure DIB_RELEASE is set to the correct distro release
- Fix incorrect Rocky 9 IPA version (promotion https://github.com/stackhpc/stackhpc-kayobe-config/actions/runs/12634678586)

Testing:
- IPA: https://github.com/stackhpc/stackhpc-kayobe-config/actions/runs/12558488437
- Host image: https://github.com/stackhpc/stackhpc-kayobe-config/actions/runs/12631136129