### PR TITLE
Add an option to append content to Ceph configs

### DIFF
--- a/etc/kayobe/ansible/cephadm-gather-keys.yml
+++ b/etc/kayobe/ansible/cephadm-gather-keys.yml
@@ -68,6 +68,7 @@
         # Kolla Ansible's merge_configs module does not like the leading tabs in ceph.conf.
         content: |
           {{ cephadm_ceph_conf.stdout | regex_replace('\t') }}
+          {{ kolla_ceph_conf_append if kolla_ceph_conf_append is defined }}
         dest: "{{ kayobe_env_config_path }}/kolla/config/{{ kolla_service_to_conf_dir[item.0.name] }}/ceph.conf"
       loop: "{{ query('subelements', kolla_ceph_services | selectattr('required'), 'keys') }}"
       loop_control:

--- a/etc/kayobe/cephadm.yml
+++ b/etc/kayobe/cephadm.yml
@@ -136,3 +136,6 @@ kolla_ceph_manila_required: "{{ kolla_enable_manila | bool }}"
 
 # Whether to generate Ceph configuration for Nova.
 kolla_ceph_nova_required: "{{ kolla_enable_nova | bool }}"
+
+# A (multiline) string to append to all Ceph configuration files.
+#kolla_ceph_conf_append:

--- a/releasenotes/notes/ceph-config-append-1cc6146d3241b63e.yaml
+++ b/releasenotes/notes/ceph-config-append-1cc6146d3241b63e.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Add ``kolla_ceph_conf_append`` configuration option to specify a string
+    to be appended to all ceph.conf files gathered from a ceph cluster using
+    ``kayobe playbook run $KAYOBE_CONFIG_PATH/ansible/cephadm-gather-keys.yml``.


### PR DESCRIPTION
Adds the `kolla_ceph_conf_append` config option to allow the specification of a string to append to all Ceph config files retrieved using the `cephadm-gather-keys.yml` playbook.