### PR TITLE
feat: add `amphora` load balancers to `ci-multinode`

### DIFF
--- a/etc/kayobe/environments/ci-multinode/controllers.yml
+++ b/etc/kayobe/environments/ci-multinode/controllers.yml
@@ -5,7 +5,6 @@ controller_bootstrap_user: "{{ os_distribution if os_distribution == 'ubuntu' el
 controller_lvm_groups:
   - "{{ stackhpc_lvm_group_rootvg }}"
 
-
 ###############################################################################
 # Controller node firewalld configuration.
 
@@ -28,3 +27,7 @@ controller_firewalld_default_zone: trusted
 # - permanent: true
 # - state: enabled
 controller_firewalld_rules: "{{ stackhpc_firewalld_rules }}"
+
+# List of extra networks to which controller nodes are attached.
+controller_extra_network_interfaces:
+  - octavia

--- a/etc/kayobe/environments/ci-multinode/inventory/group_vars/controllers/network-interfaces
+++ b/etc/kayobe/environments/ci-multinode/inventory/group_vars/controllers/network-interfaces
@@ -16,6 +16,8 @@ public_routes:
   - cidr: "{{ external_cidr }}"
     gateway: "{{ public_net_name | net_ip( groups['seed'][0] ) }}"
 
+octavia_interface: "{{ vxlan_interfaces[0].device}}.{{ octavia_vlan }}"
+
 ###############################################################################
 # Dummy variable to allow Ansible to accept this file.
 workaround_ansible_issue_8743: yes

--- a/etc/kayobe/environments/ci-multinode/kolla/globals.yml
+++ b/etc/kayobe/environments/ci-multinode/kolla/globals.yml
@@ -47,11 +47,6 @@ neutron_dns_domain: "{{ root_domain }}."
 # OpenSearch memory tuning
 opensearch_heap_size: 1g
 
-# Octavia load balancer configuration
-octavia_auto_configure: "no"
-octavia_provider_drivers: "ovn:OVN provider"
-octavia_provider_agents: "ovn"
-
 # Manila CephFS configuration
 manila_cephfs_filesystem_name: manila-cephfs
 
@@ -67,3 +62,21 @@ designate_forwarders_addresses: "1.1.1.1; 8.8.8.8"
 # Open up ports in firewalld for services on the public API network.
 enable_external_api_firewalld: true
 external_api_firewalld_zone: "{{ public_net_name | net_zone }}"
+
+# Octavia load balancer configuration
+octavia_network_interface: "{{ hostvars[groups['controllers'] | first].octavia_interface }}"
+
+octavia_amp_network:
+  name: lb-mgmt-net
+  provider_network_type: vlan
+  provider_physical_network: "physnet1"
+  provider_segmentation_id: 999
+  external: false
+  shared: false
+  subnet:
+    name: lb-mgmt-subnet
+    cidr: "192.168.34.0/24"
+    allocation_pool_start: "192.168.34.10"
+    allocation_pool_end: "192.168.34.254"
+    no_gateway_ip: yes
+    enable_dhcp: yes

--- a/etc/kayobe/environments/ci-multinode/networks.yml
+++ b/etc/kayobe/environments/ci-multinode/networks.yml
@@ -131,6 +131,13 @@ provision_oc_allocation_pool_end: 192.168.33.254
 provision_oc_vlan: 107
 provision_oc_zone: "provision_oc"
 
+octavia_cidr: 192.168.34.0/24
+octavia_vlan: 999
+octavia_allocation_pool_start: 192.168.34.3
+octavia_allocation_pool_end: 192.168.34.9
+octaiva_mtu: "{{ ansible_facts.default_ipv4.mtu - 50 }}"
+octavia_zone: octavia
+
 ###############################################################################
 # Network virtual patch link configuration.
 

--- a/etc/kayobe/environments/ci-multinode/networks.yml
+++ b/etc/kayobe/environments/ci-multinode/networks.yml
@@ -135,7 +135,7 @@ octavia_cidr: 192.168.34.0/24
 octavia_vlan: 999
 octavia_allocation_pool_start: 192.168.34.3
 octavia_allocation_pool_end: 192.168.34.9
-octaiva_mtu: "{{ ansible_facts.default_ipv4.mtu - 50 }}"
+octavia_mtu: "{{ ansible_facts.default_ipv4.mtu - 50 }}"
 octavia_zone: octavia
 
 ###############################################################################

--- a/etc/kayobe/environments/ci-multinode/stackhpc-ci.yml
+++ b/etc/kayobe/environments/ci-multinode/stackhpc-ci.yml
@@ -60,3 +60,6 @@ stackhpc_docker_registry: "{{ stackhpc_repo_mirror_url | regex_replace('^https?:
 
 stackhpc_docker_registry_username: "{{ stackhpc_repo_mirror_username }}"
 stackhpc_docker_registry_password: "{{ stackhpc_repo_mirror_password }}"
+
+stackhpc_release_pulp_username: "{{ stackhpc_repo_mirror_username }}"
+stackhpc_release_pulp_password: "{{ stackhpc_repo_mirror_password }}"


### PR DESCRIPTION
Validated working with use of `octavia` loadlist from https://github.com/stackhpc/stackhpc-kayobe-config/pull/1513.

Will require modifications to setup script before it can be merged.