### PR TITLE
CI: Avoid dependency updates in forks

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   propose_github_release_updates:
+    if: github.repository == 'stackhpc/stackhpc-kayobe-config'
     runs-on: ubuntu-22.04
     strategy:
       matrix:


### PR DESCRIPTION
This workflow currently runs in any customer repository hosted on GitHub. Restrict this workflow to stackhpc like the other ones.