### PR TITLE
Update to Prometheus v3

### DIFF
--- a/.github/workflows/stackhpc-pull-request.yml
+++ b/.github/workflows/stackhpc-pull-request.yml
@@ -69,9 +69,9 @@ jobs:
       matrix:
         include:
           # NOTE(upgrade): Keep these in sync with Kayobe's supported Ansible and Python versions (see release notes).
-          - ansible: "2.17"
+          - ansible: "2.18"
             python: "3.12"
-          - ansible: "2.16"
+          - ansible: "2.17"
             python: "3.10"
     name: Ansible ${{ matrix.ansible }} lint with Python ${{ matrix.python }}
     if: github.repository == 'stackhpc/stackhpc-kayobe-config'

--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -13,3 +13,6 @@ kolla_image_tags:
   ovn_sb_db_relay:
     rocky-9: master-rocky-9-20250305T111730
     ubuntu-noble: master-ubuntu-noble-20250305T111730
+  prometheus:
+    rocky-9: master-rocky-9-20250430T112026
+    ubuntu-noble: master-ubuntu-noble-20250430T112026

--- a/etc/kayobe/pulp.yml
+++ b/etc/kayobe/pulp.yml
@@ -526,7 +526,7 @@ stackhpc_pulp_images_kolla:
   - prometheus-mysqld-exporter
   - prometheus-node-exporter
   - prometheus-openstack-exporter
-  - prometheus-v2-server
+  - prometheus-server
   - proxysql
   - rabbitmq
   - redis

--- a/etc/kayobe/trivy/allowed-vulnerabilities.yml
+++ b/etc/kayobe/trivy/allowed-vulnerabilities.yml
@@ -14,9 +14,27 @@
 #   - CVE-2023-31047
 fluentd_allowed_vulnerabilities:
   - CVE-2024-27280
+
 grafana_allowed_vulnerabilities:
   - CVE-2024-8986
 
+prometheus_blackbox_exporter_allowed_vulnerabilities:
+  - CVE-2024-45337
+prometheus_memcached_exporter_allowed_vulnerabilities:
+  - CVE-2024-45337
+prometheus_mysqld_exporter_allowed_vulnerabilities:
+  - CVE-2024-45337
+prometheus_elasticsearch_exporter_allowed_vulnerabilities:
+  - CVE-2024-45337
+prometheus_node_exporter_allowed_vulnerabilities:
+  - CVE-2024-45337
+prometheus_openstack_exporter_allowed_vulnerabilities:
+  - CVE-2024-45337
+prometheus_libvirt_exporter_allowed_vulnerabilities:
+  - CVE-2024-45337
+prometheus_cadvisor_allowed_vulnerabilities:
+  - CVE-2024-41110
+  - CVE-2024-45337
 
 ###############################################################################
 # Dummy variable to allow Ansible to accept this file.

--- a/releasenotes/notes/prometheus-v3-68fd3d9d6cf3e420.yaml
+++ b/releasenotes/notes/prometheus-v3-68fd3d9d6cf3e420.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Bumps the Prometheus container images to bring in Prometheus v3.

--- a/tools/kolla-images.py
+++ b/tools/kolla-images.py
@@ -72,7 +72,7 @@ IMAGE_TO_CONTAINERS_EXCEPTIONS: Dict[str, List[str]] = {
     "ovn-sb-db-server": [
         "ovn_sb_db",
     ],
-    "prometheus-v2-server": [
+    "prometheus-server": [
         "prometheus_server",
     ],
 }


### PR DESCRIPTION
With Kolla bumping Promtheus to v3, the v2 name has been dropped. Updates our tooling to reflect that.