### PR TITLE
Remove proxy configuration from Wazuh manager playbook

### DIFF
--- a/etc/kayobe/ansible/wazuh-manager.yml
+++ b/etc/kayobe/ansible/wazuh-manager.yml
@@ -102,20 +102,6 @@
       notify:
         - Restart wazuh
 
-    - name: Set http/s_proxy vars in ossec-init.conf for vulnerability detector
-      blockinfile:
-        path: "/var/ossec/etc/ossec.conf"
-        state: present
-        owner: root
-        group: ossec
-        block: |
-          HTTPS_PROXY={{ http_proxy_url }}
-          HTTP_PROXY={{ http_proxy_url }}
-        backup: yes
-      when: http_proxy_url is defined
-      notify:
-        - Restart wazuh
-
     - name: Perform health check against filebeat
       command: filebeat test output
       changed_when: false


### PR DESCRIPTION
The proxy configuration block in ossec.conf is being removed as it was incorrectly placed. The proxy settings in ossec-init.conf do not affect the vulnerability detector functionality.