### PR TITLE
Correct permissions on Wazuh alerts manifest

### DIFF
--- a/etc/kayobe/ansible/wazuh-manager.yml
+++ b/etc/kayobe/ansible/wazuh-manager.yml
@@ -130,6 +130,11 @@
       changed_when: false
       retries: 2
 
+    - name: Correct permissions on alerts manifest
+      ansible.builtin.file:
+        path: "/usr/share/filebeat/module/wazuh/alerts/manifest.yml"
+        mode: "go-w"
+
   handlers:
     - name: Restart wazuh
       ansible.builtin.service:


### PR DESCRIPTION
Wazuh instance wasnt creating wazuh-alerts-* indices and the "Check alerts index pattern" health-check fails.

Error and solution from logs:

```
Error reading manifest file: config file ("/usr/share/filebeat/module/wazuh/alerts/manifest.yml") can only be writable by the owner but the permissions are "-rw-rw-rw-"
to fix the permissions use: 'chmod go-w /usr/share/filebeat/module/wazuh/alerts/manifest.yml'
```