### PR TITLE
CI: Add upstream-sync workflow

### DIFF
--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -1,0 +1,34 @@
+---
+name: Upstream Sync
+'on':
+  schedule:
+    - cron: "15 8 * * 1"
+  workflow_dispatch:
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  synchronise-2023-1:
+    if: github.repository == 'stackhpc/stackhpc-kayobe-config'
+    name: Synchronise 2023.1
+    uses: stackhpc/.github/.github/workflows/upstream-sync.yml@main
+    with:
+      release_series: 2023.1
+  synchronise-2024-1:
+    if: github.repository == 'stackhpc/stackhpc-kayobe-config'
+    name: Synchronise 2024.1
+    uses: stackhpc/.github/.github/workflows/upstream-sync.yml@main
+    with:
+      release_series: 2024.1
+  synchronise-2025.1:
+    if: github.repository == 'stackhpc/stackhpc-kayobe-config'
+    name: Synchronise 2025.1
+    uses: stackhpc/.github/.github/workflows/upstream-sync.yml@main
+    with:
+      release_series: 2025.1
+  synchronise-master:
+    if: github.repository == 'stackhpc/stackhpc-kayobe-config'
+    name: Synchronise master
+    uses: stackhpc/.github/.github/workflows/upstream-sync.yml@main
+    with:
+      release_series: master


### PR DESCRIPTION
We tried adding upstream-sync using stackhpc-release-train [1], but the workflow addition is skipped because our default branch is a StackHPC release branch [2].

Add workflow manually to synchronise releases that still exist upstream.

[1] https://github.com/stackhpc/stackhpc-release-train/pull/410
[2] https://github.com/stackhpc/stackhpc-release-train/commit/49c06d14375a90a61af7d4a4cb765111c1e6b7b3