### PR TITLE
Add first custom Ansible filter

### DIFF
--- a/etc/kayobe/ansible.cfg
+++ b/etc/kayobe/ansible.cfg
@@ -10,6 +10,8 @@ inject_facts_as_vars = False
 callbacks_enabled = ansible.posix.profile_tasks
 # Silence warning about invalid characters found in group names
 force_valid_group_names = ignore
+# Default value plus custom filter plugins path
+filter_plugins = $ANSIBLE_HOME/plugins/filter:/usr/share/ansible/plugins/filter:$KAYOBE_CONFIG_PATH/ansible/filter_plugins/
 
 [inventory]
 # Fail when any inventory source cannot be parsed.

--- a/etc/kayobe/ansible/filter_plugins/filters.py
+++ b/etc/kayobe/ansible/filter_plugins/filters.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+
+from ansible.errors import AnsibleFilterError
+from ansible.plugins.filter.core import to_bool
+
+class FilterModule(object):
+    def filters(self):
+        return {
+            'select_enabled': self.select_enabled
+        }
+
+    def select_enabled(self, items: list[dict], key: str = 'items') -> list:
+        """Filters a list of dictionaries to select enabled items.
+
+        Parameters:
+            items:
+                List of dictionaries - Each item contains an 'enabled' key, and
+                a key matching the "key" parameter.
+            key:
+                String - The key in each dictionary to extract when 'enabled'
+                is true.
+        
+        Returns:
+            A list of values from the specified key in each dictionary where
+            'enabled' is true. List values are flattened.
+        """
+        result = []
+        for item in items:
+            try:
+                if to_bool(item["enabled"]):
+                    result += item[key] if isinstance(item[key], list) else [item[key]]
+            except KeyError as e:
+                raise AnsibleFilterError("Key %s not found in item: %s" % (e, item))
+        return result

--- a/etc/kayobe/kolla/inventory/group_vars/prometheus-blackbox-exporter
+++ b/etc/kayobe/kolla/inventory/group_vars/prometheus-blackbox-exporter
@@ -6,16 +6,7 @@
 # prometheus_blackbox_exporter_endpoints_kayobe is another set of default
 # endpoints that are templated by Kayobe rather than Kolla Ansible. See
 # kolla/globals.yml for more details.
-prometheus_blackbox_exporter_endpoints_custom: |
-  {% set endpoints = [] %}
-  {% for dict_item in (prometheus_blackbox_exporter_endpoints_kayobe | default([]) + stackhpc_prometheus_blackbox_exporter_endpoints_default) %}
-  {% if dict_item.enabled | bool %}
-  {% for endpoint in dict_item.endpoints %}
-  {% set _ = endpoints.append(endpoint) %}
-  {% endfor %}
-  {% endif %}
-  {% endfor %}
-  {{ (endpoints + stackhpc_prometheus_blackbox_exporter_endpoints_custom) | unique | select | list }}
+prometheus_blackbox_exporter_endpoints_custom: "{{ ((prometheus_blackbox_exporter_endpoints_kayobe | default([]) + stackhpc_prometheus_blackbox_exporter_endpoints_default) | select_enabled('endpoints') + stackhpc_prometheus_blackbox_exporter_endpoints_custom) | unique | select | list }}"
 
 # A list of custom prometheus Blackbox exporter endpoints. Each element should
 # have the following format:

--- a/releasenotes/notes/custom-ansible-filters-bad99d417495b7e0.yaml
+++ b/releasenotes/notes/custom-ansible-filters-bad99d417495b7e0.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Added a new file ``filters.py`` containing custom Ansible filters.
+    Custom filters can be used to replace complex jinja expressions with
+    simplified python code. The first filter ``select_enabled`` replaces
+    an expression to template Blackbox Exporter endpoints. It also serves as an
+    example for future filters.


### PR DESCRIPTION
Adding a custom ansible filter.

This is mainly to serve as an example that we can extend in the future with more custom filters so we can avoid some of the hairy jinja templating we've needed in the past. (See `etc/kayobe/inventory/group_vars/all/firewall` for example)