### PR TITLE
Use downstream Glance to fix bug #2086675

### DIFF
--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -6,6 +6,9 @@ kolla_image_tags:
   openstack:
     rocky-9: 2024.1-rocky-9-20241218T141751
     ubuntu-jammy: 2024.1-ubuntu-jammy-20241218T141809
+  glance:
+    rocky-9: 2024.1-rocky-9-20250213T103134
+    ubuntu-jammy: 2024.1-ubuntu-jammy-20250213T103134
   horizon:
     rocky-9: 2024.1-rocky-9-20250203T171853
     ubuntu-jammy: 2024.1-ubuntu-jammy-20250203T171853

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -125,6 +125,10 @@ kolla_sources:
     type: git
     location: https://github.com/stackhpc/cloudkitty.git
     reference: stackhpc/{{ openstack_release }}
+  glance-base:
+    type: git
+    location: https://github.com/stackhpc/glance
+    reference: stackhpc/{{ openstack_release }}
   horizon-plugin-cloudkitty-dashboard:
     type: git
     location: https://github.com/stackhpc/cloudkitty-dashboard.git
@@ -352,6 +356,9 @@ kolla_build_blocks:
 kolla_build_customizations_common:
   bifrost_base_pip_packages_append:
     - /additions/*
+  glance_base_pip_packages_override:
+    - "/glance"
+    - "glance_store[cinder,vmware,swift,s3]@git+https://github.com/stackhpc/glance_store@stackhpc/4.7.0.3"
   ironic_inspector_pip_packages_append:
     - /additions/*
   magnum_base_pip_packages_override:

--- a/releasenotes/notes/bump-glance-to-fix-bug-2086675-303542d3208103b9.yaml
+++ b/releasenotes/notes/bump-glance-to-fix-bug-2086675-303542d3208103b9.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix `bug 2086675: <https://bugs.launchpad.net/glance/+bug/2086675>__`
+    Performance regression for Glance with RBD backend.


### PR DESCRIPTION
Bump Glance image (built from downstream stackhpc/2024.1 glance) to fix bug [#2086675](https://bugs.launchpad.net/glance/+bug/2086675)