### PR TITLE
Epoxy: fix & re-enable OVS upgrade jobs

### DIFF
--- a/.github/workflows/stackhpc-pull-request.yml
+++ b/.github/workflows/stackhpc-pull-request.yml
@@ -219,21 +219,20 @@ jobs:
     secrets: inherit
     if: ${{ ! failure() && ! cancelled() && github.repository == 'stackhpc/stackhpc-kayobe-config' }}
 
-  # FIXME: Disabled until https://bugs.launchpad.net/neutron/+bug/2112492 gets resolved
-  # all-in-one-upgrade-rocky-9-ovs:
-  #   name: aio upgrade (Rocky 9 OVS)
-  #   needs:
-  #     - check-changes
-  #     - build-kayobe-image
-  #   uses: ./.github/workflows/stackhpc-all-in-one.yml
-  #   with:
-  #     kayobe_image: ${{ needs.build-kayobe-image.outputs.kayobe_image }}
-  #     os_distribution: rocky
-  #     os_release: "9"
-  #     ssh_username: cloud-user
-  #     neutron_plugin: ovs
-  #     OS_CLOUD: openstack
-  #     if: ${{ needs.check-changes.outputs.aio == 'true' }}
-  #     upgrade: true
-  #   secrets: inherit
-  #   if: ${{ ! failure() && ! cancelled() && github.repository == 'stackhpc/stackhpc-kayobe-config' }}
+  all-in-one-upgrade-rocky-9-ovs:
+    name: aio upgrade (Rocky 9 OVS)
+    needs:
+      - check-changes
+      - build-kayobe-image
+    uses: ./.github/workflows/stackhpc-all-in-one.yml
+    with:
+      kayobe_image: ${{ needs.build-kayobe-image.outputs.kayobe_image }}
+      os_distribution: rocky
+      os_release: "9"
+      ssh_username: cloud-user
+      neutron_plugin: ovs
+      OS_CLOUD: openstack
+      if: ${{ needs.check-changes.outputs.aio == 'true' }}
+      upgrade: true
+    secrets: inherit
+    if: ${{ ! failure() && ! cancelled() && github.repository == 'stackhpc/stackhpc-kayobe-config' }}

--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -6,3 +6,6 @@ kolla_image_tags:
   openstack:
     rocky-9: 2025.1-rocky-9-20250616T133037
     ubuntu-noble: 2025.1-ubuntu-noble-20250613T131221
+  neutron_metadata_agent:
+    rocky-9: 2025.1-rocky-9-20250626T074649
+    ubuntu-noble: 2025.1-ubuntu-noble-20250626T074649


### PR DESCRIPTION
They finally fixed [metadata agent liveness](https://review.opendev.org/c/openstack/neutron/+/953064) so we can re-enable the OVS upgrade job.

Once this merges, I'll add the AIO jobs to require status checks