### PR TITLE
Revert "Merge pull request #1702 from stackhpc/update-rabbitmq-rule"

### DIFF
--- a/etc/kayobe/kolla/config/prometheus/rabbitmq.rules
+++ b/etc/kayobe/kolla/config/prometheus/rabbitmq.rules
@@ -20,7 +20,7 @@ groups:
     annotations:
       description: RabbitMQ consumers message consumption speed is low on {{ $labels.instance }}
   - alert: RabbitMQNodeNotDistributed
-    expr: erlang_vm_dist_node_state < {% endraw %}{{ alertmanager_number_of_rabbitmq_nodes }}{% raw %}
+    expr: erlang_vm_dist_node_state < 3
     for: 5m
     labels:
       severity: critical


### PR DESCRIPTION
This reverts commit c9c3ebacd967ca23b96a2738759571afaf7c025b, reversing changes made to ddd4daa8187b9664a82bb94eccd6bd647637aeea.

The metric `erlang_vm_dist_node_state` should not be compared against the size of the `RabbitMQ` cluster as the values indicate the current state of the link with `3` implying the connection is `up`.