### PR TITLE
CI: Sync multinode release matrix with 2025.1

### DIFF
--- a/.github/workflows/multinode-inputs.py
+++ b/.github/workflows/multinode-inputs.py
@@ -34,9 +34,9 @@ UBUNTU_JAMMY = OSRelease("ubuntu", "jammy", "ubuntu")
 UBUNTU_NOBLE = OSRelease("ubuntu", "noble", "ubuntu")
 # NOTE(upgrade): Add supported releases here.
 OPENSTACK_RELEASES = [
-    OpenStackRelease("2024.1", "2023.1", [ROCKY_9, UBUNTU_JAMMY]),
     OpenStackRelease("2023.1", "zed", [ROCKY_9, UBUNTU_JAMMY]),
-    OpenStackRelease("master", "2024.1", [ROCKY_9, UBUNTU_NOBLE])
+    OpenStackRelease("2024.1", "2023.1", [ROCKY_9, UBUNTU_JAMMY]),
+    OpenStackRelease("2025.1", "2024.1", [ROCKY_9, UBUNTU_NOBLE]),
 ]
 NEUTRON_PLUGINS = ["ovs", "ovn"]
 


### PR DESCRIPTION
Nightly multinode workflows were testing upgrades from 2024.1 to master instead of 2024.1 to 2025.1.