### PR TITLE
Build keystone from downstream fork

### DIFF
--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -6,3 +6,6 @@ kolla_image_tags:
   openstack:
     rocky-9: 2025.1-rocky-9-20250730T105631
     ubuntu-noble: 2025.1-ubuntu-noble-20250730T105631
+  keystone:
+    rocky-9: 2025.1-rocky-9-20250805T134044
+    ubuntu-noble: 2025.1-ubuntu-noble-20250805T134044

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -135,6 +135,10 @@ kolla_sources:
     type: git
     location: https://github.com/stackhpc/stackhpc-inspector-plugins.git
     reference: 1.3.0
+  keystone-base:
+    type: git
+    location: https://github.com/stackhpc/keystone.git
+    reference: stackhpc/{{ openstack_release }}
   magnum-base:
     type: git
     location: https://github.com/stackhpc/magnum.git


### PR DESCRIPTION
Until [1] is merged and [2] is fixed.

[1] https://review.opendev.org/c/openstack/keystone/+/956549
[2] https://bugs.launchpad.net/keystone/+bug/2119543