### PR TITLE
Revert "Use rabbitmq length for ``RabbitMQNodeNotDistributed`` (cherry-pick #1702)"

### DIFF
--- a/etc/kayobe/kolla/config/prometheus/rabbitmq.rules
+++ b/etc/kayobe/kolla/config/prometheus/rabbitmq.rules
@@ -20,7 +20,7 @@ groups:
     annotations:
       description: RabbitMQ consumers message consumption speed is low on {{ $labels.instance }}
   - alert: RabbitMQNodeNotDistributed
-    expr: erlang_vm_dist_node_state < {% endraw %}{{ alertmanager_number_of_rabbitmq_nodes }}{% raw %}
+    expr: erlang_vm_dist_node_state < 3
     for: 5m
     labels:
       severity: critical


### PR DESCRIPTION
Reverts stackhpc/stackhpc-kayobe-config#1703