### PR TITLE
feat: increase default number of retries for checking `Pulp` status

### DIFF
--- a/etc/kayobe/containers/pulp/post.yml
+++ b/etc/kayobe/containers/pulp/post.yml
@@ -4,7 +4,7 @@
     url: "{{ pulp_url }}/pulp/api/v3/status/"
   register: pulp_status
   until: pulp_status is success
-  retries: "{{ pulp_timeout_retries | default(30) }}"
+  retries: "{{ pulp_timeout_retries | default(120) }}"
   delay: "{{ pulp_timeout_delay | default(3) }}"
 
 - name: Set the Pulp admin password

--- a/releasenotes/notes/increase-pulp-retries-79cc258da9aabb4f.yaml
+++ b/releasenotes/notes/increase-pulp-retries-79cc258da9aabb4f.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Increase the number of retries when waiting for Pulp to become ready.
+    This is to avoid issues with Pulp taking longer than expected to start up.


### PR DESCRIPTION
It has been noticed in recent deployments that Pulp takes longer than the current default number of retries which causes `kayobe seed service deploy` to fail