### PR TITLE
Share built image with other projects

### DIFF
--- a/.github/workflows/overcloud-host-image-build.yml
+++ b/.github/workflows/overcloud-host-image-build.yml
@@ -280,6 +280,7 @@ jobs:
           CLOUDS_YAML: ${{ secrets.CLOUDS_YAML }}
           OS_APPLICATION_CREDENTIAL_ID: ${{ secrets.OS_APPLICATION_CREDENTIAL_ID }}
           OS_APPLICATION_CREDENTIAL_SECRET: ${{ secrets.OS_APPLICATION_CREDENTIAL_SECRET }}
+          HOST_IMAGE_BUILD_SHARE_PROJECT_ID: ${{ vars.HOST_IMAGE_BUILD_SHARE_PROJECT_ID }}
         if: inputs.rocky9 && steps.build_rocky_9.outcome == 'success'
 
       - name: Upload Rocky Linux 9 overcloud host image to other Dev Cloud (Leafcloud/SMS)
@@ -294,6 +295,7 @@ jobs:
           CLOUDS_YAML: ${{ secrets.CLOUDS_YAML_OTHER_CLOUD }}
           OS_APPLICATION_CREDENTIAL_ID: ${{ secrets.OS_APPLICATION_CREDENTIAL_ID_OTHER_CLOUD }}
           OS_APPLICATION_CREDENTIAL_SECRET: ${{ secrets.OS_APPLICATION_CREDENTIAL_SECRET_OTHER_CLOUD }}
+          HOST_IMAGE_BUILD_SHARE_PROJECT_ID: ${{ vars.HOST_IMAGE_BUILD_SHARE_PROJECT_ID_OTHER_CLOUD }}
         if: inputs.rocky9 && steps.build_rocky_9.outcome == 'success'
 
       - name: Build an Ubuntu Jammy 22.04 overcloud host image
@@ -348,6 +350,7 @@ jobs:
           CLOUDS_YAML: ${{ secrets.CLOUDS_YAML }}
           OS_APPLICATION_CREDENTIAL_ID: ${{ secrets.OS_APPLICATION_CREDENTIAL_ID }}
           OS_APPLICATION_CREDENTIAL_SECRET: ${{ secrets.OS_APPLICATION_CREDENTIAL_SECRET }}
+          HOST_IMAGE_BUILD_SHARE_PROJECT_ID: ${{ vars.HOST_IMAGE_BUILD_SHARE_PROJECT_ID }}
         if: inputs.ubuntu-jammy && steps.build_ubuntu_jammy.outcome == 'success'
 
       - name: Upload Ubuntu Jammy overcloud host image to other Dev Cloud (Leafcloud/SMS)
@@ -362,6 +365,7 @@ jobs:
           CLOUDS_YAML: ${{ secrets.CLOUDS_YAML_OTHER_CLOUD }}
           OS_APPLICATION_CREDENTIAL_ID: ${{ secrets.OS_APPLICATION_CREDENTIAL_ID_OTHER_CLOUD }}
           OS_APPLICATION_CREDENTIAL_SECRET: ${{ secrets.OS_APPLICATION_CREDENTIAL_SECRET_OTHER_CLOUD }}
+          HOST_IMAGE_BUILD_SHARE_PROJECT_ID: ${{ vars.HOST_IMAGE_BUILD_SHARE_PROJECT_ID_OTHER_CLOUD }}
         if: inputs.ubuntu-jammy && steps.build_ubuntu_jammy.outcome == 'success'
 
       - name: Build an Ubuntu Noble 24.04 overcloud host image
@@ -416,6 +420,7 @@ jobs:
           CLOUDS_YAML: ${{ secrets.CLOUDS_YAML }}
           OS_APPLICATION_CREDENTIAL_ID: ${{ secrets.OS_APPLICATION_CREDENTIAL_ID }}
           OS_APPLICATION_CREDENTIAL_SECRET: ${{ secrets.OS_APPLICATION_CREDENTIAL_SECRET }}
+          HOST_IMAGE_BUILD_SHARE_PROJECT_ID: ${{ vars.HOST_IMAGE_BUILD_SHARE_PROJECT_ID }}
         if: inputs.ubuntu-noble && steps.build_ubuntu_noble.outcome == 'success'
 
       - name: Upload Ubuntu Noble overcloud host image to other Dev Cloud (Leafcloud/SMS)
@@ -430,6 +435,7 @@ jobs:
           CLOUDS_YAML: ${{ secrets.CLOUDS_YAML_OTHER_CLOUD }}
           OS_APPLICATION_CREDENTIAL_ID: ${{ secrets.OS_APPLICATION_CREDENTIAL_ID_OTHER_CLOUD }}
           OS_APPLICATION_CREDENTIAL_SECRET: ${{ secrets.OS_APPLICATION_CREDENTIAL_SECRET_OTHER_CLOUD }}
+          HOST_IMAGE_BUILD_SHARE_PROJECT_ID: ${{ vars.HOST_IMAGE_BUILD_SHARE_PROJECT_ID_OTHER_CLOUD }}
         if: inputs.ubuntu-noble && steps.build_ubuntu_noble.outcome == 'success'
 
 

--- a/etc/kayobe/ansible/openstack-host-image-upload.yml
+++ b/etc/kayobe/ansible/openstack-host-image-upload.yml
@@ -43,16 +43,20 @@
             state: present
             filename: "{{ local_image_path }}"
             visibility: shared
-            register: image
+          register: image
 
         - name: Ensure dependencies are installed
           pip:
             name: python-openstackclient
             virtualenv: "{{ ansible_python_interpreter | dirname | dirname }}"
 
-        # Allow users in stackhpc-aufn to use these images.
+        # Add the image to the chosen project
         - name: Add image to stackhpc-dev project
-          command: openstack image add project {{ image.image.id }} 3d279fd978df4b18b2174cf336f25c9b
+          command: "{{ ansible_python_interpreter | dirname | dirname }}/bin/openstack image add project {{ image.image.id }} '{{ lookup('ansible.builtin.env', 'HOST_IMAGE_BUILD_SHARE_PROJECT_ID') }}'"
+
+        # Accept the image in the receiving project
+        - name: Accept image membership in stackhpc-dev project
+          command: "{{ ansible_python_interpreter | dirname | dirname }}/bin/openstack image set {{ image.image.id }} --project '{{ lookup('ansible.builtin.env', 'HOST_IMAGE_BUILD_SHARE_PROJECT_ID') }}' --accept"
 
       always:
         - name: Remove clouds.yaml

--- a/etc/kayobe/ansible/openstack-host-image-upload.yml
+++ b/etc/kayobe/ansible/openstack-host-image-upload.yml
@@ -32,7 +32,9 @@
 
         - name: Ensure dependencies are installed
           ansible.builtin.pip:
-            name: openstacksdk
+            name:
+              - openstacksdk
+              - python-openstackclient
 
         - name: Upload an image to Glance
           openstack.cloud.image:
@@ -45,18 +47,13 @@
             visibility: shared
           register: image
 
-        - name: Ensure dependencies are installed
-          pip:
-            name: python-openstackclient
-            virtualenv: "{{ ansible_python_interpreter | dirname | dirname }}"
-
         # Add the image to the chosen project
         - name: Add image to stackhpc-dev project
-          command: "{{ ansible_python_interpreter | dirname | dirname }}/bin/openstack image add project {{ image.image.id }} '{{ lookup('ansible.builtin.env', 'HOST_IMAGE_BUILD_SHARE_PROJECT_ID') }}'"
+          ansible.builtin.command: "openstack image add project {{ image.image.id }} '{{ lookup('ansible.builtin.env', 'HOST_IMAGE_BUILD_SHARE_PROJECT_ID') }}'"
 
         # Accept the image in the receiving project
         - name: Accept image membership in stackhpc-dev project
-          command: "{{ ansible_python_interpreter | dirname | dirname }}/bin/openstack image set {{ image.image.id }} --project '{{ lookup('ansible.builtin.env', 'HOST_IMAGE_BUILD_SHARE_PROJECT_ID') }}' --accept"
+          ansible.builtin.command: "openstack image set {{ image.image.id }} --project '{{ lookup('ansible.builtin.env', 'HOST_IMAGE_BUILD_SHARE_PROJECT_ID') }}' --accept"
 
       always:
         - name: Remove clouds.yaml

--- a/etc/kayobe/ansible/openstack-host-image-upload.yml
+++ b/etc/kayobe/ansible/openstack-host-image-upload.yml
@@ -42,6 +42,17 @@
             disk_format: qcow2
             state: present
             filename: "{{ local_image_path }}"
+            visibility: shared
+            register: image
+
+        - name: Ensure dependencies are installed
+          pip:
+            name: python-openstackclient
+            virtualenv: "{{ ansible_python_interpreter | dirname | dirname }}"
+
+        # Allow users in stackhpc-aufn to use these images.
+        - name: Add image to stackhpc-dev project
+          command: openstack image add project {{ image.image.id }} 3d279fd978df4b18b2174cf336f25c9b
 
       always:
         - name: Remove clouds.yaml


### PR DESCRIPTION
In addition to uploading the image to both SMS and LeafCloud this PR enables the images to be shared between the current CI Project and the project ID provided as environment variables ``HOST_IMAGE_BUILD_SHARE_PROJECT_ID`` & ``HOST_IMAGE_BUILD_SHARE_PROJECT_ID_OTHER_CLOUD``.