### PR TITLE
CI: revert openbao changes for multinode

### DIFF
--- a/etc/kayobe/environments/ci-multinode/stackhpc-monitoring.yml
+++ b/etc/kayobe/environments/ci-multinode/stackhpc-monitoring.yml
@@ -1,3 +1,3 @@
 ---
 # Path to a CA certificate file to trust in the OpenStack Capacity exporter.
-stackhpc_os_capacity_openstack_cacert: "{{ kayobe_env_config_path }}/kolla/certificates/ca/openbao.crt"
+stackhpc_os_capacity_openstack_cacert: "{{ kayobe_env_config_path }}/kolla/certificates/ca/vault.crt"

--- a/etc/kayobe/environments/ci-multinode/tempest.yml
+++ b/etc/kayobe/environments/ci-multinode/tempest.yml
@@ -3,4 +3,4 @@
 rally_no_sensitive_log: false
 
 # Add the Vault CA certificate to the rally container when running tempest.
-tempest_cacert: "{{ kayobe_env_config_path }}/kolla/certificates/ca/openbao.crt"
+tempest_cacert: "{{ kayobe_env_config_path }}/kolla/certificates/ca/vault.crt"


### PR DESCRIPTION
This change fully reverts the openbao deployment in multinodes, so deployments complete end-to-end again.

Tested here: https://github.com/stackhpc/stackhpc-kayobe-config/actions/runs/16140957542/job/45548117501