### PR TITLE
Filter out interfaces that don't matter for packet drops.

### DIFF
--- a/etc/kayobe/kolla/config/prometheus/ceph.rules
+++ b/etc/kayobe/kolla/config/prometheus/ceph.rules
@@ -139,7 +139,7 @@ groups:
 
   # alert on nic packet errors and drops rates > alertmanager_packet_drop_threshold packet/s
   - alert: NetworkPacketsDropped
-    expr: irate(node_network_receive_drop_total{device!~"lo|br.*|.*-ovs|tap.*"}[5m]) + irate(node_network_transmit_drop_total{device!~"lo|br.*|.*-ovs|tap.*"}[5m]) > {% endraw %}{{ alertmanager_packet_drop_threshold }}{% raw %}
+    expr: irate(node_network_receive_drop_total{device!~"lo|br.*|.*-ovs|tap.*|ha.*|qc.*|qr.*|qg.*"}[5m]) + irate(node_network_transmit_drop_total{device!~"lo|br.*|.*-ovs|tap.*|ha.*|qc.*|qr.*|qg.*"}[5m]) > {% endraw %}{{ alertmanager_packet_drop_threshold }}{% raw %}
     labels:
       severity: warning
     annotations:


### PR DESCRIPTION
OVS interfaces drop packets during normal operation, generating lots of spurious alerts.