### PR TITLE
feat: disable `TMOUT` for development environments

### DIFF
--- a/etc/kayobe/environments/ci-aio/inventory/group_vars/cis-hardening/cis
+++ b/etc/kayobe/environments/ci-aio/inventory/group_vars/cis-hardening/cis
@@ -1,0 +1,16 @@
+---
+##############################################################################
+# Rocky 9 CIS Hardening Configuration
+
+# Disable shell timeout for inactivity which can be disruptive to
+# development work.
+rhel9cis_rule_5_4_3_2: false
+
+##############################################################################
+# Ubuntu Jammy CIS Hardening Configuration
+
+# Disable shell timeout for inactivity which can be disruptive to
+# development work.
+ubtu22cis_rule_5_4_3_2: false
+
+##############################################################################

--- a/etc/kayobe/environments/ci-multinode/inventory/group_vars/cis-hardening/cis
+++ b/etc/kayobe/environments/ci-multinode/inventory/group_vars/cis-hardening/cis
@@ -1,0 +1,16 @@
+---
+##############################################################################
+# Rocky 9 CIS Hardening Configuration
+
+# Disable shell timeout for inactivity which can be disruptive to
+# development work.
+rhel9cis_rule_5_4_3_2: false
+
+##############################################################################
+# Ubuntu Jammy CIS Hardening Configuration
+
+# Disable shell timeout for inactivity which can be disruptive to
+# development work.
+ubtu22cis_rule_5_4_3_2: false
+
+##############################################################################

--- a/releasenotes/notes/remove-tmout-for-dev-env-0778550b353dce03.yaml
+++ b/releasenotes/notes/remove-tmout-for-dev-env-0778550b353dce03.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Disable the CIS hardening rule ``*_rule_5_4_3_2`` to prevent ``TMOUT``
+    from being applied which can disrupt a development environment as it
+    closes ``TMUX`` panes and servers and may close active ssh session.


### PR DESCRIPTION
To avoid disruption to development work, disable the shell timeout for inactivity in the CIS hardening configuration for the `ci-aio` and `ci-multinode` environments.