### PR TITLE
Rebuild nova-compute image to address bug 2091033

### DIFF
--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -42,6 +42,9 @@ kolla_image_tags:
   nova:
     rocky-9: 2023.1-rocky-9-20240926T151818
     ubuntu-jammy: 2023.1-ubuntu-jammy-20240926T151818
+  nova_compute:
+    rocky-9: 2023.1-rocky-9-20250121T090235
+    ubuntu-jammy: 2023.1-ubuntu-jammy-20250121T090235
   octavia:
     rocky-9: 2023.1-rocky-9-20241015T100903
     ubuntu-jammy: 2023.1-ubuntu-jammy-20241015T100903

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -151,6 +151,10 @@ kolla_sources:
     type: git
     location: https://github.com/stackhpc/networking-mlnx
     reference: stackhpc/{{ openstack_release }}
+  nova-base:
+    type: git
+    location: https://github.com/stackhpc/nova.git
+    reference: stackhpc/{{ openstack_release }}
   nova-compute-plugin-networking-mlnx:
     type: git
     location: https://github.com/stackhpc/networking-mlnx

--- a/releasenotes/notes/nova-bug-2091033-4f54893f67af5c7c.yaml
+++ b/releasenotes/notes/nova-bug-2091033-4f54893f67af5c7c.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Updates the ``nova-compute`` container image to fix `bug 2091033
+    <https://bugs.launchpad.net/nova/+bug/2091033>`__. This bug would cause
+    ``nova-compute`` to freeze, which would result in frequent monitoring
+    alerts.


### PR DESCRIPTION
This bug would cause nova-compute services to freeze, which would result in frequent monitoring alerts.