### PR TITLE
Switch to StackHPC python upper constraints

### DIFF
--- a/.github/workflows/overcloud-host-image-upload.yml
+++ b/.github/workflows/overcloud-host-image-upload.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Install OpenStack client
         run: |
           source venvs/kayobe/bin/activate &&
-          pip install python-openstackclient -c https://releases.openstack.org/constraints/upper/${{ steps.openstack_release.outputs.openstack_release }}
+          pip install python-openstackclient -c https://raw.githubusercontent.com/stackhpc/requirements/refs/heads/stackhpc/${{ steps.openstack_release.outputs.openstack_release }}/upper-constraints.txt
 
       - name: Output Rocky Linux 9 image tag
         id: rocky_9_image_tag

--- a/.github/workflows/stackhpc-ci-cleanup.yml
+++ b/.github/workflows/stackhpc-ci-cleanup.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Install OpenStack client
         run: |
-          pip install python-openstackclient -c https://releases.openstack.org/constraints/upper/${{ steps.openstack_release.outputs.openstack_release }}
+          pip install python-openstackclient -c https://raw.githubusercontent.com/stackhpc/requirements/refs/heads/stackhpc/${{ steps.openstack_release.outputs.openstack_release }}/upper-constraints.txt
 
       - name: Clean up aio instances over 3 hours old
         run: |

--- a/etc/kayobe/pip.yml
+++ b/etc/kayobe/pip.yml
@@ -3,7 +3,7 @@
 # Upper constraints file for installation of python packages.
 # Default value is
 # "https://releases.openstack.org/constraints/upper/{{ openstack_release }}"
-#pip_upper_constraints_file:
+pip_upper_constraints_file: "https://raw.githubusercontent.com/stackhpc/requirements/refs/heads/stackhpc/{{ openstack_release }}/upper-constraints.txt"
 
 # Use a local PyPi mirror for installing Pip packages
 #pip_local_mirror: false

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ skipsdist = True
 [testenv]
 install_command = pip install {opts} {packages}
 deps =
-    -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/2024.1}
+    -c{env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/stackhpc/requirements/refs/heads/stackhpc/2024.1/upper-constraints.txt}
     -r{toxinidir}/test-requirements.txt
 
 [testenv:pep8]
@@ -20,7 +20,7 @@ commands =
 allowlist_externals = rm
 skip_install = true
 deps =
-  -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/2024.1}
+  -c{env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/stackhpc/requirements/refs/heads/stackhpc/2024.1/upper-constraints.txt}
   -r{toxinidir}/releasenotes/requirements.txt
 commands =
   rm -rf releasenotes/build/html
@@ -30,7 +30,7 @@ commands =
 allowlist_externals = rm
 skip_install = true
 deps =
-    -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/2024.1}
+    -c{env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/stackhpc/requirements/refs/heads/stackhpc/2024.1/upper-constraints.txt}
     -r{toxinidir}/doc/requirements.txt
 commands =
   rm -rf doc/build/html


### PR DESCRIPTION
This change has two benefits,
1. Opendev is notoriously unstable, particularly around release windows. When upper constraints are inaccessible, many operations become impossible
2. We control the constraints, and can make security or feature updates as required