### PR TITLE
Refresh all Kolla container images

### DIFF
--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -4,8 +4,5 @@
 # where the key is the OS distro and the value is the tag to deploy.
 kolla_image_tags:
   openstack:
-    rocky-9: 2025.1-rocky-9-20250728T150626
-    ubuntu-noble: 2025.1-ubuntu-noble-20250725T143116
-  rabbitmq:
-    rocky-9: 2025.1-rocky-9-20250723T092136
-    ubuntu-noble: 2025.1-ubuntu-noble-20250723T092136
+    rocky-9: 2025.1-rocky-9-20250730T105631
+    ubuntu-noble: 2025.1-ubuntu-noble-20250730T105631

--- a/releasenotes/notes/image-refresh-043917ef996c96b7.yaml
+++ b/releasenotes/notes/image-refresh-043917ef996c96b7.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Refreshed all container image tags for both Rocky and Ubuntu. This applies
+    recent kolla build changes, so that aarch64 images are available for Rocky
+    9, and RabbitMQ now uses version 4.1.


### PR DESCRIPTION
Refreshed all container image tags for both Rocky and Ubuntu. This applies recent kolla build changes, so that aarch64 images are available for Rocky 9, and RabbitMQ now uses version 4.1.


