### PR TITLE
CI: Configure upstream repository to use for sync

### DIFF
--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -14,21 +14,25 @@ jobs:
     uses: stackhpc/.github/.github/workflows/upstream-sync.yml@main
     with:
       release_series: 2023.1
+      upstream: openstack/kayobe-config
   synchronise-2024-1:
     if: github.repository == 'stackhpc/stackhpc-kayobe-config'
     name: Synchronise 2024.1
     uses: stackhpc/.github/.github/workflows/upstream-sync.yml@main
     with:
       release_series: 2024.1
+      upstream: openstack/kayobe-config
   synchronise-2025-1:
     if: github.repository == 'stackhpc/stackhpc-kayobe-config'
     name: Synchronise 2025.1
     uses: stackhpc/.github/.github/workflows/upstream-sync.yml@main
     with:
       release_series: 2025.1
+      upstream: openstack/kayobe-config
   synchronise-master:
     if: github.repository == 'stackhpc/stackhpc-kayobe-config'
     name: Synchronise master
     uses: stackhpc/.github/.github/workflows/upstream-sync.yml@main
     with:
       release_series: master
+      upstream: openstack/kayobe-config


### PR DESCRIPTION
This requires https://github.com/stackhpc/.github/pull/55 to merge.