### PR TITLE
Fix kolla image build workflow for 2024.1

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -304,7 +304,7 @@ kolla_build_blocks:
   # With the UCA keyring installed we can now add all repos.
   base_ubuntu_package_sources_list: |
     {% if stackhpc_kolla_clean_up_repo_mirrors | bool %}
-    COPY sources.list.ubuntu /etc/apt/sources.list.backup
+    COPY sources.list.ubuntu.jammy /etc/apt/sources.list.backup
     {% endif %}
     RUN \
         rm /etc/apt/sources.list && \

--- a/releasenotes/notes/fix-2024.1-kolla-image-build-f78a5524381fa4da.yaml
+++ b/releasenotes/notes/fix-2024.1-kolla-image-build-f78a5524381fa4da.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fix Kolla container image build workflow failing to find default
+    sources.list.ubuntu.
+    The default sources.list for ubuntu now has each for Ubuntu Jammy and
+    Noble.
+    This upstream change was brought by `Ubuntu 24.04 support for Caracal
+    <https://review.opendev.org/c/openstack/kolla/+/932386>`__.


### PR DESCRIPTION
Kolla upstream change https://review.opendev.org/c/openstack/kolla/+/932386 brought Ubuntu 24.04 support for Caracal and split soruces.list.ubuntu to sources.list.ubuntu.jammy and sources.list.ubuntu.noble to cover each Ubuntu release.