### PR TITLE
[CI] Fixes update Kolla versions running on clones

### DIFF
--- a/.github/workflows/stackhpc-update-kolla.yml
+++ b/.github/workflows/stackhpc-update-kolla.yml
@@ -21,3 +21,4 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    if: github.repository == 'stackhpc/stackhpc-kayobe-config'


### PR DESCRIPTION
Recently added 'Update Kolla versions' job was missing conditional prohibiting execution in non-StackHPC repository, i.e. customer fork.