### PR TITLE
feat: add `stack` user for `Pulp`

### DIFF
--- a/doc/source/configuration/release-train.rst
+++ b/doc/source/configuration/release-train.rst
@@ -52,16 +52,29 @@ The Pulp container is deployed on the seed by default, but may be disabled by
 setting ``seed_pulp_container_enabled`` to ``false`` in
 ``etc/kayobe/seed.yml``.
 
-The URL and credentials of the local Pulp server are configured in
-``etc/kayobe/pulp.yml`` via ``pulp_url``, ``pulp_username`` and
-``pulp_password``. In most cases, the default values should be sufficient.
-An admin password must be generated and set as the value of a
-``secrets_pulp_password`` variable, typically in an Ansible Vault encrypted
-``etc/kayobe/secrets.yml`` file. This password will be automatically set on
-Pulp startup.
+The URL for the local Pulp server is configured by ``pulp_url`` within
+``etc/kayobe/pulp.yml``.
 
-If a proxy is required to access the Internet from the seed, ``pulp_proxy_url``
-may be used.
+The Pulp service can be configured with two sets of credentials; one for
+administrator operations and another read-only for overcloud hosts
+to use.
+The administrator credentials can be configured ``pulp_username``,
+``pulp_password``
+The basic user account credentials can be configured with ``pulp_stack_username``
+and ``pulp_stack_password``.
+Both sets of credentials can be found within ``etc/kayobe/pulp.yml``.
+
+Both the ``pulp_password`` and ``pulp_stack_password`` are intended to be
+configured via their ``secrets_*`` counterparts, i.e.
+``secrets_pulp_password`` and ``secrets_pulp_stack_password``. These variables
+are expected to be set in an Ansible Vault encrypted
+``etc/kayobe/secrets.yml`` file.
+
+Passwords can be generated using ``OpenSSL``
+
+.. code-block:: console
+
+  openssl rand -base64 32
 
 Host images are not synchronised to the local Pulp server, since they should
 only be pulled to the seed node once. More information on host images can be

--- a/etc/kayobe/containers/pulp/post.yml
+++ b/etc/kayobe/containers/pulp/post.yml
@@ -28,6 +28,18 @@
     - stackhpc_pulp_sync_for_local_container_build | bool
     - pulp_settings.changed
 
+- name: Ensure Pulp stack user exists
+  ansible.builtin.include_role:
+    name: stackhpc.pulp.pulp_user
+  vars:
+    pulp_users:
+      - username: "{{ pulp_stack_username }}"
+        password: "{{ pulp_stack_password }}"
+        is_staff: false
+  when:
+    - pulp_stack_username is defined and pulp_stack_username | length > 0
+    - pulp_stack_password is defined and pulp_stack_password | length > 0
+
 - name: Login to docker registry
   docker_login:
     registry_url: "{{ kolla_docker_registry or omit }}"

--- a/etc/kayobe/pulp.yml
+++ b/etc/kayobe/pulp.yml
@@ -26,6 +26,10 @@ pulp_enable_tls: false
 pulp_username: admin
 pulp_password: "{{ secrets_pulp_password }}"
 
+# Credentials for non-admin user within Pulp.
+pulp_stack_username: stack
+pulp_stack_password: "{{ secrets_pulp_stack_password | default('') }}"
+
 # Proxy to use when adding remotes.
 pulp_proxy_url: "{{ omit }}"
 

--- a/etc/kayobe/stackhpc.yml
+++ b/etc/kayobe/stackhpc.yml
@@ -178,8 +178,8 @@ stackhpc_kolla_ansible_source_version: stackhpc/18.6.0.10
 stackhpc_docker_registry: "{{ pulp_url | regex_replace('^https?://', '') }}"
 
 # Username and password of container registry.
-stackhpc_docker_registry_username: "{{ pulp_username }}"
-stackhpc_docker_registry_password: "{{ pulp_password }}"
+stackhpc_docker_registry_username: "{{ pulp_stack_username if pulp_stack_password is defined and pulp_stack_password | length > 0 else pulp_username }}"
+stackhpc_docker_registry_password: "{{ pulp_stack_password if pulp_stack_password is defined and pulp_stack_password | length > 0 else pulp_password }}"
 
 ###############################################################################
 # Feature flags

--- a/releasenotes/notes/add-stack-user-for-pulp-c96041e82c13aa10.yaml
+++ b/releasenotes/notes/add-stack-user-for-pulp-c96041e82c13aa10.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Add support for a basic user for Pulp operations instead of using
+    the admin user for usage. Can be enabled by setting
+    `pulp_stack_password`.


### PR DESCRIPTION
The `stack` user is intended to be used for accessing `Pulp` from the `overcloud` hosts rather than using the `admin` user.