### PR TITLE
Remove undefined Swift variables

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -728,9 +728,6 @@ kolla_enable_prometheus: true
 #kolla_enable_rabbitmq:
 #kolla_enable_redis:
 #kolla_enable_skyline:
-#kolla_enable_swift:
-#kolla_enable_swift_recon:
-#kolla_enable_swift_s3api:
 #kolla_enable_tacker:
 #kolla_enable_telegraf:
 #kolla_enable_trove:

--- a/etc/kayobe/kolla/inventory/group_vars/prometheus-blackbox-exporter
+++ b/etc/kayobe/kolla/inventory/group_vars/prometheus-blackbox-exporter
@@ -62,5 +62,3 @@ stackhpc_prometheus_blackbox_exporter_endpoints_default:
     enabled: "{{ enable_ironic | bool }}"
   - endpoints: "{% set ironic_inspector_endpoints = [] %}{% for host in groups.get('ironic-inspector', []) %}{{ ironic_inspector_endpoints.append('ironic_inspector_backend_' + host.replace('-', '') + ':os_endpoint:' + 'http://' + ('api' | kolla_address(host) | put_address_in_context('url')) + ':' + hostvars[host]['ironic_inspector_port']) }}{% endfor %}{{ ironic_inspector_endpoints }}"
     enabled: "{{ enable_ironic | bool }}"
-  - endpoints: "{% set swift_endpoints = [] %}{% for host in groups.get('swift-api', []) %}{{ swift_endpoints.append('swift_backend_' + host.replace('-', '') + ':os_endpoint:' + 'http://' + ('api' | kolla_address(host) | put_address_in_context('url')) + ':' + hostvars[host]['swift_api_port']) }}{% endfor %}{{ swift_endpoints }}"
-    enabled: "{{ enable_swift | bool }}"


### PR DESCRIPTION
Kolla ansible dropped Swift support since [1].
The variable ``enable_swift`` will not be generated from
``kolla_enable_swift``.

[1] https://review.opendev.org/c/openstack/kolla-ansible/+/945113