### PR TITLE
Bump Ceph to v19.2.1

### DIFF
--- a/etc/kayobe/cephadm.yml
+++ b/etc/kayobe/cephadm.yml
@@ -12,7 +12,7 @@ cephadm_ceph_release: "squid"
 cephadm_image: "{{ stackhpc_docker_registry if stackhpc_sync_ceph_images | bool else 'quay.io' }}/ceph/ceph:{{ cephadm_image_tag }}"
 
 # Ceph container image tag.
-cephadm_image_tag: "v19.2.0"
+cephadm_image_tag: "v19.2.1"
 
 # HAProxy container image.
 cephadm_haproxy_image: "{{ stackhpc_docker_registry if stackhpc_sync_ceph_images | bool else 'quay.io' }}/ceph/haproxy:{{ cephadm_haproxy_image_tag }}"

--- a/releasenotes/notes/bump-ceph-to-19-2-1-878ae64bf5420893.yaml
+++ b/releasenotes/notes/bump-ceph-to-19-2-1-878ae64bf5420893.yaml
@@ -1,0 +1,9 @@
+---
+features:
+  - |
+    Bump Ceph to v19.2.1.
+fixes:
+  - |
+    Fixes `Ceph bug #66389 <https://tracker.ceph.com/issues/66389>`__
+    causing Ubuntu Noble hosts to fail to populate OSDs, by upgrading
+    to Ceph v19.2.1.


### PR DESCRIPTION
Ceph v19.2.0 on Ubuntu Noble fails to enroll OSDs because of Ceph bug https://tracker.ceph.com/issues/66389
This is fixed on v19.2.1