### PR TITLE
Clone Kayobe into a tempdir when doing version checks

### DIFF
--- a/etc/kayobe/ansible/check-kayobe-version.yml
+++ b/etc/kayobe/ansible/check-kayobe-version.yml
@@ -29,17 +29,27 @@
           register: kayobe_git_commit
           failed_when: kayobe_git_commit.stdout == ""
 
+        - name: Create a temporary directory to clone Kayobe into
+          ansible.builtin.tempfile:
+            state: directory
+          register: kayobe_temp_dir
+
         - name: Clone Kayobe
           ansible.builtin.git:
             repo: https://github.com/stackhpc/kayobe.git
-            dest: /tmp/kayobe-git
+            dest: "{{ kayobe_temp_dir.path }}/kayobe-git"
             version: stackhpc/{{ openstack_release }}
 
         - name: Get tag from Kayobe commit
           ansible.builtin.command:
             cmd: git describe --tags {{ kayobe_git_commit.stdout }}
-            chdir: /tmp/kayobe-git
+            chdir: "{{ kayobe_temp_dir.path }}/kayobe-git"
           register: kayobe_current_version
+
+        - name: Clean up temporary directory
+          ansible.builtin.file:
+            state: absent
+            path: "{{ kayobe_temp_dir.path }}"
 
         - name: Get latest Kayobe version
           ansible.builtin.shell:

--- a/releasenotes/notes/fix-kayobe-version-checks-d1fb3e09391e4a3e.yaml
+++ b/releasenotes/notes/fix-kayobe-version-checks-d1fb3e09391e4a3e.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix Kayobe version checks that were failing on multiuser
+    Ansible control hosts.


### PR DESCRIPTION
Cloning Kayobe as part of check-kayobe-version.yml would fail with POSIX permission errors when it was run by multiple users, because the clone destination directory is a) always the same and b) never cleaned up.

Clone Kayobe into a unique directory each time using ansible.builtin.tempfile and clean up the directory tree when it is no longer needed. This ensures that each user that runs check-kayobe-version.yml gets a
Kayobe checkout to a unique path, and not one that already exists and is owned by someone else.