### PR TITLE
Revert Pulp Squeezer version bump

### DIFF
--- a/etc/kayobe/ansible/pulp-artifact-upload.yml
+++ b/etc/kayobe/ansible/pulp-artifact-upload.yml
@@ -28,6 +28,18 @@
           - urllib3
         state: present
 
+    - name: Upload an artifact
+      pulp.squeezer.artifact:
+        pulp_url: "{{ remote_pulp_url }}"
+        username: "{{ remote_pulp_username }}"
+        password: "{{ remote_pulp_password }}"
+        file: "{{ found_files.files[0].path }}"
+        state: present
+      register: upload_result
+      until: upload_result is success
+      retries: 3
+      delay: 60
+
     - name: Get sha256 hash
       ansible.builtin.stat:
         path: "{{ found_files.files[0].path }}"
@@ -46,6 +58,46 @@
         checksum_algorithm: sha256
       register: checksum_stats
 
+    - name: Upload checksum artifact
+      pulp.squeezer.artifact:
+        pulp_url: "{{ remote_pulp_url }}"
+        username: "{{ remote_pulp_username }}"
+        password: "{{ remote_pulp_password }}"
+        file: "/tmp/{{ found_files.files[0].path | basename }}.sha256"
+        state: present
+      register: checksum_upload_result
+      until: checksum_upload_result is success
+      retries: 3
+      delay: 60
+      when: upload_checksum
+
+    - name: Create file content from artifact
+      pulp.squeezer.file_content:
+        pulp_url: "{{ remote_pulp_url }}"
+        username: "{{ remote_pulp_username }}"
+        password: "{{ remote_pulp_password }}"
+        sha256: "{{ file_stats.stat.checksum }}"
+        relative_path: "{{ found_files.files[0].path | basename }}"
+        state: present
+      register: file_content_result
+      until: file_content_result is success
+      retries: 3
+      delay: 5
+
+    - name: Create checksum content from artifact
+      pulp.squeezer.file_content:
+        pulp_url: "{{ remote_pulp_url }}"
+        username: "{{ remote_pulp_username }}"
+        password: "{{ remote_pulp_password }}"
+        sha256: "{{ checksum_stats.stat.checksum }}"
+        relative_path: "{{ found_files.files[0].path | basename }}.sha256"
+        state: present
+      register: checksum_content_result
+      until: checksum_content_result is success
+      retries: 3
+      delay: 5
+      when: upload_checksum
+
     - name: Ensure file repo exists
       pulp.squeezer.file_repository:
         pulp_url: "{{ remote_pulp_url }}"
@@ -58,33 +110,31 @@
       retries: 3
       delay: 5
 
-    - name: Upload artifact
-      pulp.squeezer.file_content:
+    - name: Add content to file repo
+      pulp.squeezer.file_repository_content:
         pulp_url: "{{ remote_pulp_url }}"
         username: "{{ remote_pulp_username }}"
         password: "{{ remote_pulp_password }}"
-        file: "{{ found_files.files[0].path }}"
-        sha256: "{{ file_stats.stat.checksum }}"
-        relative_path: "{{ found_files.files[0].path | basename }}"
-        state: present
         repository: "{{ repository_name }}"
-      register: file_content_result
-      until: file_content_result is success
+        present_content:
+          - relative_path: "{{ found_files.files[0].path | basename }}"
+            sha256: "{{ file_stats.stat.checksum }}"
+      register: file_repo_content_result
+      until: file_repo_content_result is success
       retries: 3
       delay: 5
 
-    - name: Upload checksum
-      pulp.squeezer.file_content:
+    - name: Add checksum content to file repo
+      pulp.squeezer.file_repository_content:
         pulp_url: "{{ remote_pulp_url }}"
         username: "{{ remote_pulp_username }}"
         password: "{{ remote_pulp_password }}"
-        file: "/tmp/{{ found_files.files[0].path | basename }}.sha256"
-        sha256: "{{ checksum_stats.stat.checksum }}"
-        relative_path: "{{ found_files.files[0].path | basename }}.sha256"
-        state: present
         repository: "{{ repository_name }}"
-      register: checksum_content_result
-      until: checksum_content_result is success
+        present_content:
+          - relative_path: "{{ found_files.files[0].path | basename }}.sha256"
+            sha256: "{{ checksum_stats.stat.checksum }}"
+      register: checksum_repo_content_result
+      until: checksum_repo_content_result is success
       retries: 3
       delay: 5
       when: upload_checksum

--- a/etc/kayobe/ansible/requirements.yml
+++ b/etc/kayobe/ansible/requirements.yml
@@ -2,8 +2,10 @@
 collections:
   - name: stackhpc.cephadm
     version: 1.19.3
+  # NOTE: Pinning pulp.squeezer to 0.0.13 because 0.0.14+ depends on the
+  # pulp_glue Python library being installed.
   - name: pulp.squeezer
-    version: 0.1.1
+    version: 0.0.13
   - name: stackhpc.pulp
     version: 0.5.5
   - name: stackhpc.hashicorp

--- a/releasenotes/notes/ansible-requirements-bump-89313038efba83b3.yaml
+++ b/releasenotes/notes/ansible-requirements-bump-89313038efba83b3.yaml
@@ -5,7 +5,6 @@ features:
     versions. This includes:
 
     * ``stackhpc.cephadm`` - ``1.19.1`` -> ``1.19.3``
-    * ``pulp.squeezer`` - ``0.0.13`` -> ``0.1.1``
     * ``ansible-lockdown.rhel9_cis`` - ``1.3.1`` -> ``v1.3.4``
     * ``geerlingguy.pip`` - ``2.2.0`` -> ``3.1.0``
     * ``monolithprojects.github_actions_runner`` - ``1.18.5`` -> ``1.25.1``


### PR DESCRIPTION
The issues surrounding the pulp-glue refactor extend further than I was expecting. At the moment, the effort to update our Ansible Pulp collection isn't worth it.

Fixes recent check-container-images CI failures