### PR TITLE
Pin remaining Ansible dependencies

### DIFF
--- a/etc/kayobe/ansible/requirements.yml
+++ b/etc/kayobe/ansible/requirements.yml
@@ -14,6 +14,7 @@ collections:
     version: 1.1.0
 roles:
   - src: stackhpc.vxlan
+    version: 1.1.0
   - name: ansible-lockdown.ubuntu22_cis
     src: https://github.com/ansible-lockdown/UBUNTU22-CIS
     version: 1.4.1
@@ -29,3 +30,4 @@ roles:
     version: 1.18.5
   - src: https://github.com/stackhpc/ansible-role-docker.git
     name: geerlingguy.docker
+    version: stackhpc/7.0.1.1

--- a/releasenotes/notes/pin-deps-dbe52c49e945daf5.yaml
+++ b/releasenotes/notes/pin-deps-dbe52c49e945daf5.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    All Ansible dependencies are now pinned to specific versions. The
+    ``stackhpc.vxlan`` role was pinned to 1.1.0, and ``ansible-role-docker``
+    was pinned to stackhpc/7.0.1.1.

--- a/releasenotes/notes/pin-deps-dbe52c49e945daf5.yaml
+++ b/releasenotes/notes/pin-deps-dbe52c49e945daf5.yaml
@@ -2,5 +2,5 @@
 features:
   - |
     All Ansible dependencies are now pinned to specific versions. The
-    ``stackhpc.vxlan`` role was pinned to 1.1.0, and ``ansible-role-docker``
-    was pinned to stackhpc/7.0.1.1.
+    ``stackhpc.vxlan`` role is pinned to 1.1.0, and ``ansible-role-docker``
+    is pinned to stackhpc/7.0.1.1.


### PR DESCRIPTION
Pins remaining unpinned ansible dependencies. Pinning to the latest available version so there should be no change in behaviour