### PR TITLE
Apply omitted prometheus template bug fix

### DIFF
--- a/etc/kayobe/ansible/prometheus.yml.j2
+++ b/etc/kayobe/ansible/prometheus.yml.j2
@@ -273,9 +273,9 @@ scrape_configs:
 
 alerting:
   alertmanagers:
-  - static_configs:
-    - targets:
+    - static_configs:
 {% for host in groups["prometheus-alertmanager"] %}
+      - targets:
         - '{{ 'api' | kolla_address(host) | put_address_in_context('url') }}:{{ hostvars[host]['prometheus_alertmanager_port'] }}'
 {% if hostvars[host].prometheus_instance_label | default(false, true) %}
         labels:

--- a/releasenotes/notes/apply-prometheus-template-fix-4ec4ee6c2785bfea.yaml
+++ b/releasenotes/notes/apply-prometheus-template-fix-4ec4ee6c2785bfea.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed an issue with the ``prometheus.yml`` template which would break when
+    deploying alertmanager.


### PR DESCRIPTION
The patch for prometheus.yml template bug
[LP#2076660](https://bugs.launchpad.net/kolla-ansible/+bug/2076660)  was not applied to our template used for friendly network name. This brings the fix to 2023.1 release.