### PR TITLE
Remove .git for glance_store override to fix pip dependency conflict

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -358,7 +358,7 @@ kolla_build_customizations_common:
     - /additions/*
   glance_base_pip_packages_override:
     - "/glance"
-    - "glance_store[cinder,vmware,swift,s3]@git+https://github.com/stackhpc/glance_store.git@stackhpc/4.7.0.3"
+    - "glance_store[cinder,vmware,swift,s3]@git+https://github.com/stackhpc/glance_store@stackhpc/4.7.0.3"
   ironic_inspector_pip_packages_append:
     - /additions/*
   magnum_base_pip_packages_override:


### PR DESCRIPTION
Currently we override glance_store with our fork `glance_store[cinder,vmware,swift,s3]@git+https://github.com/stackhpc/glance_store.git@stackhpc/4.7.0.3
`
But upper-constraints and glance expects `glance_store[cinder,vmware,swift,s3]@git+https://github.com/stackhpc/glance_store@stackhpc/4.7.0.3`

This confuses pip and it handles this as a dependency conflict resulting glance image build failure.

Fixing by removing `.git` at the end of source url