### PR TITLE
fix: use `overcloud_openbao_docker_tag` for `OpenBao`

### DIFF
--- a/etc/kayobe/pulp.yml
+++ b/etc/kayobe/pulp.yml
@@ -730,7 +730,7 @@ stackhpc_pulp_repository_container_repos_openbao:
     policy: on_demand
     proxy_url: "{{ pulp_proxy_url }}"
     state: present
-    include_tags: "{{ overcloud_vault_docker_tag }}"
+    include_tags: "{{ overcloud_openbao_docker_tag }}"
     required: "{{ stackhpc_sync_openbao_images | bool }}"
 
 # List of OpenBao container image distributions.

--- a/releasenotes/notes/fix-openbao-include-tag-dfef2a0e731674f0.yaml
+++ b/releasenotes/notes/fix-openbao-include-tag-dfef2a0e731674f0.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Ensure that the correct tag is used for ``OpenBao`` repository in ``Pulp``.


### PR DESCRIPTION
Pulp was configured to use `overcloud_vault_docker_tag` for `include_tags` for `OpenBao` repository. This would not work as the tags are not the same. This would silently fail during a `pulp-container-sync`.