### PR TITLE
feat: `lint` and `tox` run before `AIO` tests

### DIFF
--- a/.github/workflows/stackhpc-pull-request.yml
+++ b/.github/workflows/stackhpc-pull-request.yml
@@ -18,6 +18,9 @@ jobs:
       pull-requests: read
     name: Check changed files
     if: github.repository == 'stackhpc/stackhpc-kayobe-config'
+    needs:
+      - lint
+      - tox
     outputs:
       aio: ${{ steps.changes.outputs.aio }}
       build-kayobe-image: ${{ steps.changes.outputs.build-kayobe-image }}


### PR DESCRIPTION
Avoid running more resource intensive tests before linting and unit tests. As subsequent patches to fix linting and tox issues will require running AIOs again.

<img width="1212" alt="image" src="https://github.com/user-attachments/assets/f3fcbdee-5041-4f8b-a34d-33376c1880fa" />
