### PR TITLE
Update CloudKitty docs to use OpenSearch

### DIFF
--- a/doc/source/configuration/cloudkitty.rst
+++ b/doc/source/configuration/cloudkitty.rst
@@ -22,18 +22,13 @@ storage backend. Set the following in ``kolla.yml``:
   kolla_enable_influxdb: false
 
 Set Prometheus as the backend for both the collector and fetcher, and
-Elasticsearch as the storage backend. Note that our fork of CloudKitty is
-patched so that the CloudKitty Elasticsearch V2 storage backend will also work
-with an OpenSearch cluster. Proper support for the V2 OpenSearch storage
-backend is still pending in Kolla-Ansible `here
-<https://review.opendev.org/c/openstack/kolla-ansible/+/898555>`__. Set the
-following in ``kolla/globals.yml``:
+OpenSearch as the storage backend. Set the following in ``kolla/globals.yml``:
 
 .. code-block:: yaml
 
   cloudkitty_collector_backend: prometheus
   cloudkitty_fetcher_backend: prometheus
-  cloudkitty_storage_backend: elasticsearch
+  cloudkitty_storage_backend: opensearch
 
 The default collection period is one hour, which is likely too long for most
 systems as CloudKitty charges by the **entire** collection period if any usage


### PR DESCRIPTION
The ElasticSearch backend is no longer compatible with OpenSearch as of 2025.1 Epoxy and results in an API error:

`2025-08-12 13:45:32.187 37 ERROR cloudkitty cloudkitty.storage.v2.elasticsearch.exceptions.InvalidStatusCode: Expected 200 status code, got 400: {"error":"no handler found for uri [/cloudkitty/_mapping/_doc] and method [PUT]"}. Query was {"dynamic_templates": [{"strings_as_keywords": {"match_mapping_type": "string", "mapping": {"type": "keyword"}}}], "dynamic": false, "properties": {"start": {"type": "date"}, "end": {"type": "date"}, "type": {"type": "keyword"}, "unit": {"type": "keyword"}, "qty": {"type": "double"}, "price": {"type": "double"}, "groupby": {"dynamic": true, "type": "object"}, "metadata": {"dynamic": true, "type": "object"}}}`