### PR TITLE
Fix older periodic multinodes

### DIFF
--- a/.github/workflows/multinode-inputs.py
+++ b/.github/workflows/multinode-inputs.py
@@ -63,6 +63,9 @@ def generate_inputs(scenario: Scenario) -> t.Dict[str, str]:
             VERSION_HIERARCHY.index(scenario.openstack_release.version) - 1
         ]
     )
+    terraform_kayobe_multinode_version = get_tkm_version(
+        scenario.openstack_release.version
+    )
     inputs = {
         "os_distribution": scenario.os_release.distribution,
         "os_release": scenario.os_release.release,
@@ -71,12 +74,20 @@ def generate_inputs(scenario: Scenario) -> t.Dict[str, str]:
         "upgrade": scenario.upgrade,
         "stackhpc_kayobe_config_version": branch,
         "stackhpc_kayobe_config_previous_version": previous_branch,
+        "terraform_kayobe_multinode_version": terraform_kayobe_multinode_version,
     }
     return inputs
 
 
 def get_branch(version: str) -> str:
     return f"stackhpc/{version}"
+
+
+def get_tkm_version(version: str) -> str:
+    if version in ["zed", "2023.1"]:
+        return "ea61ea1730e179e05e8f0e58b759267664c555e7"
+    else:
+        return "main"
 
 
 def write_output(name: str, value: str) -> None:

--- a/.github/workflows/multinode-inputs.py
+++ b/.github/workflows/multinode-inputs.py
@@ -17,7 +17,6 @@ class OSRelease:
 @dataclass
 class OpenStackRelease:
     version: str
-    previous_version: str
     os_releases: t.List[OSRelease]
 
 
@@ -34,11 +33,12 @@ UBUNTU_JAMMY = OSRelease("ubuntu", "jammy", "ubuntu")
 UBUNTU_NOBLE = OSRelease("ubuntu", "noble", "ubuntu")
 # NOTE(upgrade): Add supported releases here.
 OPENSTACK_RELEASES = [
-    OpenStackRelease("2023.1", "zed", [ROCKY_9, UBUNTU_JAMMY]),
-    OpenStackRelease("2024.1", "2023.1", [ROCKY_9, UBUNTU_JAMMY]),
-    OpenStackRelease("2025.1", "2024.1", [ROCKY_9, UBUNTU_NOBLE]),
+    OpenStackRelease("2023.1", [ROCKY_9, UBUNTU_JAMMY]),
+    OpenStackRelease("2024.1", [ROCKY_9, UBUNTU_JAMMY]),
+    OpenStackRelease("2025.1", [ROCKY_9, UBUNTU_NOBLE]),
 ]
 NEUTRON_PLUGINS = ["ovs", "ovn"]
+VERSION_HIERARCHY = ["zed", "2023.1", "2024.1", "2025.1"]
 
 
 def main() -> None:
@@ -52,13 +52,17 @@ def random_scenario() -> Scenario:
     openstack_release = random.choice(OPENSTACK_RELEASES)
     os_release = random.choice(openstack_release.os_releases)
     neutron_plugin = random.choice(NEUTRON_PLUGINS)
-    upgrade = 'major' if random.random() > 0.6 else 'none'
+    upgrade = "major" if random.random() > 0.6 else "none"
     return Scenario(openstack_release, os_release, neutron_plugin, upgrade)
 
 
 def generate_inputs(scenario: Scenario) -> t.Dict[str, str]:
     branch = get_branch(scenario.openstack_release.version)
-    previous_branch = get_branch(scenario.openstack_release.previous_version)
+    previous_branch = get_branch(
+        VERSION_HIERARCHY[
+            VERSION_HIERARCHY.index(scenario.openstack_release.version) - 1
+        ]
+    )
     inputs = {
         "os_distribution": scenario.os_release.distribution,
         "os_release": scenario.os_release.release,

--- a/.github/workflows/stackhpc-multinode-periodic.yml
+++ b/.github/workflows/stackhpc-multinode-periodic.yml
@@ -19,6 +19,7 @@ jobs:
       upgrade: ${{ steps.generate-inputs.outputs.upgrade }}
       stackhpc_kayobe_config_version: ${{ steps.generate-inputs.outputs.stackhpc_kayobe_config_version }}
       stackhpc_kayobe_config_previous_version: ${{ steps.generate-inputs.outputs.stackhpc_kayobe_config_previous_version }}
+      terraform_kayobe_multinode_version: ${{ steps.generate-inputs.outputs.terraform_kayobe_multinode_version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -45,6 +46,7 @@ jobs:
       upgrade: ${{ needs.generate-inputs.outputs.upgrade }}
       stackhpc_kayobe_config_version: ${{ needs.generate-inputs.outputs.stackhpc_kayobe_config_version }}
       stackhpc_kayobe_config_previous_version: ${{ needs.generate-inputs.outputs.stackhpc_kayobe_config_previous_version }}
+      terraform_kayobe_multinode_version: ${{ needs.generate-inputs.outputs.terraform_kayobe_multinode_version }}
       enable_slack_alert: true
     secrets: inherit
     if: github.repository == 'stackhpc/stackhpc-kayobe-config'


### PR DESCRIPTION
Includes 2 commits

The first is a minor refactor of the periodic Multinode python script (which is not required for the old periodic mn fix)

The second adds a new argument to the workflow invocation, to change the version of terraform-kayobe-multinode. The input [already exists](https://github.com/stackhpc/stackhpc-openstack-gh-workflows/blob/main/.github/workflows/multinode.yml#L49).