### PR TITLE
DNM: Generate ProxySQL certificates

### DIFF
--- a/etc/kayobe/ansible/secret-store/secret-store-generate-internal-tls.yml
+++ b/etc/kayobe/ansible/secret-store/secret-store-generate-internal-tls.yml
@@ -54,3 +54,38 @@
         dest: "{{ kayobe_env_config_path }}/kolla/certificates/ca/{{ stackhpc_ca_secret_store }}.crt"
         mode: "0600"
       delegate_to: localhost
+
+# NOTE(seunghun1ee): Kolla Ansible reuses internal TLS certificate when
+# creating certificate for proxysql
+# https://opendev.org/openstack/kolla-ansible/src/branch/stable/2025.1/ansible/roles/certificates/tasks/generate.yml#L169-L183
+    - name: Generate ProxySQL certificates
+      when: kolla_enable_proxysql
+      block:
+        - name: Copy ProxySQL certificate
+          no_log: true
+          ansible.builtin.copy:
+            dest: "{{ kayobe_env_config_path }}/kolla/certificates/proxysql-cert.pem"
+            content: |
+              {{ internal_cert.data.certificate }}
+              {{ internal_cert.data.issuing_ca }}
+            mode: "0600"
+          delegate_to: localhost
+
+        - name: Copy ProxySQL certificate key
+          no_log: true
+          ansible.builtin.copy:
+            dest: "{{ kayobe_env_config_path }}/kolla/certificates/proxysql-key.pem"
+            content: |
+              {{ internal_cert.data.private_key }}
+            mode: "0600"
+          delegate_to: localhost
+
+# NOTE(seunghun1ee): ProxySQL only expects root CA to be named ``root.crt`` because of
+# https://opendev.org/openstack/kolla-ansible/src/branch/stable/2025.1/ansible/roles/loadbalancer/templates/proxysql/proxysql.json.j2#L36
+# Make a duplicate of ``openbao.crt`` named ``root.crt``
+        - name: Copy root CA for ProxySQL
+          ansible.builtin.copy:
+            src: "{{ kayobe_env_config_path }}/openbao/OS-TLS-ROOT.pem"
+            dest: "{{ kayobe_env_config_path }}/kolla/certificates/ca/root.crt"
+            mode: "0600"
+          delegate_to: localhost


### PR DESCRIPTION
This is currently not needed as we decided to disable database internal/backend TLS for now.
However it will be needed once we enable them.