### PR TITLE
Fix handler notify in fix-houston.yml

### DIFF
--- a/etc/kayobe/ansible/fix-houston.yml
+++ b/etc/kayobe/ansible/fix-houston.yml
@@ -29,7 +29,7 @@
       vars:
         interface_name: "{{ item }}"
       when: neutron_bridge_name | length > 0
-      notify: reload systemd
+      notify: Reload systemd
 
     - name: Enable and start systemd service for -ovs network interface
       ansible.builtin.systemd:

--- a/releasenotes/notes/fix-fix-houston-notify-165a7871bda48f68.yaml
+++ b/releasenotes/notes/fix-fix-houston-notify-165a7871bda48f68.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes an issue where the fix-houston.yml playbook would fail to reload
+    systemd as the ``notify`` statement was incorrect.


### PR DESCRIPTION
The handler was changed when we fixed linting, but the notify wasn't updated.