### PR TITLE
Rebuild nova-compute image to address bug 2091033

### DIFF
--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -9,3 +9,6 @@ kolla_image_tags:
   magnum:
     rocky-9: 2024.1-rocky-9-20250102T094625
     ubuntu-jammy: 2024.1-ubuntu-jammy-20250102T094625
+  nova_compute:
+    rocky-9: 2024.1-rocky-9-20250127T211632
+    ubuntu-jammy: 2024.1-ubuntu-jammy-20250127T211632

--- a/releasenotes/notes/nova-bug-2091033-4f54893f67af5c7c.yaml
+++ b/releasenotes/notes/nova-bug-2091033-4f54893f67af5c7c.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Updates the ``nova-compute`` container image to fix `bug 2091033
+    <https://bugs.launchpad.net/nova/+bug/2091033>`__. This bug would cause
+    ``nova-compute`` to freeze, which would result in frequent monitoring
+    alerts.


### PR DESCRIPTION
This bug would cause nova-compute services to freeze, which would result in frequent monitoring alerts.