### PR TITLE
Bump neutron images to fix #2097770 (For stackhpc/2023.1)

### DIFF
--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -37,8 +37,8 @@ kolla_image_tags:
   manila:
     rocky-9: 2023.1-rocky-9-20240809T102431
   neutron:
-    rocky-9: 2023.1-rocky-9-20250203T090355
-    ubuntu-jammy: 2023.1-ubuntu-jammy-20250203T090355
+    rocky-9: 2023.1-rocky-9-20250311T093325
+    ubuntu-jammy: 2023.1-ubuntu-jammy-20250311T093325
   nova:
     rocky-9: 2023.1-rocky-9-20240926T151818
     ubuntu-jammy: 2023.1-ubuntu-jammy-20240926T151818

--- a/releasenotes/notes/revert-track-all-interfaces-in-keepalived-371eea147fbebf36.yaml
+++ b/releasenotes/notes/revert-track-all-interfaces-in-keepalived-371eea147fbebf36.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Reverts "Track all interfaces in Keepalived" so only HA interfaces are
+    tracked. This prevents L3 HA router flapping when detaching floating IP
+    addresses, because non-HA router interfaces did not include "no_track".
+    Closes-Bug: #2097770


### PR DESCRIPTION
Reverts "Track all interfaces in Keepalived" so only HA interfaces are tracked. This prevents L3 HA router flapping when detaching floating IP addresses, because non-HA router interfaces did not include "no_track". Closes-Bug: #2097770

This was applied to both Caracal and Antelope but we missed Antelope neutron bump.