### PR TITLE
Fix kolla-images.py for latest master Kolla Ansible

### DIFF
--- a/tools/kolla-images.py
+++ b/tools/kolla-images.py
@@ -311,7 +311,7 @@ def check_image_map(kolla_ansible_path: str):
     image_map = yaml.safe_load(image_map_str)
     image_var_re = re.compile(r"^([a-z0-9_]+)_image$")
     image_map = {
-        image_var_re.match(image_var).group(1): image.split("/")[-1].replace('{{ docker_image_name_prefix }}', '')
+        image_var_re.match(image_var).group(1): image.split("/")[-1].replace('{{ docker_image_url }}', '')
         for image_var, image in image_map.items()
     }
     # Filter out unsupported images.


### PR DESCRIPTION
Kolla-ansible change [1] introduced ``docker_image_url`` variable and it replaced the prefix for all kolla images.
Changed replacement in kolla-images.py accordingly to fix ``image_map`` not being able to be constructed well as before.

[1] https://review.opendev.org/c/openstack/kolla-ansible/+/951747