### PR TITLE
CI: bump docker engine max version

### DIFF
--- a/etc/kayobe/ansible/stackhpc-cloud-tests.yml
+++ b/etc/kayobe/ansible/stackhpc-cloud-tests.yml
@@ -142,7 +142,7 @@
             # Inclusive min
             sct_docker_version_min: "24.0.0"
             # Exclusive max
-            sct_docker_version_max: "28.1.0"
+            sct_docker_version_max: "29.0.0"
             sct_selinux_state: "{{ selinux_state }}"
           failed_when: host_results.rc not in [0, 1]
           register: host_results


### PR DESCRIPTION
Fixes recent CI failures https://github.com/stackhpc/stackhpc-kayobe-config/actions/runs/15606525495/job/43957715335?pr=1701

Latest version is 28.2.2, which is outside the current range. I think we can raise the limit to the next major version 