### PR TITLE
[fix] Make sure all the sources from the build are removed

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -267,7 +267,8 @@ kolla_build_blocks:
     {% endfor %}
     {% else %}
     RUN \
-        rm /etc/apt/sources.list && \
+        rm -f /etc/apt/sources.list && \
+        rm -f /etc/apt/sources.list.d/* && \
     {% if stackhpc_repo_mirror_auth_proxy_enabled | bool %}
     {# We lack the ca-certificates package at this stage, so don't verify the CA initially #}
         echo 'Acquire::https::Verify-Peer "false";' > /etc/apt/apt.conf.d/90no-verify-peer && \
@@ -305,7 +306,8 @@ kolla_build_blocks:
     COPY sources.list.ubuntu /etc/apt/sources.list.backup
     {% endif %}
     RUN \
-        rm /etc/apt/sources.list && \
+        rm -f /etc/apt/sources.list && \
+        rm -f /etc/apt/sources.list.d/* && \
         rm -f /etc/apt/apt.conf.d/90no-verify-peer && \
     {% for repo in stackhpc_ubuntu_noble_repos %}
         echo '{{ repo }}' >> /etc/apt/sources.list {% if not loop.last %} && \

--- a/releasenotes/notes/fix-ubuntu-sources-12be12aa9853b7b0.yaml
+++ b/releasenotes/notes/fix-ubuntu-sources-12be12aa9853b7b0.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    This update addresses a packaging issue introduced with Ubuntu Noble.
+    The default Apt repository sources now use .sources files in deb822 format, 
+    stored under /etc/apt/sources.list.d/ubuntu.sources. 
+    The change ensures that all build sources, regardless of format are correctly removed during cleanup.


### PR DESCRIPTION
We need to make sure all the sources from kolla build are being removed, because since ubuntu noble:
```
Ubuntu sources have moved to the /etc/apt/sources.list.d/ubuntu.sources
file, which uses the deb822 format. Use deb822-formatted .sources files
to manage package sources in the /etc/apt/sources.list.d/ directory.
See the sources.list(5) manual page for details.
```