### PR TITLE
Deploy OS capacity after overcloud service upgrade

### DIFF
--- a/doc/source/operations/upgrading-openstack.rst
+++ b/doc/source/operations/upgrading-openstack.rst
@@ -176,6 +176,21 @@ authentication will fail if this configuration is absent. See `upstream
 Keystone change <https://review.opendev.org/c/openstack/keystone/+/833876>`__
 for more details.
 
+OS Capacity exporter and dashboard enabled by default
+-----------------------------------------------------
+
+The OS Capacity exporter will automatically be deployed after the upgrade.
+During the upgrade, HAProxy config, Prometheus config  and Grafana dashboards
+will also be updated to use the exporter. If you want to disable this, change
+the following in ``kayobe-config/etc/kayobe/stackhpc-monitoring.yml``:
+
+.. code-block:: yaml
+
+   # Whether the OpenStack Capacity exporter is enabled.
+   # Enabling this flag will result in HAProxy configuration and Prometheus scrape
+   # targets being templated during deployment.
+   stackhpc_enable_os_capacity: false
+
 Known issues
 ============
 

--- a/etc/kayobe/hooks/overcloud-service-upgrade/post.d/deploy-os-capacity-exporter.yml
+++ b/etc/kayobe/hooks/overcloud-service-upgrade/post.d/deploy-os-capacity-exporter.yml
@@ -1,0 +1,1 @@
+../../../ansible/deploy-os-capacity-exporter.yml


### PR DESCRIPTION
We only started enabling this by default in Caracal, so this needs to get deployed as part of an Antelope->Caracal upgrade. Otherwise, the haproxy and grafana config gets put in place without the exporter being present.