### PR TITLE
Bump Cephadm collection in Antelope

### DIFF
--- a/etc/kayobe/ansible/requirements.yml
+++ b/etc/kayobe/ansible/requirements.yml
@@ -1,7 +1,7 @@
 ---
 collections:
   - name: stackhpc.cephadm
-    version: 1.18.0
+    version: 1.19.1
   # NOTE: Pinning pulp.squeezer to 0.0.13 because 0.0.14+ depends on the
   # pulp_glue Python library being installed.
   - name: pulp.squeezer

--- a/releasenotes/notes/bump-ansible-collection-cephadm-2a6c988a34b192a6.yaml
+++ b/releasenotes/notes/bump-ansible-collection-cephadm-2a6c988a34b192a6.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Updates the StackHPC Cephadm Ansible collection from 1.18.0 to 1.19.1.


### PR DESCRIPTION
Cherry pick of https://github.com/stackhpc/stackhpc-kayobe-config/pull/1444 to mitigate multinode deployment issues such as [this](https://github.com/stackhpc/stackhpc-kayobe-config/actions/runs/12780574397/job/35627067895#step:30:227)