### PR TITLE
fixup! Add set of merged playbooks for OpenBao and Vault

### DIFF
--- a/etc/kayobe/inventory/group_vars/all/vault
+++ b/etc/kayobe/inventory/group_vars/all/vault
@@ -86,6 +86,6 @@ overcloud_vault_pki_roles:
 
 seed_vault_pki_certificate_subject:
   - common_name: "{% if kolla_internal_fqdn != kolla_internal_vip_address %}{{ kolla_internal_fqdn }}{% else %}overcloud{% endif %}"
-    role: "{{ seed_openbao_pki_role_name }}"
+    role: "{{ seed_vault_pki_role_name }}"
     extra_params:
       ip_sans: "{% for host in groups['controllers'] %}{{ internal_net_name | net_ip(host) }}{% if not loop.last %},{% endif %}{% endfor %},{{ kolla_internal_vip_address }}"


### PR DESCRIPTION
Fixed ``seed_vault_pki_certificate_subject`` uses openbao pki role name instead of vault pki role name.