### PR TITLE
Fix Kolla dependencies update schedule

### DIFF
--- a/.github/workflows/stackhpc-update-kolla.yml
+++ b/.github/workflows/stackhpc-update-kolla.yml
@@ -3,9 +3,9 @@ name: Update Kolla versions
 on:
   # Allow manual executions
   workflow_dispatch:
-  # Run nightly
+  # Run weekly on Tuesday
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 0 * * 2'
 
 jobs:
   update-from-branch:

--- a/.github/workflows/stackhpc-update-kolla.yml
+++ b/.github/workflows/stackhpc-update-kolla.yml
@@ -14,10 +14,13 @@ jobs:
       matrix:
         include:
           - version: stackhpc/2023.1
+            codename: Antelope
           - version: stackhpc/2024.1
+            codename: Caracal
     uses: ./.github/workflows/update-dependencies.yml
     with:
       openstack_version: ${{ matrix.version }}
+      openstack_codename: ${{ matrix.codename }}
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -7,6 +7,10 @@ on:
         description: OpenStack version
         type: string
         required: true
+    openstack_codename:
+        description: OpenStack codename
+        type: string
+        required: true
 
 jobs:
   propose_github_release_updates:
@@ -80,3 +84,6 @@ jobs:
           body: >
             This PR was created automatically to update ${{ inputs.openstack_version }}
             ${{ matrix.key }} to ${{ steps.latest_tag.outputs.latest_tag }}.
+          labels: |
+            stackhpc-ci
+            ${{ inputs.openstack_codename }}

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -84,6 +84,9 @@ jobs:
           body: >
             This PR was created automatically to update ${{ inputs.openstack_version }}
             ${{ matrix.key }} to ${{ steps.latest_tag.outputs.latest_tag }}.
+
+            GitHub Release Changelog:
+            https://github.com/stackhpc/${{ matrix.key }}/releases/tag/${{ steps.latest_tag.outputs.latest_tag }}
           labels: |
             stackhpc-ci
             ${{ inputs.openstack_codename }}

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -7,7 +7,7 @@ on:
         description: OpenStack version
         type: string
         required: true
-    openstack_codename:
+      openstack_codename:
         description: OpenStack codename
         type: string
         required: true

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -77,6 +77,7 @@ jobs:
           path: ${{ github.workspace }}/src/kayobe-config
           commit-message: >-
             Bump ${{ matrix.key }} to ${{ steps.latest_tag.outputs.latest_tag }}
+          author: stackhpc-ci <22933334+stackhpc-ci@users.noreply.github.com>
           branch: update-dependency/${{ matrix.key }}/${{ inputs.openstack_version }}
           delete-branch: true
           title: >-

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -80,7 +80,7 @@ jobs:
           branch: update-dependency/${{ matrix.key }}/${{ inputs.openstack_version }}
           delete-branch: true
           title: >-
-            Bump ${{ inputs.openstack_version }} ${{ matrix.key }} to ${{ steps.latest_tag.outputs.latest_tag }}
+            Bump ${{ matrix.key }} to ${{ steps.latest_tag.outputs.latest_tag }}
           body: >
             This PR was created automatically to update ${{ inputs.openstack_version }}
             ${{ matrix.key }} to ${{ steps.latest_tag.outputs.latest_tag }}.


### PR DESCRIPTION
Changes:

- Run workflow weekly on Tuesday to line up with upstream syncs usually merging on Monday morning. (e.g. https://github.com/stackhpc/kayobe/pull/398)
- Change commit authorship to stackhpc-ci
- Remove full branch from title, rely on labels instead to differentiate releases and include stackhpc-ci label to filter automated PRs.
- Include release changelog in PR body