### PR TITLE
Fix kolla images script

### DIFF
--- a/tools/kolla-images.py
+++ b/tools/kolla-images.py
@@ -240,7 +240,7 @@ def validate(kolla_image_tags: KollaImageTags):
     tag_var_re = re.compile(r"^[a-z0-9_]+$")
     openstack_release = get_openstack_release()
     tag_res = {
-        base_distro: re.compile(f"^{openstack_release}-{base_distro}-[\d]{{8}}T[\d]{{6}}$")
+        base_distro: re.compile(rf"^{openstack_release}-{base_distro}-[\d]{{8}}T[\d]{{6}}$")
         for base_distro in SUPPORTED_BASE_DISTROS
     }
     errors = []
@@ -308,7 +308,7 @@ def check_image_map(kolla_ansible_path: str):
     image_map = yaml.safe_load(image_map_str)
     image_var_re = re.compile(r"^([a-z0-9_]+)_image$")
     image_map = {
-        image_var_re.match(image_var).group(1): image.split("/")[-1]
+        image_var_re.match(image_var).group(1): image.split("/")[-1].replace('{{ docker_image_name_prefix }}', '')
         for image_var, image in image_map.items()
     }
     # Filter out unsupported images.


### PR DESCRIPTION
Kolla image names have recently been updated to include a prefix, `docker_image_name_prefix`. This change updates the kolla-images.py script to compensate.

It also fixes a warning brought in by the upgrade to Python 3.12