### PR TITLE
Fix Ceph release conditional

### DIFF
--- a/etc/kayobe/cephadm.yml
+++ b/etc/kayobe/cephadm.yml
@@ -3,7 +3,7 @@
 # Cephadm deployment configuration.
 
 # Ceph release name.
-cephadm_ceph_release: "{{ 'squid' if (ansible_facts['distribution_release'] == 'noble') else 'reef' }}"
+cephadm_ceph_release: "{{ 'squid' if os_release == 'noble' else 'reef' }}"
 
 # Ceph FSID.
 #cephadm_fsid:

--- a/releasenotes/notes/fix-cephadm-facts-2ee6dc9a1c617944.yaml
+++ b/releasenotes/notes/fix-cephadm-facts-2ee6dc9a1c617944.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    The Ceph version is now determined by ``os_release``, rather
+    than Ansible facts. Using Ansible facts caused playbooks to fail when
+    facts are not gathered. 


### PR DESCRIPTION
The Cephadm release version is now determined by `os_release`, than Ansible Facts.
Using Ansible facts caused playbooks to fail when facts are not gathered. 