### PR TITLE
Use rabbitmq length for ``RabbitMQNodeNotDistributed``

### DIFF
--- a/etc/kayobe/kolla/config/prometheus/rabbitmq.rules
+++ b/etc/kayobe/kolla/config/prometheus/rabbitmq.rules
@@ -20,7 +20,7 @@ groups:
     annotations:
       description: RabbitMQ consumers message consumption speed is low on {{ $labels.instance }}
   - alert: RabbitMQNodeNotDistributed
-    expr: erlang_vm_dist_node_state < 3
+    expr: erlang_vm_dist_node_state < {% endraw %}{{ alertmanager_number_of_rabbitmq_nodes }}{% raw %}
     for: 5m
     labels:
       severity: critical


### PR DESCRIPTION
This complements https://github.com/stackhpc/stackhpc-kayobe-config/pull/1579
Would be good to be backported to stackhpc/2024.1