### PR TITLE
Put the RadosGW Usage Exporter behind HAProxy

### DIFF
--- a/etc/kayobe/ansible/deploy-radosgw-usage-exporter.yml
+++ b/etc/kayobe/ansible/deploy-radosgw-usage-exporter.yml
@@ -114,7 +114,7 @@
               ADMIN_ENTRY: admin
               ACCESS_KEY: "{{ ec2.Access }}"
               SECRET_KEY: "{{ ec2.Secret }}"
-              VIRTUAL_PORT: "{{ stackhpc_radosgw_usage_exporter_port | string }}"
+              VIRTUAL_PORT: "{{ stackhpc_radosgw_usage_exporter_backend_port | string }}"
               REQUESTS_CA_BUNDLE: "/etc/ssl/certs/ca-certificates.crt"
             entrypoint: "{{ ['python', '-u', './radosgw_usage_exporter.py', '--insecure'] if not stackhpc_radosgw_usage_exporter_verify else omit }}"
           vars:

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -560,6 +560,8 @@ kolla_build_args: {}
 kolla_overcloud_inventory_pass_through_host_vars_extra:
   - stackhpc_gpu_data
   - gpu_group_map
+  - stackhpc_radosgw_usage_exporter_frontend_port
+  - stackhpc_radosgw_usage_exporter_backend_port
 
 # List of names of host variables to pass through from kayobe hosts to
 # kolla-ansible hosts, if set. See also

--- a/etc/kayobe/kolla/config/haproxy/services.d/radosgw_usage_exporter.cfg
+++ b/etc/kayobe/kolla/config/haproxy/services.d/radosgw_usage_exporter.cfg
@@ -1,0 +1,25 @@
+{% if stackhpc_enable_radosgw_usage_exporter | bool %}
+{% raw %}
+frontend radosgw_usage_exporter_frontend
+    mode http
+    http-request del-header X-Forwarded-Proto
+    option httplog
+    option forwardfor
+    http-request set-header X-Forwarded-Proto https if { ssl_fc }
+{% if kolla_enable_tls_internal | bool %}
+    bind {{ kolla_internal_vip_address }}:{{ stackhpc_radosgw_usage_exporter_frontend_port }} ssl crt /etc/haproxy/certificates/haproxy-internal.pem
+{% else %}
+    bind {{ kolla_internal_vip_address }}:{{ stackhpc_radosgw_usage_exporter_frontend_port }}
+{% endif %}
+    default_backend radosgw_usage_exporter_backend
+
+backend radosgw_usage_exporter_backend
+    mode http
+
+{% for host in groups['monitoring'] %}
+{% set host_name = hostvars[host].ansible_facts.hostname %}
+{% set host_ip = 'api' | kolla_address(host) %}
+    server {{ host_name }} {{ host_ip }}:{{ stackhpc_radosgw_usage_exporter_backend_port }} check inter 2000 rise 2 fall 5
+{% endfor %}
+{% endraw %}
+{% endif %}

--- a/etc/kayobe/kolla/config/prometheus/prometheus.yml.d/80-radosgw-exporter.yml
+++ b/etc/kayobe/kolla/config/prometheus/prometheus.yml.d/80-radosgw-exporter.yml
@@ -14,8 +14,9 @@ scrape_configs:
       regex: (.+)
     static_configs:
       - targets:
-      {% for host in groups['monitoring'] %}
-        - "{{ 'api' | kolla_address(host) | put_address_in_context('url') }}:{% endraw %}{{ stackhpc_radosgw_usage_exporter_port }}{% raw %}"
-      {% endfor %}
+        - "{{ kolla_internal_fqdn | put_address_in_context('url') }}:{{ stackhpc_radosgw_usage_exporter_frontend_port }}"
+{% if kolla_enable_tls_internal | bool %}
+    scheme: https
+{% endif %}
 {% endraw %}
 {% endif %}

--- a/etc/kayobe/stackhpc-monitoring.yml
+++ b/etc/kayobe/stackhpc-monitoring.yml
@@ -74,8 +74,11 @@ stackhpc_prometheus_openstack_exporter_interval: 300
 # Prometheus scrape targets during deployment.
 stackhpc_enable_radosgw_usage_exporter: false
 
-# Port to expose RADOS gateway usage exporter. Default is 9242
-stackhpc_radosgw_usage_exporter_port: 9242
+# Port to expose RADOS gateway usage exporter backend. Default is 9242
+stackhpc_radosgw_usage_exporter_backend_port: 9242
+
+# Port to expose RADOS gateway usage exporter frontend (via HAProxy). Default is 9240
+stackhpc_radosgw_usage_exporter_frontend_port: 9240
 
 # Path to a certificate for internal TLS in the RADOS gateway usage exporter.
 stackhpc_radosgw_usage_exporter_cacert: ""

--- a/releasenotes/notes/radosgw-usage-exporter-behind-haproxy-e4371d2732f2a081.yaml
+++ b/releasenotes/notes/radosgw-usage-exporter-behind-haproxy-e4371d2732f2a081.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes an issue where object storage metrics were missing from Prometheus by
+    putting the radosgw-usage-exporter behind HAProxy.

--- a/releasenotes/notes/radosgw-usage-exporter-behind-haproxy-e4371d2732f2a081.yaml
+++ b/releasenotes/notes/radosgw-usage-exporter-behind-haproxy-e4371d2732f2a081.yaml
@@ -1,4 +1,11 @@
 ---
+features:
+  - |
+    The radosgw-usage-exporter is now put behind HAProxy. To facilitate this,
+    ``stackhpc_radosgw_usage_exporter_port`` had been renamed to
+    ``stackhpc_radosgw_usage_exporter_backend_port`` (it remains 9242) and
+    ``stackhpc_radosgw_usage_exporter_frontend_port`` (defaults to 9240) has
+    been introduced.
 fixes:
   - |
     Fixes an issue where object storage metrics were missing from Prometheus by


### PR DESCRIPTION
Metrics were coming out patchy because multiple prometheus-server instances would try to scrape from the same exporter, which would return empty if a collection is already in progress. Fix this by round-robining the requests through haproxy.

A nice graph to show it works:
![image](https://github.com/user-attachments/assets/c8aadb3a-5332-4fa9-b652-a4f884f6a07d)
