### PR TITLE
Fix "Max Inlet Temp" time series chart

### DIFF
--- a/etc/kayobe/kolla/config/grafana/dashboards/openstack/redfish.json
+++ b/etc/kayobe/kolla/config/grafana/dashboards/openstack/redfish.json
@@ -2216,7 +2216,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "redfish_chassis_temperature_celsius{sensor_id=~\".*InletTemp\"} or redfish_chassis_temperature_celsius{sensor=~\"CPU2.*\"}",
+          "expr": "redfish_chassis_temperature_celsius{sensor_id=~\".*InletTemp\"} or redfish_chassis_temperature_celsius{sensor=~\".*Inlet.*\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{ env }} {{ server }}",

--- a/releasenotes/notes/redfish-dashboard-fix-inlet-temp-91a7018adb2e1763.yaml
+++ b/releasenotes/notes/redfish-dashboard-fix-inlet-temp-91a7018adb2e1763.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes "Max Inlet Temp" time series chart in Redfish dashboard. This chart
+    could wrongly display CPU2 temperature instead of inlet temperature.


### PR DESCRIPTION
This chart could wrongly display CPU2 temperature instead of inlet temperature.