### PR TITLE
feat: increase `TTL` for `TLS` role

### DIFF
--- a/etc/kayobe/inventory/group_vars/all/openbao.yml
+++ b/etc/kayobe/inventory/group_vars/all/openbao.yml
@@ -19,8 +19,8 @@ seed_openbao_pki_role_name: "ServerCert"
 seed_openbao_pki_roles:
   - name: "{{ seed_openbao_pki_role_name }}"
     config:
-      max_ttl: 8760h
-      ttl: 8760h
+      max_ttl: 730d
+      ttl: 730d
       allow_any_name: true
       allow_ip_sans: true
       require_cn: false
@@ -59,8 +59,8 @@ overcloud_openbao_pki_external_tls_role_name: "{{ overcloud_openbao_pki_default_
 overcloud_openbao_pki_roles:
   - name: "{{ overcloud_openbao_pki_default_role_name }}"
     config:
-      max_ttl: 8760h
-      ttl: 8760h
+      max_ttl: 730d
+      ttl: 730d
       allow_any_name: true
       allow_ip_sans: true
       require_cn: false

--- a/etc/kayobe/inventory/group_vars/all/vault
+++ b/etc/kayobe/inventory/group_vars/all/vault
@@ -25,8 +25,8 @@ seed_vault_pki_role_name: "ServerCert"
 seed_vault_pki_roles:
   - name: "{{ seed_vault_pki_role_name }}"
     config:
-      max_ttl: 8760h
-      ttl: 8760h
+      max_ttl: 730d
+      ttl: 730d
       allow_any_name: true
       allow_ip_sans: true
       require_cn: false
@@ -71,8 +71,8 @@ overcloud_vault_pki_external_tls_role_name: "{{ overcloud_vault_pki_default_role
 overcloud_vault_pki_roles:
   - name: "{{ overcloud_vault_pki_default_role_name }}"
     config:
-      max_ttl: 8760h
-      ttl: 8760h
+      max_ttl: 730d
+      ttl: 730d
       allow_any_name: true
       allow_ip_sans: true
       require_cn: false

--- a/releasenotes/notes/increase-tls-ttl-c1eba5cca7767d0f.yaml
+++ b/releasenotes/notes/increase-tls-ttl-c1eba5cca7767d0f.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Increase the ``ttl`` of the ``PKI`` role to two years providing
+    the opportunity to replace ``internal`` and ``backend`` certificates
+    during the annual upgrade.


### PR DESCRIPTION
Increasing the `TTL` for both `Vault` and `OpenBao` server role will allow for certificate replacement to be done in conjunction with `OpenStack` upgrades.