### PR TITLE
CI: Remove Ubuntu OVS, add RL9 OVS upgrade cases

### DIFF
--- a/.github/workflows/stackhpc-pull-request.yml
+++ b/.github/workflows/stackhpc-pull-request.yml
@@ -130,23 +130,6 @@ jobs:
     secrets: inherit
     if: ${{ ! failure() && ! cancelled() && github.repository == 'stackhpc/stackhpc-kayobe-config' }}
 
-  all-in-one-ubuntu-jammy-ovs:
-    name: aio (Ubuntu Jammy OVS)
-    needs:
-      - check-changes
-      - build-kayobe-image
-    uses: ./.github/workflows/stackhpc-all-in-one.yml
-    with:
-      kayobe_image: ${{ needs.build-kayobe-image.outputs.kayobe_image }}
-      os_distribution: ubuntu
-      os_release: jammy
-      ssh_username: ubuntu
-      neutron_plugin: ovs
-      OS_CLOUD: openstack
-      if: ${{ needs.check-changes.outputs.aio == 'true' }}
-    secrets: inherit
-    if: ${{ ! failure() && ! cancelled() && github.repository == 'stackhpc/stackhpc-kayobe-config' }}
-
   all-in-one-ubuntu-jammy-ovn:
     name: aio (Ubuntu Jammy OVN)
     needs:
@@ -159,23 +142,6 @@ jobs:
       os_release: jammy
       ssh_username: ubuntu
       neutron_plugin: ovn
-      OS_CLOUD: openstack
-      if: ${{ needs.check-changes.outputs.aio == 'true' }}
-    secrets: inherit
-    if: ${{ ! failure() && ! cancelled() && github.repository == 'stackhpc/stackhpc-kayobe-config' }}
-
-  all-in-one-ubuntu-noble-ovs:
-    name: aio (Ubuntu Noble OVS)
-    needs:
-      - check-changes
-      - build-kayobe-image
-    uses: ./.github/workflows/stackhpc-all-in-one.yml
-    with:
-      kayobe_image: ${{ needs.build-kayobe-image.outputs.kayobe_image }}
-      os_distribution: ubuntu
-      os_release: noble
-      ssh_username: ubuntu
-      neutron_plugin: ovs
       OS_CLOUD: openstack
       if: ${{ needs.check-changes.outputs.aio == 'true' }}
     secrets: inherit
@@ -232,10 +198,10 @@ jobs:
     secrets: inherit
     if: ${{ ! failure() && ! cancelled() && github.repository == 'stackhpc/stackhpc-kayobe-config' }}
 
-  # Test two upgrade scenarios: Ubuntu Jammy OVS and Rocky 9 OVN.
+  # Test upgrade scenarios
 
-  all-in-one-upgrade-ubuntu-jammy-ovs:
-    name: aio upgrade (Ubuntu Jammy OVS)
+  all-in-one-upgrade-ubuntu-jammy-ovn:
+    name: aio upgrade (Ubuntu Jammy OVN)
     needs:
       - check-changes
       - build-kayobe-image
@@ -245,7 +211,7 @@ jobs:
       os_distribution: ubuntu
       os_release: jammy
       ssh_username: ubuntu
-      neutron_plugin: ovs
+      neutron_plugin: ovn
       OS_CLOUD: openstack
       if: ${{ needs.check-changes.outputs.aio == 'true' }}
       upgrade: true
@@ -264,6 +230,24 @@ jobs:
       os_release: "9"
       ssh_username: cloud-user
       neutron_plugin: ovn
+      OS_CLOUD: openstack
+      if: ${{ needs.check-changes.outputs.aio == 'true' }}
+      upgrade: true
+    secrets: inherit
+    if: ${{ ! failure() && ! cancelled() && github.repository == 'stackhpc/stackhpc-kayobe-config' }}
+
+  all-in-one-upgrade-rocky-9-ovs:
+    name: aio upgrade (Rocky 9 OVS)
+    needs:
+      - check-changes
+      - build-kayobe-image
+    uses: ./.github/workflows/stackhpc-all-in-one.yml
+    with:
+      kayobe_image: ${{ needs.build-kayobe-image.outputs.kayobe_image }}
+      os_distribution: rocky
+      os_release: "9"
+      ssh_username: cloud-user
+      neutron_plugin: ovs
       OS_CLOUD: openstack
       if: ${{ needs.check-changes.outputs.aio == 'true' }}
       upgrade: true


### PR DESCRIPTION
Ubuntu OVS jobs are being removed as we no longer have any clients with Ubuntu OVS systems.
Since we are removing some jobs, we can add in a RL9 OVS upgrade task without increasing resource usage.