### PR TITLE
Add a confirmation prompt to reboot.yml

### DIFF
--- a/etc/kayobe/ansible/reboot.yml
+++ b/etc/kayobe/ansible/reboot.yml
@@ -9,9 +9,26 @@
     ansible_user: "{{ bootstrap_user if reboot_with_bootstrap_user | bool else kayobe_ansible_user }}"
     ansible_ssh_common_args: "{{ '-o StrictHostKeyChecking=no' if reboot_with_bootstrap_user | bool else '' }}"
     ansible_python_interpreter: /usr/bin/python3
+    confirm_reboot: False
   tags:
     - reboot
   tasks:
+    - name: Prompt to confirm reboot
+      ansible.builtin.pause:
+        prompt: >
+          The following hosts will be rebooted:
+          {{ play_hosts | join(', ') }}
+          If you want to proceed type: yes
+      register: pause_prompt
+      when: not confirm_reboot
+
+    - name: Fail if reboot is not confirmed
+      ansible.builtin.assert:
+        that: confirm_reboot == 'yes' or pause_prompt.user_input == 'yes'
+        msg: >
+          Reboot has not been confirmed. You must either type 'yes' when
+          prompted, or set ``confirm_reboot=yes``.
+
     - name: Reboot and wait
       become: true
       ansible.builtin.reboot:

--- a/etc/kayobe/ansible/reboot.yml
+++ b/etc/kayobe/ansible/reboot.yml
@@ -9,7 +9,7 @@
     ansible_user: "{{ bootstrap_user if reboot_with_bootstrap_user | bool else kayobe_ansible_user }}"
     ansible_ssh_common_args: "{{ '-o StrictHostKeyChecking=no' if reboot_with_bootstrap_user | bool else '' }}"
     ansible_python_interpreter: /usr/bin/python3
-    confirm_reboot: False
+    confirm_reboot: false
   tags:
     - reboot
   tasks:
@@ -27,7 +27,7 @@
         that: confirm_reboot | bool or pause_prompt.user_input == 'yes'
         msg: >
           Reboot has not been confirmed. You must either type 'yes' when
-          prompted, or set ``confirm_reboot=yes``.
+          prompted, or set ``confirm_reboot: true``.
 
     - name: Reboot and wait
       become: true

--- a/etc/kayobe/ansible/reboot.yml
+++ b/etc/kayobe/ansible/reboot.yml
@@ -24,7 +24,7 @@
 
     - name: Fail if reboot is not confirmed
       ansible.builtin.assert:
-        that: confirm_reboot == 'yes' or pause_prompt.user_input == 'yes'
+        that: confirm_reboot | bool or pause_prompt.user_input == 'yes'
         msg: >
           Reboot has not been confirmed. You must either type 'yes' when
           prompted, or set ``confirm_reboot=yes``.

--- a/etc/kayobe/environments/aufn-ceph/globals.yml
+++ b/etc/kayobe/environments/aufn-ceph/globals.yml
@@ -13,3 +13,9 @@ os_distribution: "{{ lookup('pipe', '. /etc/os-release && echo $ID') | trim }}"
 os_release: >-
           {{ (lookup('pipe', '. /etc/os-release && echo $VERSION_CODENAME') | trim) if os_distribution == 'ubuntu' else
              (lookup('pipe', '. /etc/os-release && echo $VERSION_ID') | trim | split('.') | first) if os_distribution == 'rocky' }}
+
+###############################################################################
+# Extra vars.
+
+# Don't prompt when rebooting hosts.
+confirm_reboot: "yes"

--- a/etc/kayobe/environments/aufn-ceph/globals.yml
+++ b/etc/kayobe/environments/aufn-ceph/globals.yml
@@ -18,4 +18,4 @@ os_release: >-
 # Extra vars.
 
 # Don't prompt when rebooting hosts.
-confirm_reboot: "yes"
+confirm_reboot: true

--- a/etc/kayobe/environments/ci-aio/globals.yml
+++ b/etc/kayobe/environments/ci-aio/globals.yml
@@ -56,5 +56,11 @@ os_release: >-
              (lookup('pipe', '. /etc/os-release && echo $VERSION_ID') | trim | split('.') | first) if os_distribution == 'rocky' }}
 
 ###############################################################################
+# Extra vars.
+
+# Don't prompt when rebooting hosts.
+confirm_reboot: "yes"
+
+###############################################################################
 # Dummy variable to allow Ansible to accept this file.
 workaround_ansible_issue_8743: yes

--- a/etc/kayobe/environments/ci-aio/globals.yml
+++ b/etc/kayobe/environments/ci-aio/globals.yml
@@ -59,7 +59,7 @@ os_release: >-
 # Extra vars.
 
 # Don't prompt when rebooting hosts.
-confirm_reboot: "yes"
+confirm_reboot: true
 
 ###############################################################################
 # Dummy variable to allow Ansible to accept this file.

--- a/etc/kayobe/environments/ci-builder/globals.yml
+++ b/etc/kayobe/environments/ci-builder/globals.yml
@@ -7,3 +7,9 @@
 # OS distribution name. Valid options are "rocky", "ubuntu". Default is
 # "rocky".
 os_distribution: "{{ lookup('pipe', '. /etc/os-release && echo $ID') | trim }}"
+
+###############################################################################
+# Extra vars.
+
+# Don't prompt when rebooting hosts.
+confirm_reboot: "yes"

--- a/etc/kayobe/environments/ci-builder/globals.yml
+++ b/etc/kayobe/environments/ci-builder/globals.yml
@@ -12,4 +12,4 @@ os_distribution: "{{ lookup('pipe', '. /etc/os-release && echo $ID') | trim }}"
 # Extra vars.
 
 # Don't prompt when rebooting hosts.
-confirm_reboot: "yes"
+confirm_reboot: true

--- a/etc/kayobe/environments/ci-doca-builder/globals.yml
+++ b/etc/kayobe/environments/ci-doca-builder/globals.yml
@@ -3,4 +3,4 @@
 # Extra vars.
 
 # Don't prompt when rebooting hosts.
-confirm_reboot: "yes"
+confirm_reboot: true

--- a/etc/kayobe/environments/ci-doca-builder/globals.yml
+++ b/etc/kayobe/environments/ci-doca-builder/globals.yml
@@ -1,0 +1,6 @@
+---
+###############################################################################
+# Extra vars.
+
+# Don't prompt when rebooting hosts.
+confirm_reboot: "yes"

--- a/etc/kayobe/environments/ci-multinode/globals.yml
+++ b/etc/kayobe/environments/ci-multinode/globals.yml
@@ -67,7 +67,7 @@ selinux_do_reboot: true
 # Extra vars.
 
 # Don't prompt when rebooting hosts.
-confirm_reboot: "yes"
+confirm_reboot: true
 
 ###############################################################################
 # Dummy variable to allow Ansible to accept this file.

--- a/etc/kayobe/environments/ci-multinode/globals.yml
+++ b/etc/kayobe/environments/ci-multinode/globals.yml
@@ -64,5 +64,11 @@ stackhpc_barbican_role_id_file_path: "/tmp/barbican-role-id"
 selinux_do_reboot: true
 
 ###############################################################################
+# Extra vars.
+
+# Don't prompt when rebooting hosts.
+confirm_reboot: "yes"
+
+###############################################################################
 # Dummy variable to allow Ansible to accept this file.
 workaround_ansible_issue_8743: yes

--- a/releasenotes/notes/add-confirmation-prompt-to-reboot.yml-4fd1ae8e8d360e57.yaml
+++ b/releasenotes/notes/add-confirmation-prompt-to-reboot.yml-4fd1ae8e8d360e57.yaml
@@ -4,8 +4,3 @@ features:
     A confirmation prompt has been added to ``reboot.yml`` to help avoid
     rebooting the wrong hosts by mistake. This check can be skipped by setting
     ``confirm_reboot: yes``.
-upgrade:
-  - |
-    A confirmation prompt has been added to ``reboot.yml`` to help avoid
-    rebooting the wrong hosts by mistake. This check can be skipped by setting
-    ``confirm_reboot=yes``.

--- a/releasenotes/notes/add-confirmation-prompt-to-reboot.yml-4fd1ae8e8d360e57.yaml
+++ b/releasenotes/notes/add-confirmation-prompt-to-reboot.yml-4fd1ae8e8d360e57.yaml
@@ -3,4 +3,4 @@ features:
   - |
     A confirmation prompt has been added to ``reboot.yml`` to help avoid
     rebooting the wrong hosts by mistake. This check can be skipped by setting
-    ``confirm_reboot: yes``.
+    ``confirm_reboot: true``.

--- a/releasenotes/notes/add-confirmation-prompt-to-reboot.yml-4fd1ae8e8d360e57.yaml
+++ b/releasenotes/notes/add-confirmation-prompt-to-reboot.yml-4fd1ae8e8d360e57.yaml
@@ -3,7 +3,7 @@ features:
   - |
     A confirmation prompt has been added to ``reboot.yml`` to help avoid
     rebooting the wrong hosts by mistake. This check can be skipped by setting
-    ``confirm_reboot=yes``.
+    ``confirm_reboot: yes``.
 upgrade:
   - |
     A confirmation prompt has been added to ``reboot.yml`` to help avoid

--- a/releasenotes/notes/add-confirmation-prompt-to-reboot.yml-4fd1ae8e8d360e57.yaml
+++ b/releasenotes/notes/add-confirmation-prompt-to-reboot.yml-4fd1ae8e8d360e57.yaml
@@ -1,0 +1,11 @@
+---
+features:
+  - |
+    A confirmation prompt has been added to ``reboot.yml`` to help avoid
+    rebooting the wrong hosts by mistake. This check can be skipped by setting
+    ``confirm_reboot=yes``.
+upgrade:
+  - |
+    A confirmation prompt has been added to ``reboot.yml`` to help avoid
+    rebooting the wrong hosts by mistake. This check can be skipped by setting
+    ``confirm_reboot=yes``.


### PR DESCRIPTION
This is a risky playbook to run without confirmation, especially as it targets all hosts when not using a limit.