### PR TITLE
Rename periodic mutinodes to be clearer

### DIFF
--- a/.github/workflows/stackhpc-multinode-periodic.yml
+++ b/.github/workflows/stackhpc-multinode-periodic.yml
@@ -37,7 +37,7 @@ jobs:
       - generate-inputs
     uses: stackhpc/stackhpc-openstack-gh-workflows/.github/workflows/multinode.yml@1.4.0
     with:
-      multinode_name: mn-prdc-${{ github.run_id }}
+      multinode_name: mn-periodic-${{ github.run_id }}
       os_distribution: ${{ needs.generate-inputs.outputs.os_distribution }}
       os_release: ${{ needs.generate-inputs.outputs.os_release }}
       ssh_username: ${{ needs.generate-inputs.outputs.ssh_username }}


### PR DESCRIPTION
Previously, the nightly multinode instances were named `mn-prdc`. The abbreviation is unnecessary and unclear unless you know what you're looking for.