### PR TITLE
Fix PCI passthrough default templates

### DIFF
--- a/etc/kayobe/ansible/pci-passthrough.yml
+++ b/etc/kayobe/ansible/pci-passthrough.yml
@@ -11,7 +11,7 @@
     vfio_pci_ids: |-
       {% set gpu_list = [] %}
       {% set output = [] %}
-      {% for gpu_group in gpu_group_map | dict2items | default([]) %}
+      {% for gpu_group in (gpu_group_map | default({})) | dict2items %}
       {% if gpu_group.key in group_names %}
       {% set _ = gpu_list.append(gpu_group.value) %}
       {% endif %}

--- a/etc/kayobe/kolla/config/nova/nova-api.conf
+++ b/etc/kayobe/kolla/config/nova/nova-api.conf
@@ -1,4 +1,4 @@
 [pci]
-{% for item in gpu_group_map | dict2items | map(attribute='value') | flatten | unique | list %}
+{% for item in (gpu_group_map | default({})) | dict2items | map(attribute='value') | flatten | unique | list %}
 alias = { "vendor_id":"{{ stackhpc_gpu_data[item].vendor_id }}", "product_id":"{{ stackhpc_gpu_data[item].product_id }}", "device_type":"{{ stackhpc_gpu_data[item].device_type }}", "name":"{{ stackhpc_gpu_data[item].resource_name }}" }
 {% endfor %}

--- a/etc/kayobe/kolla/config/nova/nova-compute.conf
+++ b/etc/kayobe/kolla/config/nova/nova-compute.conf
@@ -1,7 +1,7 @@
 [pci]
 {% raw %}
 {% set gpu_list = [] %}
-{% for gpu_group in gpu_group_map | dict2items | default([]) %}
+{% for gpu_group in (gpu_group_map | default({})) | dict2items %}
 {% if gpu_group.key in group_names %}
 {% set _ = gpu_list.append(gpu_group.value) %}
 {% endif %}

--- a/releasenotes/notes/fix-pci-default-template-8660ab2a7a106376.yaml
+++ b/releasenotes/notes/fix-pci-default-template-8660ab2a7a106376.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixes possible templating error with PCI passthrough configuration.


### PR DESCRIPTION
Even though the variable ``gpu_group_map`` has default value of {} defined at stackhpc-compute.yml, it can be set to anything by users. Therefore, Using dict2items filter with it can cause unexpected templating error.

Fixing this by setting {} as a default of ``gpu_group_map`` before using dict2items filter.
So even if ``gpu_group_map`` becomes undefined for some reason, it doesn't fail in run time.