### PR TITLE
Rebuild kolla container images for Ubuntu Noble

### DIFF
--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -9,6 +9,8 @@ kolla_image_tags:
     ubuntu-noble: master-ubuntu-noble-20250509T092545
   bifrost_deploy:
     rocky-9: master-rocky-9-20250219T145044
+  mariadb:
+    ubuntu-noble: master-ubuntu-noble-20250513T135603
   ovn_sb_db_relay:
     rocky-9: master-rocky-9-20250305T111730
   prometheus:

--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -19,3 +19,4 @@ kolla_image_tags:
     rocky-9: master-rocky-9-20250502T080944
   skyline:
     rocky-9: master-rocky-9-20250425T091159
+    ubuntu-noble: master-ubuntu-noble-20250425T091159

--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -6,19 +6,14 @@
 kolla_image_tags:
   openstack:
     rocky-9: master-rocky-9-20250213T114650
-    ubuntu-noble: master-ubuntu-noble-20250213T091307
+    ubuntu-noble: master-ubuntu-noble-20250509T092545
   bifrost_deploy:
     rocky-9: master-rocky-9-20250219T145044
-    ubuntu-noble: master-ubuntu-noble-20250219T145044
   ovn_sb_db_relay:
     rocky-9: master-rocky-9-20250305T111730
-    ubuntu-noble: master-ubuntu-noble-20250305T111730
   prometheus:
     rocky-9: master-rocky-9-20250430T112026
-    ubuntu-noble: master-ubuntu-noble-20250430T112026
   rabbitmq:
     rocky-9: master-rocky-9-20250502T080944
-    ubuntu-noble: master-ubuntu-noble-20250502T080944
   skyline:
     rocky-9: master-rocky-9-20250425T091159
-    ubuntu-noble: master-ubuntu-noble-20250425T091159


### PR DESCRIPTION
Previous images are too old that they cause downgrade of dependencies when performing upgrading from Caracal.