### PR TITLE
(doc)wazuh: Update encryption pattern for private keys

### DIFF
--- a/doc/source/configuration/wazuh.rst
+++ b/doc/source/configuration/wazuh.rst
@@ -349,11 +349,11 @@ If you are using the wazuh generated certificates,
 this will result in the creation of some certificates and keys (in case of custom certs adjust path to it).
 Encrypt the keys (and remember to commit to git):
 
-``ansible-vault encrypt --vault-password-file ~/vault.pass $KAYOBE_CONFIG_PATH/environments/<environment>/wazuh/wazuh-certificates/*.key``
+``ansible-vault encrypt --vault-password-file ~/vault.pass $KAYOBE_CONFIG_PATH/environments/<environment>/wazuh/wazuh-certificates/*.key $KAYOBE_CONFIG_PATH/environments/<environment>/wazuh/wazuh-certificates/*-key.pem``
 
 If using the kayobe environments feature, otherwise:
 
-``ansible-vault encrypt --vault-password-file ~/vault.pass $KAYOBE_CONFIG_PATH/ansible/wazuh/certificates/certs/*.key``
+``ansible-vault encrypt --vault-password-file ~/vault.pass $KAYOBE_CONFIG_PATH/ansible/wazuh/certificates/certs/*.key $KAYOBE_CONFIG_PATH/ansible/wazuh/certificates/certs/*-key.pem``
 
 .. _wazuh-verification:
 


### PR DESCRIPTION
Update the ansible-vault encrypt command pattern to include both *.key and *-key.pem files. This ensures all private key files (root-ca.key, os-wazuh-key.pem, and admin-key.pem) are properly encrypted when deploying Wazuh.