### PR TITLE
Update heat removal docs

### DIFF
--- a/doc/source/operations/upgrading-openstack.rst
+++ b/doc/source/operations/upgrading-openstack.rst
@@ -79,11 +79,10 @@ Then from the OpenStack CLI:
 .. code-block:: console
 
    openstack service delete heat
+   openstack service delete heat-cfn
    openstack user delete heat
    openstack domain set --disable heat_user_domain
    openstack domain delete heat_user_domain
-   openstack endpoint list --service heat -c ID -f value | xargs openstack endpoint delete
-   openstack endpoint list --service heat-cfn -c ID -f value | xargs openstack endpoint delete
 
 You can drop the ``heat`` database too, unless you want to keep historical content.
 


### PR DESCRIPTION
We need to also delete the ``heat-cfn`` service. The endpoint deletions are redundant, as endpoints are removed when the services are deleted.