### PR TITLE
fix: use `rabbitmq` length for `RabbitMQNodeDown`

### DIFF
--- a/etc/kayobe/kolla/config/prometheus/rabbitmq.rules
+++ b/etc/kayobe/kolla/config/prometheus/rabbitmq.rules
@@ -6,7 +6,7 @@ groups:
 - name: rabbitmq.rules
   rules:
   - alert: RabbitMQNodeDown
-    expr: sum(rabbitmq_build_info{instance!=""}) < 3
+    expr: sum(rabbitmq_build_info{instance!=""}) < {% endraw %}{{ groups['rabbitmq'] | length }}{% raw %}
     for: 30m
     labels:
       severity: critical

--- a/etc/kayobe/kolla/config/prometheus/rabbitmq.rules
+++ b/etc/kayobe/kolla/config/prometheus/rabbitmq.rules
@@ -6,7 +6,7 @@ groups:
 - name: rabbitmq.rules
   rules:
   - alert: RabbitMQNodeDown
-    expr: sum(rabbitmq_build_info{instance!=""}) < {% endraw %}{{ groups['rabbitmq'] | length }}{% raw %}
+    expr: sum(rabbitmq_build_info{instance!=""}) < {{ groups['rabbitmq'] | length }}
     for: 30m
     labels:
       severity: critical

--- a/etc/kayobe/kolla/config/prometheus/rabbitmq.rules
+++ b/etc/kayobe/kolla/config/prometheus/rabbitmq.rules
@@ -6,7 +6,7 @@ groups:
 - name: rabbitmq.rules
   rules:
   - alert: RabbitMQNodeDown
-    expr: sum(rabbitmq_build_info{instance!=""}) < {{ groups['rabbitmq'] | length }}
+    expr: sum(rabbitmq_build_info{instance!=""}) < {% endraw %}{{ alertmanager_number_of_rabbitmq_nodes }}{% raw %}
     for: 30m
     labels:
       severity: critical

--- a/etc/kayobe/stackhpc-monitoring.yml
+++ b/etc/kayobe/stackhpc-monitoring.yml
@@ -26,6 +26,9 @@ alertmanager_packet_drop_threshold: 1
 # packets/s averaged over 5 minutes.
 alertmanager_packet_errors_threshold: 1
 
+# Number of RabbitMQ nodes in the cluster.
+alertmanager_number_of_rabbitmq_nodes: "{{ groups['controllers'] | length }}"
+
 ###############################################################################
 # Exporter configuration
 

--- a/releasenotes/notes/use-length-for-rabbitmq-node-down-rule-c9e9c6b09f57954d.yaml
+++ b/releasenotes/notes/use-length-for-rabbitmq-node-down-rule-c9e9c6b09f57954d.yaml
@@ -1,6 +1,8 @@
 ---
 features:
   - |
-    Use the length of the ``rabbitmq`` group to determine if any RabbitMQ
-    nodes are down. This is benefical for deployments that do not use a
-    standard three node setup.
+    Allow for easy customisation of the number of expected `RabbitMQ`
+    nodes when evaluating the alert `RabbitMQNodeDown`. It is set by
+    the `alertmanager_number_of_rabbitmq_nodes` which defaults to the
+    number of `controllers`. This is benefical for deployments that
+    do not use a standard three node setup.

--- a/releasenotes/notes/use-length-for-rabbitmq-node-down-rule-c9e9c6b09f57954d.yaml
+++ b/releasenotes/notes/use-length-for-rabbitmq-node-down-rule-c9e9c6b09f57954d.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Use the length of the ``rabbitmq`` group to determine if any RabbitMQ
+    nodes are down. This is benefical for deployments that do not use a
+    standard three node setup.


### PR DESCRIPTION
The `RabbitMQNodeDown` made the assumption that all deployments involve three controllers. However, this is not always the case as we do support deployments with a single controller or more than three controllers.

Before this would have caused false alerts in deployments with a single controller. Whilst also concealing alerts in deployments with more than three controllers.