### PR TITLE
Fixed pytest output options not being specified

### DIFF
--- a/.github/path-filters.yml
+++ b/.github/path-filters.yml
@@ -11,6 +11,7 @@ aio: &aio
   - '.github/workflows/stackhpc-pull-request.yml'
   - 'etc/kayobe/*.yml'
   - 'etc/kayobe/ansible/configure-aio-resources.yml'
+  - 'etc/kayobe/ansible/stackhpc-openstack-tests.yml'
   - 'etc/kayobe/ansible/growroot.yml'
   - 'etc/kayobe/ansible/requirements.yml'
   - 'etc/kayobe/ansible/scripts/aio-init.sh'

--- a/etc/kayobe/ansible/stackhpc-openstack-tests.yml
+++ b/etc/kayobe/ansible/stackhpc-openstack-tests.yml
@@ -68,7 +68,7 @@
               --self-contained-html
               --pyargs stackhpc_cloud_tests
               --timeout {{ sot_timeout }}
-              -r
+              -rfEx
               -vv
           environment:
             OPENSEARCH_HOSTS: "{{ sot_opensearch_hosts }}"


### PR DESCRIPTION
stackhpc-cloud-tests also now add to ci path filters