### PR TITLE
Match job name of OS Capacity to what Azimuth expects

### DIFF
--- a/etc/kayobe/kolla/config/prometheus/prometheus.yml.d/70-oscapacity.yml
+++ b/etc/kayobe/kolla/config/prometheus/prometheus.yml.d/70-oscapacity.yml
@@ -3,7 +3,7 @@
 {% if stackhpc_enable_os_capacity | bool %}
 {% raw %}
 scrape_configs:
-  - job_name: os-capacity
+  - job_name: os_capacity
     static_configs:
         - targets:
           - '{{ kolla_internal_fqdn | put_address_in_context('url') }}:9090'

--- a/releasenotes/notes/fix-os-capacity-prometheus-job-name-for-azimuth-cloud-metrics-39cf81eebe16b879.yaml
+++ b/releasenotes/notes/fix-os-capacity-prometheus-job-name-for-azimuth-cloud-metrics-39cf81eebe16b879.yaml
@@ -3,4 +3,4 @@ fixes:
   - |
     Changed the Prometheus job name of OS Capacity exporter to
     ``os_capacity`` which is what Azimuth is expecting to have for
-    `cloud metrics dashboard <https://github.com/azimuth-cloud/ansible-collection-azimuth-ops/blob/main/roles/cloud_metrics/defaults/main.yml#L41C1-L43C48>__`.
+    `cloud metrics dashboard <https://github.com/azimuth-cloud/ansible-collection-azimuth-ops/blob/main/roles/cloud_metrics/defaults/main.yml#L41C1-L43C48>`__.

--- a/releasenotes/notes/fix-os-capacity-prometheus-job-name-for-azimuth-cloud-metrics-39cf81eebe16b879.yaml
+++ b/releasenotes/notes/fix-os-capacity-prometheus-job-name-for-azimuth-cloud-metrics-39cf81eebe16b879.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Changed the Prometheus job name of OS Capacity exporter to
+    ``os_capacity`` which is what Azimuth is expecting to have for
+    `cloud metrics dashboard <https://github.com/azimuth-cloud/ansible-collection-azimuth-ops/blob/main/roles/cloud_metrics/defaults/main.yml#L41C1-L43C48>__`.


### PR DESCRIPTION
The prometheus job name for OS capacity exporter on SKC is not matching what Azimuth is expecting by default: https://github.com/azimuth-cloud/ansible-collection-azimuth-ops/blob/main/roles/cloud_metrics/defaults/main.yml#L41C1-L43C48  ``os-capacity`` on SKC but ``os_capacity`` on Azimuth (dash vs underscore)

This can result breaking cloud metrics dashboard of Azimuth.
