### PR TITLE
CI: Replace next_nth_usable with FQCN

### DIFF
--- a/etc/kayobe/environments/ci-multinode/inventory/group_vars/all/vxlan.yml
+++ b/etc/kayobe/environments/ci-multinode/inventory/group_vars/all/vxlan.yml
@@ -15,4 +15,4 @@ vxlan_vni:
 # This is a dictionary of interfaces to be created by the stackhpc.vxlan role.
 vxlan_interfaces:
   - device: "vxlan{{ vxlan_vni }}"
-    group: "{{ '239.0.0.0/8' | next_nth_usable(vxlan_vni) }}"
+    group: "{{ '239.0.0.0/8' | ansible.utils.next_nth_usable(vxlan_vni) }}"


### PR DESCRIPTION
Ansible Netcommon 8.0.0 dropped support for next_nth_usable, which must now come from ansible.utils.