### PR TITLE
Fix growroot LVM check

### DIFF
--- a/etc/kayobe/ansible/growroot.yml
+++ b/etc/kayobe/ansible/growroot.yml
@@ -32,7 +32,7 @@
     - name: Check LVM status
       ansible.builtin.shell:
         executable: "/bin/bash"
-        cmd: set -o pipefail && vgdisplay | grep -q lvm2
+        cmd: set -o pipefail && vgdisplay | grep lvm2 >> /dev/null
       changed_when: false
       failed_when: false
       check_mode: false


### PR DESCRIPTION
``grep -q`` always returns rc 141 [1], so the check will never pass. Send the output to /dev/null so we capture the correct return code from grep.

[1] https://stackoverflow.com/questions/19120263/why-exit-code-141-with-grep-q