### PR TITLE
Bump to wazuh-ansible v4.10.0

### DIFF
--- a/doc/source/configuration/wazuh.rst
+++ b/doc/source/configuration/wazuh.rst
@@ -336,11 +336,6 @@ rulesets. However, you may find you want to add more. This can be achieved via
 SKC supports this automatically, just add the policy file from this PR to
 ``{{ kayobe_env_config_path }}/wazuh/custom_sca_policies``.
 
-Currently, Wazuh does not ship with a CIS benchmark for Rocky 9. You can find
-the in-development policy here: https://github.com/wazuh/wazuh/pull/17810 To
-include this in your deployment, simply copy it to
-``{{ kayobe_env_config_path }}/wazuh/custom_sca_policies/cis_rocky_linux_9.yml``.
-
 .. _Deploy:
 
 Deploy

--- a/etc/kayobe/ansible/requirements.yml
+++ b/etc/kayobe/ansible/requirements.yml
@@ -22,7 +22,7 @@ roles:
     version: 1.3.1
   - name: wazuh-ansible
     src: https://github.com/stackhpc/wazuh-ansible
-    version: stackhpc
+    version: stackhpc-v4.10.0
   - name: geerlingguy.pip
     version: 2.2.0
   - name: monolithprojects.github_actions_runner

--- a/releasenotes/notes/wazuh-ansible-v4.10.0-ed5209199194cddf.yaml
+++ b/releasenotes/notes/wazuh-ansible-v4.10.0-ed5209199194cddf.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Upgrades the version of wazuh-ansible to v4.10.0. This brings in the SCA CIS
+    checks for Rocky Linux 9 by default.


### PR DESCRIPTION
This brings in SCA CIS checks for RL9 by default.
Keep using our fork for unmerged bugfixes