### PR TITLE
Manually set openstack_release to master for stackhpc/master

### DIFF
--- a/etc/kayobe/openstack.yml
+++ b/etc/kayobe/openstack.yml
@@ -2,14 +2,16 @@
 ###############################################################################
 # OpenStack release configuration.
 
-# Name of the current OpenStack release. Default is "master".
-#openstack_release:
+# Name of the current OpenStack release. Default is "2025.1".
+openstack_release: master
 
 # Codename of the current OpenStack release.
 # NOTE(upgrade): Update to current release codename.
 openstack_release_codename: "epoxy"
 
-# Name of the current OpenStack branch. Default is "master".
+# Name of the current OpenStack branch. Default is "master" if
+# openstack_release is "master".
+# Otherwise, the default is "stable/{{ openstack_release }}".
 #openstack_branch:
 
 ###############################################################################


### PR DESCRIPTION
With the Kayobe 2025.1 release [1], openstack_release is no longer "master" by default

[1] https://review.opendev.org/c/openstack/kayobe/+/949499