### PR TITLE
Fix download of IPA images from Ark

### DIFF
--- a/etc/kayobe/ipa.yml
+++ b/etc/kayobe/ipa.yml
@@ -107,6 +107,13 @@ ipa_ramdisk_upstream_url: "{{ (stackhpc_ipa_image_url + '/ipa.initramfs') if sta
 # Algorithm of checksum of Ironic deployment ramdisk image.
 #ipa_ramdisk_checksum_algorithm:
 
+# IPA download parameters
+image_download_url_username: "{{ stackhpc_release_pulp_username }}"
+image_download_url_password: "{{ stackhpc_release_pulp_password }}"
+image_download_force_basic_auth: true
+image_download_unredirected_headers:
+  - Authorization
+
 ###############################################################################
 # Ironic Python Agent (IPA) deployment configuration.
 


### PR DESCRIPTION
This requires https://review.opendev.org/c/openstack/kayobe/+/939121.