### PR TITLE
Bump proxysql to be compatible with K-A bug #2112339 fix

### DIFF
--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -15,6 +15,9 @@ kolla_image_tags:
     rocky-9: master-rocky-9-20250305T111730
   prometheus:
     rocky-9: master-rocky-9-20250430T112026
+  proxysql:
+    rocky-9: master-rocky-9-20250609T102146
+    ubuntu-noble: master-ubuntu-noble-20250609T102146
   rabbitmq:
     rocky-9: master-rocky-9-20250502T080944
   skyline:

--- a/releasenotes/notes/bump-proxysql-to-fix-bug-2112339-4ff996a807e78204.yaml
+++ b/releasenotes/notes/bump-proxysql-to-fix-bug-2112339-4ff996a807e78204.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Bumped ProxySQL Kolla image to be compatible with Kolla-Ansible bug
+    fix: `Missing default hostgroup for user in proxysql Edit
+    <https://bugs.launchpad.net/kolla-ansible/+bug/2112339>`__

--- a/tools/kolla-images.py
+++ b/tools/kolla-images.py
@@ -311,7 +311,7 @@ def check_image_map(kolla_ansible_path: str):
     image_map = yaml.safe_load(image_map_str)
     image_var_re = re.compile(r"^([a-z0-9_]+)_image$")
     image_map = {
-        image_var_re.match(image_var).group(1): image.split("/")[-1].replace('{{ docker_image_name_prefix }}', '')
+        image_var_re.match(image_var).group(1): image.split("/")[-1].replace('{{ docker_image_url }}', '')
         for image_var, image in image_map.items()
     }
     # Filter out unsupported images.


### PR DESCRIPTION
https://github.com/stackhpc/kolla-ansible/commit/aecefb1b8714c9e2b3fee6996f3e2f2276389d56 and https://github.com/stackhpc/kolla/pull/422/commits/b643e8f9fd3e9d8e881e112e53183db743f1e5d3 made old proxysql images obsolete.