### PR TITLE
kolla_base_arch: derive from local uname

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -62,6 +62,11 @@ kolla_ansible_source_version: "{{ stackhpc_kolla_ansible_source_version }}"
 ###############################################################################
 # Kolla configuration.
 
+# Kolla base container image architecture. Options are "x86_64", "aarch64".
+# Default is "{{ ansible_facts.architecture }}"
+# NOTE(bbezak): evaluating this var locally for non facts gathering playbooks
+kolla_base_arch: "{{ 'aarch64' if lookup('pipe','uname -m') in ['aarch64','arm64'] else 'x86_64' }}"
+
 # Kolla base container image distribution. Options are "centos", "debian",
 # "rocky", "ubuntu". Default is {{ os_distribution }}.
 #kolla_base_distro:


### PR DESCRIPTION
Some playbooks skip fact gathering. Kayobe's default references ansible_facts.architecture for kolla_base_arch, which may be undefined. Derive from `uname -m` so templating works without gathered facts.