### PR TITLE
fix: use `volumev3` as `catalog_type`

### DIFF
--- a/.automation.conf/tempest/tempest-ci-aio.overrides.conf
+++ b/.automation.conf/tempest/tempest-ci-aio.overrides.conf
@@ -1,1 +1,2 @@
-# Blank file
+[volume]
+catalog_type = volumev3

--- a/.automation.conf/tempest/tempest-ci-multinode.overrides.conf
+++ b/.automation.conf/tempest/tempest-ci-multinode.overrides.conf
@@ -23,6 +23,7 @@ volume_backed_live_migration = true
 console_output = true
 
 [volume]
+catalog_type = volumev3
 storage_protocol = ceph
 build_timeout = 600
 min_microversion = 3.0


### PR DESCRIPTION
Due to the recent changes in the tempest configuration, the
`catalog_type` for the volume service has been changed to
`block-storage` [1]. Kolla Ansible uses `volumev3` as the catalog type.

[1]: https://opendev.org/openstack/tempest/commit/1a744c8042d3c5c5ad153ef1e645975428ba0dfe