### PR TITLE
Cherry-pick last changes from stackhpc/master to stackhpc/2025.1

### DIFF
--- a/doc/source/operations/upgrading-openstack.rst
+++ b/doc/source/operations/upgrading-openstack.rst
@@ -135,12 +135,26 @@ the following in ``kayobe-config/etc/kayobe/stackhpc-monitoring.yml``:
 Prometheus blackbox exporter endpoints
 --------------------------------------
 
-Endpoints for the blackbox exporter are now templated in the kolla-ansible
+Many endpoints for the Blackbox exporter are now templated in the Kolla-Ansible
 group vars for the cloud. This means that the
 ``prometheus_blackbox_exporter_endpoints`` variable can be removed from the
 environment's ``kolla/globals.yml`` file (if applicable) and the endpoints will
-fallback to the ones templated in the group vars. Additional endpoints may be
-added through the ``prometheus_blackbox_exporter_endpoints_kayobe`` variable.
+fallback to the ones templated in the group vars. Backend endpoints such as
+`these <https://github.com/stackhpc/stackhpc-kayobe-config/blob/094c2e012a037309d103c08a71eb633fdeb214e7/etc/kayobe/kolla/inventory/group_vars/prometheus-blackbox-exporter#L27-L64>`__
+are not yet templated by Kolla-Ansible.
+
+Additional endpoints may still be added.
+
+For Kolla-Ansible templating, use ``stackhpc_prometheus_blackbox_exporter_endpoints_custom``.
+For example:
+
+.. code-block:: yaml
+   :caption: ``etc/kayobe/kolla/inventory/group_vars/prometheus-blackbox-exporter``
+
+   stackhpc_prometheus_blackbox_exporter_endpoints_custom:
+     - 'custom_service:http_2xx:{{ public_protocol }}://{{ external_fqdn | put_address_in_context('url') }}:{{ custom_serivce_port }}'
+
+Alternatively, for Kayobe templating, use the ``prometheus_blackbox_exporter_endpoints_kayobe`` variable.
 For example:
 
 .. code-block:: yaml

--- a/doc/source/operations/upgrading-openstack.rst
+++ b/doc/source/operations/upgrading-openstack.rst
@@ -132,6 +132,25 @@ the following in ``kayobe-config/etc/kayobe/stackhpc-monitoring.yml``:
    # targets being templated during deployment.
    stackhpc_enable_os_capacity: false
 
+Prometheus blackbox exporter endpoints
+--------------------------------------
+
+Endpoints for the blackbox exporter are now templated in the kolla-ansible
+group vars for the cloud. This means that the
+``prometheus_blackbox_exporter_endpoints`` variable can be removed from the
+environment's ``kolla/globals.yml`` file (if applicable) and the endpoints will
+fallback to the ones templated in the group vars. Additional endpoints may be
+added through the ``prometheus_blackbox_exporter_endpoints_kayobe`` variable.
+For example:
+
+.. code-block:: yaml
+   :caption: ``kolla/globals.yml``
+
+   prometheus_blackbox_exporter_endpoints_kayobe:
+      - endpoints:
+         - "pulp:http_2xx:{{ pulp_url }}/pulp/api/v3/status/"
+      enabled: "{{ seed_pulp_container_enabled | bool }}"
+
 Known issues
 ============
 

--- a/etc/kayobe/ansible/pulp-artifact-upload.yml
+++ b/etc/kayobe/ansible/pulp-artifact-upload.yml
@@ -28,18 +28,6 @@
           - urllib3
         state: present
 
-    - name: Upload an artifact
-      pulp.squeezer.artifact:
-        pulp_url: "{{ remote_pulp_url }}"
-        username: "{{ remote_pulp_username }}"
-        password: "{{ remote_pulp_password }}"
-        file: "{{ found_files.files[0].path }}"
-        state: present
-      register: upload_result
-      until: upload_result is success
-      retries: 3
-      delay: 60
-
     - name: Get sha256 hash
       ansible.builtin.stat:
         path: "{{ found_files.files[0].path }}"
@@ -58,46 +46,6 @@
         checksum_algorithm: sha256
       register: checksum_stats
 
-    - name: Upload checksum artifact
-      pulp.squeezer.artifact:
-        pulp_url: "{{ remote_pulp_url }}"
-        username: "{{ remote_pulp_username }}"
-        password: "{{ remote_pulp_password }}"
-        file: "/tmp/{{ found_files.files[0].path | basename }}.sha256"
-        state: present
-      register: checksum_upload_result
-      until: checksum_upload_result is success
-      retries: 3
-      delay: 60
-      when: upload_checksum
-
-    - name: Create file content from artifact
-      pulp.squeezer.file_content:
-        pulp_url: "{{ remote_pulp_url }}"
-        username: "{{ remote_pulp_username }}"
-        password: "{{ remote_pulp_password }}"
-        sha256: "{{ file_stats.stat.checksum }}"
-        relative_path: "{{ found_files.files[0].path | basename }}"
-        state: present
-      register: file_content_result
-      until: file_content_result is success
-      retries: 3
-      delay: 5
-
-    - name: Create checksum content from artifact
-      pulp.squeezer.file_content:
-        pulp_url: "{{ remote_pulp_url }}"
-        username: "{{ remote_pulp_username }}"
-        password: "{{ remote_pulp_password }}"
-        sha256: "{{ checksum_stats.stat.checksum }}"
-        relative_path: "{{ found_files.files[0].path | basename }}.sha256"
-        state: present
-      register: checksum_content_result
-      until: checksum_content_result is success
-      retries: 3
-      delay: 5
-      when: upload_checksum
-
     - name: Ensure file repo exists
       pulp.squeezer.file_repository:
         pulp_url: "{{ remote_pulp_url }}"
@@ -110,31 +58,33 @@
       retries: 3
       delay: 5
 
-    - name: Add content to file repo
-      pulp.squeezer.file_repository_content:
+    - name: Upload artifact
+      pulp.squeezer.file_content:
         pulp_url: "{{ remote_pulp_url }}"
         username: "{{ remote_pulp_username }}"
         password: "{{ remote_pulp_password }}"
+        file: "{{ found_files.files[0].path }}"
+        sha256: "{{ file_stats.stat.checksum }}"
+        relative_path: "{{ found_files.files[0].path | basename }}"
+        state: present
         repository: "{{ repository_name }}"
-        present_content:
-          - relative_path: "{{ found_files.files[0].path | basename }}"
-            sha256: "{{ file_stats.stat.checksum }}"
-      register: file_repo_content_result
-      until: file_repo_content_result is success
+      register: file_content_result
+      until: file_content_result is success
       retries: 3
       delay: 5
 
-    - name: Add checksum content to file repo
-      pulp.squeezer.file_repository_content:
+    - name: Upload checksum
+      pulp.squeezer.file_content:
         pulp_url: "{{ remote_pulp_url }}"
         username: "{{ remote_pulp_username }}"
         password: "{{ remote_pulp_password }}"
+        file: "/tmp/{{ found_files.files[0].path | basename }}.sha256"
+        sha256: "{{ checksum_stats.stat.checksum }}"
+        relative_path: "{{ found_files.files[0].path | basename }}.sha256"
+        state: present
         repository: "{{ repository_name }}"
-        present_content:
-          - relative_path: "{{ found_files.files[0].path | basename }}.sha256"
-            sha256: "{{ checksum_stats.stat.checksum }}"
-      register: checksum_repo_content_result
-      until: checksum_repo_content_result is success
+      register: checksum_content_result
+      until: checksum_content_result is success
       retries: 3
       delay: 5
       when: upload_checksum

--- a/etc/kayobe/ansible/requirements.yml
+++ b/etc/kayobe/ansible/requirements.yml
@@ -1,11 +1,9 @@
 ---
 collections:
   - name: stackhpc.cephadm
-    version: 1.19.1
-  # NOTE: Pinning pulp.squeezer to 0.0.13 because 0.0.14+ depends on the
-  # pulp_glue Python library being installed.
+    version: 1.19.3
   - name: pulp.squeezer
-    version: 0.0.13
+    version: 0.1.1
   - name: stackhpc.pulp
     version: 0.5.5
   - name: stackhpc.hashicorp
@@ -15,19 +13,20 @@ collections:
 roles:
   - src: stackhpc.vxlan
     version: 1.1.0
-  - name: ansible-lockdown.ubuntu22_cis
-    src: https://github.com/ansible-lockdown/UBUNTU22-CIS
-    version: 1.4.1
+  - name: ansible-lockdown.ubuntu24_cis
+    src: https://github.com/ansible-lockdown/UBUNTU24-CIS
+    version: 1.0.1
   - name: ansible-lockdown.rhel9_cis
     src: https://github.com/ansible-lockdown/RHEL9-CIS
-    version: 1.3.1
+    version: v1.3.4
   - name: wazuh-ansible
     src: https://github.com/stackhpc/wazuh-ansible
     version: stackhpc-v4.10.0
   - name: geerlingguy.pip
-    version: 2.2.0
+    version: 3.1.0
   - name: monolithprojects.github_actions_runner
-    version: 1.18.5
-  - src: https://github.com/stackhpc/ansible-role-docker.git
-    name: geerlingguy.docker
+    src: https://github.com/MonolithProjects/ansible-github_actions_runner
+    version: 1.25.1
+  - name: geerlingguy.docker
+    src: https://github.com/stackhpc/ansible-role-docker.git
     version: stackhpc/7.0.1.1

--- a/releasenotes/notes/ansible-requirements-bump-89313038efba83b3.yaml
+++ b/releasenotes/notes/ansible-requirements-bump-89313038efba83b3.yaml
@@ -1,0 +1,16 @@
+---
+features:
+  - |
+    Ansible dependencies have been bumped to the latest available
+    versions. This includes:
+
+    * ``stackhpc.cephadm`` - ``1.19.1`` -> ``1.19.3``
+    * ``pulp.squeezer`` - ``0.0.13`` -> ``0.1.1``
+    * ``ansible-lockdown.rhel9_cis`` - ``1.3.1`` -> ``v1.3.4``
+    * ``geerlingguy.pip`` - ``2.2.0`` -> ``3.1.0``
+    * ``monolithprojects.github_actions_runner`` - ``1.18.5`` -> ``1.25.1``
+    * ``geerlingguy.docker`` - unpinned -> ``stackhpc/7.0.1.1``
+    * ``ansible-modules-hashivault`` - ``5.2.1`` -> ``5.3.0``
+
+    ``ansible-lockdown.ubuntu22_cis`` has been replaced with
+    ``ansible-lockdown.ubuntu24_cis``, which is pinned to ``1.0.1``.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 kayobe@git+https://github.com/stackhpc/kayobe@stackhpc/18.0.0.0rc1.2
-ansible-modules-hashivault>=5.2.1
+ansible-modules-hashivault>=5.3.0
 jmespath


### PR DESCRIPTION
Cherry picks of https://github.com/stackhpc/stackhpc-kayobe-config/pull/1494 and https://github.com/stackhpc/stackhpc-kayobe-config/pull/1515

These should be the last changes we need from `stackhpc/master` this upgrade cycle.

Cherry-picking rather than merging in this instance just because it is easier.