### PR TITLE
CI: Upload checksums by default for Ark artifacts

### DIFF
--- a/.github/workflows/ipa-image-build.yml
+++ b/.github/workflows/ipa-image-build.yml
@@ -248,8 +248,7 @@ jobs:
           -e artifact_tag=${{ steps.ipa_image_tag.outputs.ipa_image_tag }} \
           -e os_distribution="ubuntu" \
           -e os_release="noble" \
-          -e file_regex='*.kernel' \
-          -e upload_checksum=true
+          -e file_regex='*.kernel'
         env:
           KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
         if: inputs.ubuntu-noble && steps.build_ubuntu_noble_ipa.outcome == 'success'
@@ -265,8 +264,7 @@ jobs:
           -e artifact_tag=${{ steps.ipa_image_tag.outputs.ipa_image_tag }} \
           -e os_distribution="ubuntu" \
           -e os_release="noble" \
-          -e file_regex='*.initramfs' \
-          -e upload_checksum=true
+          -e file_regex='*.initramfs'
         env:
           KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
         if: inputs.ubuntu-noble && steps.build_ubuntu_noble_ipa.outcome == 'success'
@@ -307,8 +305,7 @@ jobs:
           -e artifact_tag=${{ steps.ipa_image_tag.outputs.ipa_image_tag }} \
           -e os_distribution="rocky" \
           -e os_release="9" \
-          -e file_regex='*.kernel' \
-          -e upload_checksum=true
+          -e file_regex='*.kernel'
         env:
           KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
         if: inputs.rocky9 && steps.build_rocky_9_ipa.outcome == 'success'
@@ -324,8 +321,7 @@ jobs:
           -e artifact_tag=${{ steps.ipa_image_tag.outputs.ipa_image_tag }} \
           -e os_distribution="rocky" \
           -e os_release="9" \
-          -e file_regex='*.initramfs' \
-          -e upload_checksum=true
+          -e file_regex='*.initramfs'
         env:
           KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
         if: inputs.rocky9 && steps.build_rocky_9_ipa.outcome == 'success'

--- a/etc/kayobe/ansible/pulp-artifact-upload.yml
+++ b/etc/kayobe/ansible/pulp-artifact-upload.yml
@@ -7,7 +7,7 @@
     remote_pulp_password: "{{ stackhpc_release_pulp_password }}"
     repository_name: "{{ artifact_type }}-{{ openstack_release }}-{{ os_distribution }}-{{ os_release }}"
     pulp_base_path: "{{ artifact_type }}/{{ openstack_release }}/{{ os_distribution }}/{{ os_release }}"
-    upload_checksum: false
+    upload_checksum: true
   tasks:
     - name: Print artifact tag
       ansible.builtin.debug:


### PR DESCRIPTION
There's no reason we shouldn't generate checksums by default for the artifacts we upload to ark. At the moment, we don't generate them for host images, which we need for `custom_deploy_image_checksum_url` since Bobcat