### PR TITLE
Disable OVS upgrade CI AIO job temporarily

### DIFF
--- a/.github/workflows/stackhpc-pull-request.yml
+++ b/.github/workflows/stackhpc-pull-request.yml
@@ -219,20 +219,21 @@ jobs:
     secrets: inherit
     if: ${{ ! failure() && ! cancelled() && github.repository == 'stackhpc/stackhpc-kayobe-config' }}
 
-  all-in-one-upgrade-rocky-9-ovs:
-    name: aio upgrade (Rocky 9 OVS)
-    needs:
-      - check-changes
-      - build-kayobe-image
-    uses: ./.github/workflows/stackhpc-all-in-one.yml
-    with:
-      kayobe_image: ${{ needs.build-kayobe-image.outputs.kayobe_image }}
-      os_distribution: rocky
-      os_release: "9"
-      ssh_username: cloud-user
-      neutron_plugin: ovs
-      OS_CLOUD: openstack
-      if: ${{ needs.check-changes.outputs.aio == 'true' }}
-      upgrade: true
-    secrets: inherit
-    if: ${{ ! failure() && ! cancelled() && github.repository == 'stackhpc/stackhpc-kayobe-config' }}
+  # FIXME: Disabled until https://bugs.launchpad.net/neutron/+bug/2112492 gets resolved
+  # all-in-one-upgrade-rocky-9-ovs:
+  #   name: aio upgrade (Rocky 9 OVS)
+  #   needs:
+  #     - check-changes
+  #     - build-kayobe-image
+  #   uses: ./.github/workflows/stackhpc-all-in-one.yml
+  #   with:
+  #     kayobe_image: ${{ needs.build-kayobe-image.outputs.kayobe_image }}
+  #     os_distribution: rocky
+  #     os_release: "9"
+  #     ssh_username: cloud-user
+  #     neutron_plugin: ovs
+  #     OS_CLOUD: openstack
+  #     if: ${{ needs.check-changes.outputs.aio == 'true' }}
+  #     upgrade: true
+  #   secrets: inherit
+  #   if: ${{ ! failure() && ! cancelled() && github.repository == 'stackhpc/stackhpc-kayobe-config' }}


### PR DESCRIPTION
Disabling until https://bugs.launchpad.net/neutron/+bug/2112492 is fixed (properly)