### PR TITLE
Fix multinode instance cleanup

### DIFF
--- a/.github/workflows/stackhpc-multinode.yml
+++ b/.github/workflows/stackhpc-multinode.yml
@@ -56,7 +56,7 @@ name: Multinode
 jobs:
   multinode:
     name: Multinode
-    uses: stackhpc/stackhpc-openstack-gh-workflows/.github/workflows/multinode.yml@1.4.0
+    uses: stackhpc/stackhpc-openstack-gh-workflows/.github/workflows/multinode.yml@1.4.1
     with:
       multinode_name: ${{ inputs.multinode_name }}
       os_distribution: ${{ inputs.os_distribution }}


### PR DESCRIPTION
Multinode instances should be automatically deleted by the [cleanup workflow](https://github.com/stackhpc/stackhpc-kayobe-config/blob/stackhpc/2024.1/.github/workflows/stackhpc-ci-cleanup.yml) but have always been skipped because they don't have the right tag.

This change bumps the stackhpc-openstack-gh-workflows pin, so that tags are properly set on multinode instances

See diff here https://github.com/stackhpc/stackhpc-openstack-gh-workflows/compare/1.4.0...1.4.1