### PR TITLE
Bump Ironic to expand check_cipher_suite_errors

### DIFF
--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -12,6 +12,12 @@ kolla_image_tags:
   horizon:
     rocky-9: 2024.1-rocky-9-20250203T171853
     ubuntu-jammy: 2024.1-ubuntu-jammy-20250203T171853
+  ironic:
+    rocky-9: 2024.1-rocky-9-20250213T110505
+    ubuntu-jammy: 2024.1-ubuntu-jammy-20250213T110505
+  ironic_dnsmasq:
+    rocky-9: 2024.1-rocky-9-20241218T141751
+    ubuntu-jammy: 2024.1-ubuntu-jammy-20241218T141809
   ironic_prometheus_exporter:
     rocky-9: 2024.1-rocky-9-20250124T081816
     ubuntu-jammy: 2024.1-ubuntu-jammy-20250124T081816

--- a/releasenotes/notes/ironic-expand-check_cipher_suite_errors-c8915956be17a28c.yaml
+++ b/releasenotes/notes/ironic-expand-check_cipher_suite_errors-c8915956be17a28c.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Bumped Ironic container image tag to fix a bug where some cipher suite
+    errors for SuperMicro hardware were not caught. See patch:
+    https://review.opendev.org/c/openstack/ironic/+/940957


### PR DESCRIPTION
Bumped Ironic tag to fix a bug where some cipher sute errors for SuperMicro hardware were not caught