### PR TITLE
Fix dangerous wazuh secrets templating

### DIFF
--- a/etc/kayobe/ansible/templates/wazuh-secrets.yml.j2
+++ b/etc/kayobe/ansible/templates/wazuh-secrets.yml.j2
@@ -3,12 +3,12 @@
 # Store these securely and use lookups here
 secrets_wazuh:
   # Wazuh agent authd pass
-  authd_pass: "{{ secrets_wazuh.authd_pass | default(lookup('password', '/dev/null'), true) }}"
+  authd_pass: '{{ secrets_wazuh.authd_pass | default(lookup("password", "/dev/null"), true) }}'
   # Strengthen default wazuh api user pass
   wazuh_api_users:
     - username: "wazuh"
-      password: "{{ secrets_wazuh.wazuh_api_users[0].password | default(lookup('community.general.random_string', min_lower=1, min_upper=1, min_special=1, min_numeric=1, length=30, override_special=override_special_characters)) }}"
+      password: '{{ secrets_wazuh.wazuh_api_users[0].password | default(lookup("community.general.random_string", min_lower=1, min_upper=1, min_special=1, min_numeric=1, length=30, override_special=override_special_characters)) }}'
   # OpenSearch 'admin' user pass
-  opendistro_admin_password: "{{ secrets_wazuh.opendistro_admin_password | default(lookup('password', '/dev/null'), true) }}"
+  opendistro_admin_password: '{{ secrets_wazuh.opendistro_admin_password | default(lookup("password", "/dev/null"), true) }}'
   # OpenSearch 'kibanaserver' user pass
-  opendistro_kibana_password: "{{ secrets_wazuh.opendistro_kibana_password | default(lookup('password', '/dev/null'), true) }}"
+  opendistro_kibana_password: '{{ secrets_wazuh.opendistro_kibana_password | default(lookup("password", "/dev/null"), true) }}'


### PR DESCRIPTION
Replace double quotes with singles in wazuh secrets template, since passwords can contain  special characters that break Ansible's parsing