### PR TITLE
Push DOCA OFED modules to release

### DIFF
--- a/etc/kayobe/ansible/push-ofed.yml
+++ b/etc/kayobe/ansible/push-ofed.yml
@@ -76,6 +76,6 @@
         password: "{{ stackhpc_release_pulp_password }}"
         name: "{{ doca_modules_repo_distribution_name + ofed_tag }}"
         publication: "{{ publication.publication.pulp_href }}"
-        content_guard: development
+        content_guard: release
         base_path: "{{ doca_modules_repo_base_path + ofed_tag }}"
         state: present


### PR DESCRIPTION
At the moment, we don't have a way to test DOCA modules, or promote them, so we may as well just push them to the release content guard.