### PR TITLE
Fix RADOS gateway usage exporter deployment

### DIFF
--- a/etc/kayobe/ansible/deploy-radosgw-usage-exporter.yml
+++ b/etc/kayobe/ansible/deploy-radosgw-usage-exporter.yml
@@ -66,7 +66,7 @@
           vars:
             ansible_host: "{{ hostvars[groups['controllers'][0]].ansible_host }}"
           run_once: true
-          when: credential_check.stdout == []
+          when: credential_check.stdout | from_json == []
 
         - name: Query ec2 credential for ceph_rgw
           ansible.builtin.command: >

--- a/etc/kayobe/ansible/deploy-radosgw-usage-exporter.yml
+++ b/etc/kayobe/ansible/deploy-radosgw-usage-exporter.yml
@@ -115,6 +115,7 @@
               ACCESS_KEY: "{{ ec2.Access }}"
               SECRET_KEY: "{{ ec2.Secret }}"
               VIRTUAL_PORT: "{{ stackhpc_radosgw_usage_exporter_port | string }}"
+              REQUESTS_CA_BUNDLE: "/etc/ssl/certs/ca-certificates.crt"
             entrypoint: "{{ ['python', '-u', './radosgw_usage_exporter.py', '--insecure'] if not stackhpc_radosgw_usage_exporter_verify else omit }}"
           vars:
             ec2: "{{ credential.stdout | from_json | first }}"

--- a/releasenotes/notes/rgw-usage-exporter-deployment-fixes-0196167326dbe456.yaml
+++ b/releasenotes/notes/rgw-usage-exporter-deployment-fixes-0196167326dbe456.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed RADOS gateway usage exporter deployment failing
+    to generate ec2 credentials for the ceph_rgw user.
+  - |
+    Fixed RADOS gateway usage exporter not using the system
+    trust root as its CA bundle.


### PR DESCRIPTION
credential_check.stdout is a string representation of a list, and as such will never return true when compared to an empty Python list.

Passing credential_check.stdout through the from_json filter casts the string to a list, and the equality can be properly evaluated.