### PR TITLE
Remove old OFED method

### DIFF
--- a/etc/kayobe/ansible/pulp-host-image-download.yml
+++ b/etc/kayobe/ansible/pulp-host-image-download.yml
@@ -7,10 +7,8 @@
     # password in the get_url task of this playbook
     stackhpc_overcloud_host_image_url_no_auth: "{{ stackhpc_release_pulp_content_url }}/kayobe-images/\
       {{ openstack_release }}/{{ os_distribution }}/{{ os_release }}/\
-      {{ 'ofed/' if stackhpc_overcloud_host_image_is_ofed else '' }}\
       {{ stackhpc_overcloud_host_image_version }}/\
-      overcloud-{{ os_distribution }}-{{ os_release }}\
-      {{ '-ofed' if stackhpc_overcloud_host_image_is_ofed else '' }}.qcow2"
+      overcloud-{{ os_distribution }}-{{ os_release }}.qcow2"
   tasks:
     - name: Print image information
       ansible.builtin.debug:
@@ -18,7 +16,6 @@
           OS Distribution: {{ os_distribution }}
           OS Release: {{ os_release }}
           Image tag: {{ stackhpc_overcloud_host_image_version }}
-          OFED: {{ stackhpc_overcloud_host_image_is_ofed }}
 
     # TODO: Add checksum support
     - name: Download image artifact

--- a/etc/kayobe/stackhpc-overcloud-host-images.yml
+++ b/etc/kayobe/stackhpc-overcloud-host-images.yml
@@ -5,19 +5,12 @@
 # Whether or not to download overcloud host images from Ark
 stackhpc_download_overcloud_host_images: false
 
-# Whether or not to use images with MLNX_OFED installed (for deployment using
-# mellanox/Nvidia NICs). Only available for Ubuntu Jammy and Rocky Linux 9
-# OFED images are currently WIP and this variable is a placeholder
-stackhpc_overcloud_host_image_is_ofed: false
-
 # The overcloud host image source, defined by os_distribution, os_release,
-# stackhpc_overcloud_host_image_is_ofed, and the current stable version.
+# and the current stable version.
 stackhpc_overcloud_host_image_url: "{{ stackhpc_release_pulp_content_url_with_auth }}/kayobe-images/\
                                     {{ openstack_release }}/{{ os_distribution }}/{{ os_release }}/\
-                                    {{ 'ofed/' if stackhpc_overcloud_host_image_is_ofed else '' }}\
                                     {{ stackhpc_overcloud_host_image_version }}/\
-                                    overcloud-{{ os_distribution }}-{{ os_release }}\
-                                    {{ '-ofed' if stackhpc_overcloud_host_image_is_ofed else '' }}.qcow2"
+                                    overcloud-{{ os_distribution }}-{{ os_release }}.qcow2"
 
 # Overcloud host image version tag selection
 stackhpc_overcloud_host_image_version: >-


### PR DESCRIPTION
OFED is no longer pre-installed in our host images. Instead, it should be installed after provisioning. See docs:
https://stackhpc-kayobe-config.readthedocs.io/en/stackhpc-2024.1/contributor/ofed.html