### PR TITLE
Fix ceph-rgw blackbox endpoint enabling

### DIFF
--- a/etc/kayobe/kolla/inventory/group_vars/prometheus-blackbox-exporter
+++ b/etc/kayobe/kolla/inventory/group_vars/prometheus-blackbox-exporter
@@ -37,7 +37,7 @@ prometheus_blackbox_exporter_endpoints_default:
   - endpoints:
       - "ceph_rgw:http_2xx:{{ ceph_rgw_public_base_endpoint }}"
       - "{{ ('ceph_rgw_internal:http_2xx:' + ceph_rgw_internal_base_endpoint) if not kolla_same_external_internal_vip | bool }}"
-    enabled: "{{ enable_ceph_rgw | bool }}"
+    enabled: "{{ enable_ceph_rgw | bool and enable_ceph_rgw_loadbalancer | bool }}"
   - endpoints:
       - "cinder:os_endpoint:{{ cinder_public_base_endpoint }}"
       - "{{ ('cinder_internal:os_endpoint:' + cinder_internal_base_endpoint) if not kolla_same_external_internal_vip | bool }}"

--- a/releasenotes/notes/fix-ceph-rgw-blackbox-endpoint-7af02679b3fd093d.yaml
+++ b/releasenotes/notes/fix-ceph-rgw-blackbox-endpoint-7af02679b3fd093d.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixes an issue where the ``ceph-rgw`` endpoints were added to the
+    Prometheus blackbox exporter when the Kolla loadbalancer was not in use for
+    RGWs.


### PR DESCRIPTION
When using the Ceph ingress for balancing RGW traffic, we disable the KA loadbalancing of this traffic. Therefore, we do not need to monitor the ``ceph-rgw`` endpoints when ``enable_ceph_rgw_loadbalancer=false``.