### PR TITLE
Beokay usage documentation

### DIFF
--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -57,3 +57,51 @@ configuration:
 The intention is to avoid merge conflicts where possible, but there may be
 cases where this is difficult. We are open to discussion on how best to
 approach this on both sides.
+
+Beokay
+------
+
+`Beokay <https://github.com/stackhpc/beokay>` is a tool to help assist managing Kayobe
+environments. This can be utilised to help create new StackHPC Kayobe environments and
+ensure StackHPC Kayobe Configuration dependencies are from the correct repositories and
+are up-to-date:
+
+To create a Beokay environment using the base configuration, for the latest release:
+
+.. code-block:: console
+
+   beokay.py create \
+   --base-path skc-environment \
+   --kayobe-config-repo https://github.com/stackhpc/stackhpc-kayobe-config.git \
+   --kayobe-config-branch stackhpc/2024.1 \
+   --kayobe-in-requirements
+
+Kayobe environments can also be specified, for example, to create an AIO environment:
+
+.. code-block:: console
+
+   beokay.py create \
+   --base-path skc-aio-environment \
+   --kayobe-config-repo https://github.com/stackhpc/stackhpc-kayobe-config.git \
+   --kayobe-config-branch stackhpc/2024.1 \
+   --kayobe-config-env-name ci-aio \
+   --vault-password-file ~/vault-pw \
+   --kayobe-in-requirements
+
+When Beokay environments are no longer required, they can be deleted by running:
+
+.. code-block:: console
+
+   beokay.py destroy \
+   --base-path skc-environment
+
+Specific Kayobe commands can also be run via Beokay, for example, to run a Kolla
+service deployment on overcloud hosts:
+
+.. code-block:: console
+
+   beokay.py run \
+   'kayobe overcloud service deploy' \
+   --base-path skc-aio-environment \
+   --kayobe-config-env-name ci-aio \
+   --vault-password-file ~/vault-pw

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -83,7 +83,7 @@ Kayobe environments can also be specified, for example, to create an AIO environ
    beokay.py create \
    --base-path skc-aio-environment \
    --kayobe-config-repo https://github.com/stackhpc/stackhpc-kayobe-config.git \
-   --kayobe-config-branch stackhpc/2024.1 \
+   --kayobe-config-branch |current_release_git_branch_name| \
    --kayobe-config-env-name ci-aio \
    --vault-password-file ~/vault-pw \
    --kayobe-in-requirements

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -73,7 +73,7 @@ To create a Beokay environment using the base configuration, for the latest rele
    beokay.py create \
    --base-path skc-environment \
    --kayobe-config-repo https://github.com/stackhpc/stackhpc-kayobe-config.git \
-   --kayobe-config-branch stackhpc/2024.1 \
+   --kayobe-config-branch |current_release_git_branch_name| \
    --kayobe-in-requirements
 
 Kayobe environments can also be specified, for example, to create an AIO environment:

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -61,8 +61,8 @@ approach this on both sides.
 Beokay
 ------
 
-`Beokay <https://github.com/stackhpc/beokay>` is a tool to help assist managing Kayobe
-environments. This can be utilised to help create new StackHPC Kayobe environments and
+`Beokay <https://github.com/stackhpc/beokay>` is a tool to manage Kayobe
+environments. This can create new StackHPC Kayobe environments and
 ensure StackHPC Kayobe Configuration dependencies are from the correct repositories and
 are up-to-date:
 


### PR DESCRIPTION
Documentation for setting up and managing SKC environments, mainly to be used to ensure Kayobe is installed via SKC requirements.