### PR TITLE
feat: use `include_tags` for kolla repositories

### DIFF
--- a/etc/kayobe/pulp.yml
+++ b/etc/kayobe/pulp.yml
@@ -582,10 +582,11 @@ stackhpc_pulp_repository_container_repos_kolla_common:
 # List of Kolla container image repositories.
 stackhpc_pulp_repository_container_repos_kolla: >-
   {%- set repos = [] -%}
+  {%- set image_tags = lookup('pipe', 'python3 ' ~ kayobe_config_path ~ '/../../tools/kolla-images.py list-tags') | from_yaml -%}
   {%- for image in stackhpc_pulp_images_kolla_filtered -%}
-  {%- if image not in stackhpc_kolla_unbuildable_images[kolla_base_distro_and_version]-%}
+  {%- if image not in stackhpc_kolla_unbuildable_images[kolla_base_distro_and_version] -%}
   {%- set image_repo = kolla_docker_namespace ~ "/" ~ image -%}
-  {%- set repo = {"name": image_repo} -%}
+  {%- set repo = {"name": image_repo, "include_tags": image_tags[image]} -%}
   {%- set _ = repos.append(stackhpc_pulp_repository_container_repos_kolla_common | combine(repo)) -%}
   {%- endif -%}
   {%- endfor -%}

--- a/releasenotes/notes/use-include-tags-for-client-pulp-cf46d328b30162be.yaml
+++ b/releasenotes/notes/use-include-tags-for-client-pulp-cf46d328b30162be.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Restrict the content that is synced to the client by using include tags.
+    This feature ensures that the tags as defined within
+    ``kolla-image-tags.yml`` are synced.


### PR DESCRIPTION
Currently all tags of all containers are implicitly included when setting up remotes during `pulp-container-sync.yml` this means that client Pulp creates references for all tags that have ever been published for a given container.

Currently sync with Ark will produce the following;

```
$ pulp container content list
Not all 3243 entries were shown.
```

Whereas with this patch;

```
$ pulp container content list
Not all 202 entries were shown.
```

Unfortunately doesn't appear to have any meaningful improvements to wait times when running the playbook.