### PR TITLE
Fix playbook failure due to invalid escaped character

### DIFF
--- a/etc/kayobe/ansible/rabbitmq-reset.yml
+++ b/etc/kayobe/ansible/rabbitmq-reset.yml
@@ -31,7 +31,7 @@
       register: inspection
 
     - name: Ensure the {{ container_name }} container is running
-      ansible.builtin.command: systemctl start kolla-{{ container_name }}-container.service  # noqa command-instead-of-module
+      ansible.builtin.command: systemctl start kolla-{{ container_name }}-container.service # noqa command-instead-of-module
       when: inspection.stdout == 'false'
 
     - name: Wait for the {{ container_name }} container to reach state 'Running'
@@ -70,7 +70,8 @@
       ansible.builtin.shell:
         cmd: >-
           set -o pipefail &&
-          systemctl -a | egrep 'kolla-(barbican|blazar|cinder|cloudkitty|designate|heat|ironic|keystone|magnum|manila|neutron|nova|octavia)' |
+          systemctl list-units --type=service --all --no-legend --plain |
+          egrep 'kolla-(barbican|blazar|cinder|cloudkitty|designate|heat|ironic|keystone|magnum|manila|neutron|nova|octavia)' |
           awk '{ print $1 }' |
-          xargs systemctl restart
+          xargs -r systemctl restart
         executable: "/bin/bash"


### PR DESCRIPTION
The playbook was failing when attempting to restart OpenStack services because of an invalid escaped character in the command that lists and restarts services. The original implementation used a shorthand systemctl flag (-a) along with a regular expression for egrep, which led to improper parsing and execution issues during the playbook run.

This PR replaces the shorthand with a more explicit invocation that is confirmed to run without error:
- Uses "systemctl list-units --type=service --all --no-legend --plain" to reliably list service units.
- Adds the "-r" flag to xargs to avoid running systemctl restart without input, ensuring more predictable behavior.

Note: This bug may be specific to hosts running Ubuntu Jammy