### PR TITLE
feat: add `stress-ng` to `IPA` image

### DIFF
--- a/etc/kayobe/ipa.yml
+++ b/etc/kayobe/ipa.yml
@@ -20,7 +20,8 @@
 #ipa_builder_source_version:
 
 # List of additional build host packages to install. Default is an empty list.
-#ipa_build_dib_host_packages_extra:
+ipa_build_dib_host_packages_extra:
+  - stress-ng
 
 # List of default Diskimage Builder (DIB) elements to use when building IPA
 # images. Default is ["centos", "enable-serial-console",

--- a/etc/kayobe/pulp-ipa-image-versions.yml
+++ b/etc/kayobe/pulp-ipa-image-versions.yml
@@ -1,5 +1,5 @@
 ---
 # IPA image versioning tags
-stackhpc_rocky_9_ipa_image_version: "2024.1-20241231T102920"
-stackhpc_ubuntu_jammy_ipa_image_version: "2024.1-20241206T160829"
-stackhpc_ubuntu_noble_ipa_image_version: "2024.1-20250402T132932"
+stackhpc_rocky_9_ipa_image_version: "2024.1-20250630T101821"
+stackhpc_ubuntu_jammy_ipa_image_version: "2024.1-20250630T101821"
+stackhpc_ubuntu_noble_ipa_image_version: "2024.1-20250630T101821"

--- a/releasenotes/notes/add-stress-ng-to-ipa-3cdc1e3f7f7b4cab.yaml
+++ b/releasenotes/notes/add-stress-ng-to-ipa-3cdc1e3f7f7b4cab.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Add ``stress-ng`` to ``IPA`` used for ironic burn-in tests.
+    Update ``IPA`` to ``2024.1-20250630T101821``.


### PR DESCRIPTION
Add ``stress-ng`` to ``IPA`` used for ironic burn-in tests.
Update ``IPA`` to ``2024.1-20250630T101821``.