### PR TITLE
Minor fixes to RMQ dashboard

### DIFF
--- a/etc/kayobe/kolla/config/grafana/dashboards/openstack/rabbitmq.json
+++ b/etc/kayobe/kolla/config/grafana/dashboards/openstack/rabbitmq.json
@@ -3391,7 +3391,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(\n  (rate(rabbitmq_channel_messages_delivered_total[60s]) * on(instance) group_left(rabbitmq_node, rabbitmq_node) rabbitmq_identity_info{rabbitmq_node=\"$rabbitmq_node\", namespace=\"$namespace\"}) +\n  (rate(rabbitmq_channel_messages_delivered_ack_total[60s]) * on(instance) group_left(rabbitmq_node, rabbitmq_node) rabbitmq_identity_info{rabbitmq_node=\"$rabbitmq_node\", namespace=\"$namespace\"})\n) by(rabbitmq_node)",
+          "expr": "sum(\n  (rate(rabbitmq_channel_messages_delivered_total[5m]) * on(instance) group_left(rabbitmq_node, rabbitmq_node) rabbitmq_identity_info{rabbitmq_node=\"$rabbitmq_node\", namespace=\"$namespace\"}) +\n  (rate(rabbitmq_channel_messages_delivered_ack_total[5m]) * on(instance) group_left(rabbitmq_node, rabbitmq_node) rabbitmq_identity_info{rabbitmq_node=\"$rabbitmq_node\", namespace=\"$namespace\"})\n) by(rabbitmq_node)",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -5887,9 +5887,9 @@
     ]
   },
   "timezone": "",
-  "title": "RabbitMQ-Overview - Update",
+  "title": "RabbitMQ-Overview",
   "uid": "Hz7D2_LGp",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }
 {% endraw %}

--- a/releasenotes/notes/rmq-dashboard-5bb5eb36ff72100c.yaml
+++ b/releasenotes/notes/rmq-dashboard-5bb5eb36ff72100c.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Minor issue with RabbitMQ dashboard panel showing no data with
+    default scrape settings.


### PR DESCRIPTION
- Messages delivered panel showing as 'empty' with default settings. The time over which the rate was calculated needed extending.
- Tweak dashboard title