### PR TITLE
Upstream magnum

### DIFF
--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -10,5 +10,5 @@ kolla_image_tags:
     rocky-9: 2025.1-rocky-9-20250805T134044
     ubuntu-noble: 2025.1-ubuntu-noble-20250805T134044
   magnum:
-    rocky-9: 2025.1-rocky-9-20250805T095746
-    ubuntu-noble: 2025.1-ubuntu-noble-20250805T095746
+    rocky-9: 2025.1-rocky-9-20250811T111154
+    ubuntu-noble: 2025.1-ubuntu-noble-20250811T111154

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -139,10 +139,6 @@ kolla_sources:
     type: git
     location: https://github.com/stackhpc/keystone.git
     reference: stackhpc/{{ openstack_release }}
-  magnum-base:
-    type: git
-    location: https://github.com/stackhpc/magnum.git
-    reference: stackhpc/{{ openstack_release }}
   neutron-server-plugin-networking-mlnx:
     type: git
     location: https://github.com/stackhpc/networking-mlnx.git

--- a/releasenotes/notes/use-upstream-magnum-86854beee69151f5.yaml
+++ b/releasenotes/notes/use-upstream-magnum-86854beee69151f5.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Use upstream source of Magnum for Kolla container image build.
+    The StackHPC downstream Magnum repository was for keeping Heat driver
+    support.
+    As Heat support was deprecated, there's no need to build Magnum from
+    downstream source.


### PR DESCRIPTION
Our downstream Magnum [1] was for keeping Heat driver support.
But we dropped them, so there's no need to build magnum from downstream.

[1] https://github.com/stackhpc/magnum/pull/202