### PR TITLE
feat(wazuh): Add JVM proxy configuration for Slack notifications

### DIFF
--- a/etc/kayobe/ansible/wazuh-manager.yml
+++ b/etc/kayobe/ansible/wazuh-manager.yml
@@ -116,6 +116,23 @@
       notify:
         - Restart wazuh
 
+    - name: Add JVM proxy settings to wazuh-indexer
+      blockinfile:
+        path: "/etc/wazuh-indexer/jvm.options"
+        state: present
+        owner: root
+        group: wazuh
+        marker: "# {mark} ANSIBLE MANAGED BLOCK JVM PROXY SETTINGS"
+        block: |
+          -Dhttp.proxyHost={{ http_proxy_url | urlsplit('hostname') }}
+          -Dhttp.proxyPort={{ http_proxy_url | urlsplit('port') }}
+          -Dhttps.proxyHost={{ http_proxy_url | urlsplit('hostname') }}
+          -Dhttps.proxyPort={{ http_proxy_url | urlsplit('port') }}
+        backup: yes
+      when: http_proxy_url is defined
+      notify:
+        - Restart wazuh-indexer
+
     - name: Perform health check against filebeat
       command: filebeat test output
       changed_when: false
@@ -125,4 +142,9 @@
     - name: Restart wazuh
       service:
         name: wazuh-manager
+        state: restarted
+
+    - name: Restart wazuh-indexer
+      service:
+        name: wazuh-indexer
         state: restarted


### PR DESCRIPTION
Add JVM proxy settings to wazuh-indexer configuration to enable OpenSearch Dashboard Slack notifications when running behind a proxy. The configuration:
- Sets both HTTP and HTTPS proxy host and port from http_proxy_url
- Triggers wazuh-indexer restart when proxy settings change

http_proxy_url needs to be defined before running wazuh-manager.yml