### PR TITLE
Bump neutron images to fix #2097770

### DIFF
--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -19,8 +19,8 @@ kolla_image_tags:
     rocky-9: 2024.1-rocky-9-20250127T211632
     ubuntu-jammy: 2024.1-ubuntu-jammy-20250127T211632
   neutron:
-    rocky-9: 2024.1-rocky-9-20250129T143601
-    ubuntu-jammy: 2024.1-ubuntu-jammy-20250129T143601
+    rocky-9: 2024.1-rocky-9-20250213T084602
+    ubuntu-jammy: 2024.1-ubuntu-jammy-20250213T084602
   ovn_sb_db_relay:
     rocky-9: 2024.1-rocky-9-20250129T155601
     ubuntu-jammy: 2024.1-ubuntu-jammy-20250129T155601

--- a/releasenotes/notes/revert-track-all-interfaces-in-keepalived-41ef4834b7659af4.yaml
+++ b/releasenotes/notes/revert-track-all-interfaces-in-keepalived-41ef4834b7659af4.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Reverts "Track all interfaces in Keepalived" so only HA interfaces are
+    tracked. This prevents L3 HA router flapping when detaching floating IP
+    addresses, because non-HA router interfaces did not include "no_track".
+    Closes-Bug: #2097770


### PR DESCRIPTION
Reverts "Track all interfaces in Keepalived" so only HA interfaces are tracked. This prevents L3 HA router flapping when detaching floating IP addresses, because non-HA router interfaces did not include "no_track". 

Closes-Bug: #2097770