### PR TITLE
Disable Skyline build

### DIFF
--- a/etc/kayobe/environments/ci-builder/stackhpc-ci.yml
+++ b/etc/kayobe/environments/ci-builder/stackhpc-ci.yml
@@ -28,7 +28,6 @@ kolla_enable_octavia: true
 kolla_enable_opensearch: true
 kolla_enable_prometheus: true
 kolla_enable_redis: true
-kolla_enable_skyline: true
 kolla_build_neutron_ovs: true
 
 ###############################################################################

--- a/etc/kayobe/pulp.yml
+++ b/etc/kayobe/pulp.yml
@@ -531,8 +531,6 @@ stackhpc_pulp_images_kolla:
   - rabbitmq
   - redis
   - redis-sentinel
-  - skyline-apiserver
-  - skyline-console
 
 # List of images for each base distribution which should not/cannot be built.
 stackhpc_kolla_unbuildable_images:

--- a/etc/kayobe/trivy/allowed-vulnerabilities.yml
+++ b/etc/kayobe/trivy/allowed-vulnerabilities.yml
@@ -36,9 +36,6 @@ prometheus_cadvisor_allowed_vulnerabilities:
   - CVE-2024-41110
   - CVE-2024-45337
 
-skyline_apiserver_allowed_vulnerabilities:
-  - CVE-2024-33663
-
 ###############################################################################
 # Dummy variable to allow Ansible to accept this file.
 workaround_ansible_issue_8743: yes

--- a/releasenotes/notes/drop-skyline-support-31d683f58f125335.yaml
+++ b/releasenotes/notes/drop-skyline-support-31d683f58f125335.yaml
@@ -1,0 +1,4 @@
+---
+deprecations:
+  - |
+    Disabled building of Kolla container images for Skyline

--- a/releasenotes/notes/enable-building-skyline-61a41c13cfcd54a1.yaml
+++ b/releasenotes/notes/enable-building-skyline-61a41c13cfcd54a1.yaml
@@ -1,5 +1,0 @@
----
-features:
-  - |
-    Enable building of ``Skyline`` an alternative to ``Horizon``.
-


### PR DESCRIPTION
Decided not to support skyline.

This effectively reverts https://github.com/stackhpc/stackhpc-kayobe-config/pull/1597