### PR TITLE
feat: enable `skyline` build

### DIFF
--- a/etc/kayobe/environments/ci-builder/stackhpc-ci.yml
+++ b/etc/kayobe/environments/ci-builder/stackhpc-ci.yml
@@ -29,6 +29,7 @@ kolla_enable_octavia: true
 kolla_enable_opensearch: true
 kolla_enable_prometheus: true
 kolla_enable_redis: true
+kolla_enable_skyline: true
 kolla_build_neutron_ovs: true
 
 ###############################################################################

--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -48,3 +48,9 @@ kolla_image_tags:
   ovn:
     rocky-9: 2024.1-rocky-9-20250219T113722
     ubuntu-jammy: 2024.1-ubuntu-jammy-20250219T113722
+  skyline_apiserver:
+    rocky-9: 2024.1-rocky-9-20250408T133253
+    ubuntu-jammy: 2024.1-ubuntu-jammy-20250408T133253
+  skyline_console:
+    rocky-9: 2024.1-rocky-9-20250408T133253
+    ubuntu-jammy: 2024.1-ubuntu-jammy-20250408T133253

--- a/etc/kayobe/pulp.yml
+++ b/etc/kayobe/pulp.yml
@@ -536,8 +536,8 @@ stackhpc_pulp_images_kolla:
   - ovn-controller
   - ovn-nb-db-server
   - ovn-northd
-  - ovn-sb-db-server
   - ovn-sb-db-relay
+  - ovn-sb-db-server
   - placement-api
   - prometheus-alertmanager
   - prometheus-blackbox-exporter
@@ -554,6 +554,8 @@ stackhpc_pulp_images_kolla:
   - rabbitmq
   - redis
   - redis-sentinel
+  - skyline-apiserver
+  - skyline-console
 
 # List of images for each base distribution which should not/cannot be built.
 stackhpc_kolla_unbuildable_images:

--- a/etc/kayobe/trivy/allowed-vulnerabilities.yml
+++ b/etc/kayobe/trivy/allowed-vulnerabilities.yml
@@ -16,7 +16,8 @@ fluentd_allowed_vulnerabilities:
   - CVE-2024-27280
 grafana_allowed_vulnerabilities:
   - CVE-2024-8986
-
+skyline_apiserver_allowed_vulnerabilities:
+  - CVE-2024-33663
 
 ###############################################################################
 # Dummy variable to allow Ansible to accept this file.

--- a/releasenotes/notes/enable-building-skyline-61a41c13cfcd54a1.yaml
+++ b/releasenotes/notes/enable-building-skyline-61a41c13cfcd54a1.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Enable building of ``Skyline`` an alternative to ``Horizon``.
+


### PR DESCRIPTION
Customer(s) have requested and in some cases started deploying `Skyline` using upstream images. Before we can decide to support it we should be probably build the container images for testing and evaluation purposes.
