### PR TITLE
Fix the Horizon Identity->Domains panel for admins

### DIFF
--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -10,8 +10,8 @@ kolla_image_tags:
     rocky-9: 2024.1-rocky-9-20250213T103134
     ubuntu-jammy: 2024.1-ubuntu-jammy-20250213T103134
   horizon:
-    rocky-9: 2024.1-rocky-9-20250203T171853
-    ubuntu-jammy: 2024.1-ubuntu-jammy-20250203T171853
+    rocky-9: 2024.1-rocky-9-20250227T091118
+    ubuntu-jammy: 2024.1-ubuntu-jammy-20250227T091118
   ironic:
     rocky-9: 2024.1-rocky-9-20250213T110505
     ubuntu-jammy: 2024.1-ubuntu-jammy-20250213T110505

--- a/releasenotes/notes/horizon-fix-multiple-domains-51086e9ba3d197b7.yaml
+++ b/releasenotes/notes/horizon-fix-multiple-domains-51086e9ba3d197b7.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Bumps the Horizon container image tag to fix the Identity->Domains panel
+    for admins when multiple Domains are in use. See patch:
+    https://review.opendev.org/c/openstack/horizon/+/940461


### PR DESCRIPTION
Bumps the Horizon container image tag to bring in this patch: https://review.opendev.org/c/openstack/horizon/+/940461