### PR TITLE
CI: Force system clock synchronisation

### DIFF
--- a/etc/kayobe/environments/ci-aio/time.yml
+++ b/etc/kayobe/environments/ci-aio/time.yml
@@ -1,0 +1,3 @@
+---
+# Force system clock synchronisation
+ntp_force_sync: True


### PR DESCRIPTION
Recently there have been a lot of sync errors in CI, particularly on Rocky AIOs. This change should help mitigate the issues