### PR TITLE
Ironic config overrides to support aarch64 hosts

### DIFF
--- a/etc/kayobe/ansible/ironic-get-aarch64-ipa.yml
+++ b/etc/kayobe/ansible/ironic-get-aarch64-ipa.yml
@@ -1,0 +1,39 @@
+---
+- name: Configure Ironic for multiarch
+  any_errors_fatal: True
+  gather_facts: True
+  hosts: controllers
+  vars:
+    ironic_volume_location: /var/lib/docker/volumes/ironic/_data
+    stackhpc_ipa_image_version_aarch64: "2024.1-20250407T193151"
+    stackhpc_ipa_image_url_aarch64: >-
+      {{ stackhpc_release_pulp_content_url }}/ipa-images/\
+      {{ openstack_release }}/{{ os_distribution }}/\
+      {{ os_release }}-aarch64/{{ stackhpc_ipa_image_version_aarch64 }}
+    ironic_aarch64_kernel_filename: ipa-aarch64.kernel
+    ironic_aarch64_initramfs_filename: ipa-aarch64.initramfs
+
+  tasks:
+    - name: Download aarch64 deployment kernel
+      ansible.builtin.get_url:
+        url: "{{ stackhpc_ipa_image_url_aarch64 }}/{{ ironic_aarch64_kernel_filename }}"
+        dest: "{{ ironic_volume_location }}/httpboot/ironic-agent-aarch64.kernel"
+        force_basic_auth: true
+        username: "{{ stackhpc_release_pulp_username }}"
+        password: "{{ stackhpc_release_pulp_password }}"
+        unredirected_headers:
+          - "Authorization"
+        mode: '0644'
+      become: true
+
+    - name: Download aarch64 deployment initramfs
+      ansible.builtin.get_url:
+        url: "{{ stackhpc_ipa_image_url_aarch64 }}/{{ ironic_aarch64_initramfs_filename }}"
+        dest: "{{ ironic_volume_location }}/httpboot/ironic-agent-aarch64.initramfs"
+        force_basic_auth: true
+        username: "{{ stackhpc_release_pulp_username }}"
+        password: "{{ stackhpc_release_pulp_password }}"
+        unredirected_headers:
+          - "Authorization"
+        mode: '0644'
+      become: true

--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -17,14 +17,8 @@ kolla_image_tags:
     rocky-9: 2024.1-rocky-9-20250227T091118
     ubuntu-jammy: 2024.1-ubuntu-jammy-20250227T091118
   ironic:
-    rocky-9: 2024.1-rocky-9-20250213T110505
-    ubuntu-jammy: 2024.1-ubuntu-jammy-20250213T110505
-  ironic_dnsmasq:
-    rocky-9: 2024.1-rocky-9-20241218T141751
-    ubuntu-jammy: 2024.1-ubuntu-jammy-20241218T141809
-  ironic_prometheus_exporter:
-    rocky-9: 2024.1-rocky-9-20250124T081816
-    ubuntu-jammy: 2024.1-ubuntu-jammy-20250124T081816
+    rocky-9: 2024.1-rocky-9-20250408T163250
+    ubuntu-jammy: 2024.1-ubuntu-jammy-20250408T163250
   kolla_toolbox:
     rocky-9: 2024.1-rocky-9-20250529T081147
     ubuntu-jammy: 2024.1-ubuntu-jammy-20250529T081147

--- a/etc/kayobe/kolla/config/ironic.conf
+++ b/etc/kayobe/kolla/config/ironic.conf
@@ -1,0 +1,6 @@
+[pxe]
+ipxe_bootfile_name_by_arch = aarch64:ipxe-snponly-aarch64.efi
+
+[conductor]
+deploy_kernel_by_arch = aarch64:glance-id-goes-here
+deploy_ramdisk_by_arch = aarch64:glance-id-goes-here

--- a/etc/kayobe/kolla/config/ironic/inspector.ipxe
+++ b/etc/kayobe/kolla/config/ironic/inspector.ipxe
@@ -1,0 +1,32 @@
+{% raw %}#!ipxe
+
+:retry_dhcp
+dhcp || goto retry_dhcp
+
+set arch ${buildarch}
+echo ${arch}
+
+{# Standalone ironic: use ironic-configured PXE configs #}
+{% if not enable_neutron | bool %}
+# load the MAC-specific file or fail if it's not found
+:boot_system
+chain pxelinux.cfg/${mac:hexhyp} || goto inspector_ipa
+{% endif %}
+
+:inspector_ipa
+:retry_boot
+# Check architecture and set boot options accordingly
+set arch ${buildarch}
+
+iseq ${arch} x86_64 && set kernel_url {{ ironic_http_url }}/ironic-agent.kernel ||
+iseq ${arch} x86_64 && set initrd_url {{ ironic_http_url }}/ironic-agent.initramfs ||
+iseq ${arch} x86_64 && set initrd_file ironic-agent.initramfs ||
+
+iseq ${arch} arm64 && set kernel_url {{ ironic_http_url }}/ironic-agent-aarch64.kernel ||
+iseq ${arch} arm64 && set initrd_url {{ ironic_http_url }}/ironic-agent-aarch64.initramfs ||
+iseq ${arch} arm64 && set initrd_file ironic-agent-aarch64.initramfs ||
+imgfree
+kernel --timeout 30000 ${kernel_url} ipa-inspection-callback-url={{ ironic_inspector_internal_endpoint }}/v1/continue systemd.journald.forward_to_console=yes BOOTIF=${mac} initrd=${initrd_file} {{ ironic_inspector_kernel_cmdline_extras | join(' ') }}
+initrd --timeout 30000 ${initrd_url}
+boot
+{% endraw %}

--- a/etc/kayobe/kolla/config/ironic/ironic-dnsmasq.conf
+++ b/etc/kayobe/kolla/config/ironic/ironic-dnsmasq.conf
@@ -1,0 +1,48 @@
+{% raw %}
+# NOTE(yoctozepto): ironic-dnsmasq is used to deliver DHCP(v6) service
+# DNS service is disabled:
+port=0
+
+interface={{ ironic_dnsmasq_interface }}
+bind-interfaces
+
+{% for item in ironic_dnsmasq_dhcp_ranges %}
+{% set tag = item.tag | default('range_' ~ loop.index) %}
+{% set lease_time = item.lease_time | default(ironic_dnsmasq_dhcp_default_lease_time) %}
+dhcp-range=set:{{ tag }},{{ item.range }},{{ lease_time }}
+{% if item.routers is defined %}dhcp-option=tag:{{ tag }},option:router,{{ item.routers }}{% endif %}
+{% if item.ntp_server is defined %}dhcp-option=tag:{{ tag }},option:ntp-server,{{ item.ntp_server }}{% endif %}
+{% endfor %}
+
+{% if api_address_family == 'ipv6' %}
+{# TODO(yoctozepto): IPv6-only support - DHCPv6 PXE support #}
+{# different options must be used here #}
+{% else %}{# ipv4 #}
+dhcp-option=option:tftp-server,{{ api_interface_address }}
+dhcp-option=option:server-ip-address,{{ api_interface_address }}
+dhcp-option=210,/var/lib/ironic/tftpboot/
+{% if ironic_dnsmasq_serve_ipxe | bool %}
+dhcp-match=ipxe,175
+dhcp-match=set:efi,option:client-arch,7
+dhcp-match=set:efi,option:client-arch,9
+dhcp-match=set:aarchefi,option:client-arch,11
+# Client is already running iPXE; move to next stage of chainloading
+dhcp-option=tag:ipxe,option:bootfile-name,{{ ironic_http_url }}/inspector.ipxe
+# Client is PXE booting over EFI without iPXE ROM,
+# send EFI version of iPXE chainloader
+dhcp-option=tag:efi,tag:!ipxe,option:bootfile-name,{{ ironic_dnsmasq_uefi_ipxe_boot_file }}
+dhcp-option=tag:aarchefi,tag:!ipxe,option:bootfile-name,ipxe-snponly-aarch64.efi
+{% endif %}
+dhcp-option=option:bootfile-name,{{ ironic_dnsmasq_boot_file }}
+{% endif %}{# ipv6/ipv4 #}
+
+log-async
+log-facility=/var/log/kolla/ironic/dnsmasq.log
+{% if ironic_logging_debug | bool %}
+log-dhcp
+{% endif %}
+
+{% if ironic_inspector_pxe_filter == 'dnsmasq' %}
+dhcp-hostsdir=/etc/dnsmasq/dhcp-hostsdir
+{% endif %}
+{% endraw %}

--- a/etc/kayobe/stackhpc.yml
+++ b/etc/kayobe/stackhpc.yml
@@ -165,7 +165,7 @@ stackhpc_repo_elrepo_9_version: "{{ stackhpc_repo_distribution }}"
 
 # Kolla source repository.
 stackhpc_kolla_source_url: "https://github.com/stackhpc/kolla"
-stackhpc_kolla_source_version: stackhpc/18.6.0.12
+stackhpc_kolla_source_version: stackhpc-ironic-aarch64
 
 # Kolla Ansible source repository.
 stackhpc_kolla_ansible_source_url: "https://github.com/stackhpc/kolla-ansible"


### PR DESCRIPTION
Requires images built from Kolla backport branch (https://github.com/stackhpc/kolla/pull/429), which are included in this config

