### PR TITLE
Update periodic multinode workflow to SOGW 1.4.0

### DIFF
--- a/.github/workflows/stackhpc-multinode-periodic.yml
+++ b/.github/workflows/stackhpc-multinode-periodic.yml
@@ -35,14 +35,14 @@ jobs:
     name: Multinode periodic
     needs:
       - generate-inputs
-    uses: stackhpc/stackhpc-openstack-gh-workflows/.github/workflows/multinode.yml@1.2.0
+    uses: stackhpc/stackhpc-openstack-gh-workflows/.github/workflows/multinode.yml@1.4.0
     with:
       multinode_name: mn-prdc-${{ github.run_id }}
       os_distribution: ${{ needs.generate-inputs.outputs.os_distribution }}
       os_release: ${{ needs.generate-inputs.outputs.os_release }}
       ssh_username: ${{ needs.generate-inputs.outputs.ssh_username }}
       neutron_plugin: ${{ needs.generate-inputs.outputs.neutron_plugin }}
-      upgrade: ${{ needs.generate-inputs.outputs.upgrade == 'true' }}
+      upgrade: ${{ needs.generate-inputs.outputs.upgrade }}
       stackhpc_kayobe_config_version: ${{ needs.generate-inputs.outputs.stackhpc_kayobe_config_version }}
       stackhpc_kayobe_config_previous_version: ${{ needs.generate-inputs.outputs.stackhpc_kayobe_config_previous_version }}
       enable_slack_alert: true


### PR DESCRIPTION
I missed a file when I changed the multinode workflow recently https://github.com/stackhpc/stackhpc-kayobe-config/pull/1443. The manual deployment was updated but not the periodic (nightly) workflow.