### PR TITLE
Fix Grafana project metrics dashboard

### DIFF
--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -87,6 +87,10 @@ kolla_image_tags:
     ubuntu-jammy: 2024.1-ubuntu-jammy-20250219T145255
   prometheus_alertmanager:
     ubuntu-jammy: 2024.1-ubuntu-jammy-20250422T103147
+  prometheus_libvirt_exporter:
+    rocky-9: 2024.1-rocky-9-20250819T151035
+    ubuntu-jammy: 2024.1-ubuntu-jammy-20250819T151035
+    ubuntu-noble: 2024.1-ubuntu-noble-20250819T151035
   rabbitmq:
     rocky-9: 2024.1-rocky-9-20250722T083943
     ubuntu-jammy: 2024.1-ubuntu-jammy-20250722T083943

--- a/etc/kayobe/kolla/config/grafana/dashboards/openstack/grafana_project_dashboard.json
+++ b/etc/kayobe/kolla/config/grafana/dashboards/openstack/grafana_project_dashboard.json
@@ -25,8 +25,8 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
+  "id": 7,
   "links": [],
-  "liveNow": false,
   "panels": [
     {
       "collapsed": false,
@@ -57,8 +57,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "semi-dark-yellow",
-                "value": null
+                "color": "semi-dark-yellow"
               },
               {
                 "color": "green",
@@ -78,8 +77,16 @@
       "id": 18,
       "options": {
         "displayMode": "basic",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
         "minVizHeight": 10,
         "minVizWidth": 0,
+        "namePlacement": "auto",
         "orientation": "horizontal",
         "reduceOptions": {
           "calcs": [
@@ -89,9 +96,10 @@
           "values": false
         },
         "showUnfilled": true,
+        "sizing": "auto",
         "valueMode": "color"
       },
-      "pluginVersion": "10.1.5",
+      "pluginVersion": "12.0.1+security-01",
       "targets": [
         {
           "datasource": {
@@ -121,11 +129,13 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 23,
             "gradientMode": "none",
@@ -156,8 +166,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -190,10 +199,12 @@
           "sortDesc": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
+      "pluginVersion": "12.0.1+security-01",
       "targets": [
         {
           "datasource": {
@@ -223,11 +234,13 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 23,
             "gradientMode": "none",
@@ -258,8 +271,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -292,10 +304,12 @@
           "sortDesc": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
+      "pluginVersion": "12.0.1+security-01",
       "targets": [
         {
           "datasource": {
@@ -324,11 +338,13 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 23,
             "gradientMode": "none",
@@ -359,8 +375,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -392,10 +407,12 @@
           "sortDesc": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
+      "pluginVersion": "12.0.1+security-01",
       "targets": [
         {
           "datasource": {
@@ -403,7 +420,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "count(count(libvirt_domain_info_meta{project_uuid=~\"${project_id}\"}) by (domain,flavor)) by (flavor)",
+          "expr": "count(count(libvirt_domain_openstack_info{project_id=~\"${project_id}\"}) by (domain,flavor_name)) by (flavor_name)",
           "hide": false,
           "legendFormat": "__auto",
           "range": true,
@@ -424,12 +441,14 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "axisSoftMax": 1,
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 23,
             "gradientMode": "none",
@@ -460,8 +479,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -494,10 +512,12 @@
           "sortDesc": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
+      "pluginVersion": "12.0.1+security-01",
       "targets": [
         {
           "datasource": {
@@ -505,14 +525,14 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "avg(sum(irate(libvirt_domain_vcpu_time_seconds_total{}[5m]) / ignoring(instance,vcpu) group_left(domain) libvirt_domain_info_virtual_cpus{}) by (domain) * on(domain) group_left(instance_name,project_name,project_uuid) libvirt_domain_info_meta{project_uuid=~\"${project_id}\"}) by (project_name)",
+          "expr": "avg(sum(irate(libvirt_domain_vcpu_time_seconds_total{}[5m]) / ignoring(instance,vcpu) group_left(domain) libvirt_domain_info_virtual_cpus{}) by (domain) * on(domain) group_left(instance_name,project_name,project_id) libvirt_domain_openstack_info{project_id=~\"${project_id}\"}) by (project_name)",
           "hide": false,
           "legendFormat": "{{instance_name}}",
           "range": true,
           "refId": "B"
         }
       ],
-      "title": "CPU utilization per instance",
+      "title": "CPU utilization per project",
       "type": "timeseries"
     },
     {
@@ -526,11 +546,13 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 23,
             "gradientMode": "none",
@@ -562,8 +584,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -595,10 +616,12 @@
           "sortDesc": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
+      "pluginVersion": "12.0.1+security-01",
       "targets": [
         {
           "datasource": {
@@ -606,14 +629,14 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "avg(libvirt_domain_memory_stats_used_percent * on(domain) group_left(instance_name,project_name,project_uuid) libvirt_domain_info_meta{project_uuid=~\"${project_id}\"}) by (project_name)",
+          "expr": "avg(libvirt_domain_memory_stats_used_percent * on(domain) group_left(instance_name,project_name,project_id) libvirt_domain_openstack_info{project_id=~\"${project_id}\"}) by (project_name)",
           "hide": false,
           "legendFormat": "{{instance_name}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Memory utilization per instance",
+      "title": "Memory utilization per project",
       "type": "timeseries"
     },
     {
@@ -628,11 +651,13 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": true,
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 23,
             "gradientMode": "none",
@@ -665,8 +690,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -698,10 +722,12 @@
           "sortDesc": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
+      "pluginVersion": "12.0.1+security-01",
       "targets": [
         {
           "datasource": {
@@ -709,7 +735,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "avg(rate(libvirt_domain_block_stats_read_time_seconds_total[5m]) * on(domain) group_left(instance_name,project_name,project_uuid) libvirt_domain_info_meta{project_uuid=~\"${project_id}\"}) by (project_name)",
+          "expr": "avg(rate(libvirt_domain_block_stats_read_time_seconds_total[5m]) * on(domain) group_left(instance_name,project_name,project_id) libvirt_domain_openstack_info{project_id=~\"${project_id}\"}) by (project_name)",
           "hide": false,
           "legendFormat": "read: {{project_name}}",
           "range": true,
@@ -721,14 +747,14 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "avg(rate(libvirt_domain_block_stats_write_time_seconds_total[5m]) * on(domain) group_left(instance_name,project_name,project_uuid) libvirt_domain_info_meta{project_uuid=~\"${project_id}\"} * -1) by (project_name)",
+          "expr": "avg(rate(libvirt_domain_block_stats_write_time_seconds_total[5m]) * on(domain) group_left(instance_name,project_name,project_id) libvirt_domain_openstack_info{project_id=~\"${project_id}\"} * -1) by (project_name)",
           "hide": false,
           "legendFormat": " write: {{project_name}}",
           "range": true,
           "refId": "C"
         }
       ],
-      "title": "Disk utilization per instance",
+      "title": "Disk utilization per project",
       "type": "timeseries"
     },
     {
@@ -755,12 +781,14 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "axisSoftMax": 1,
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 23,
             "gradientMode": "none",
@@ -791,8 +819,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -825,10 +852,12 @@
           "sortDesc": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
+      "pluginVersion": "12.0.1+security-01",
       "targets": [
         {
           "datasource": {
@@ -836,7 +865,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(irate(libvirt_domain_vcpu_time_seconds_total{}[5m]) / ignoring(instance,vcpu) group_left(domain) libvirt_domain_info_virtual_cpus{}) by (domain) * on(domain) group_left(instance_name,project_name,project_uuid) libvirt_domain_info_meta{project_uuid=~\"${project_id}\"}",
+          "expr": "sum(irate(libvirt_domain_vcpu_time_seconds_total{}[5m]) / ignoring(instance,vcpu) group_left(domain) libvirt_domain_info_virtual_cpus{}) by (domain) * on(domain) group_left(instance_name,project_name,project_id) libvirt_domain_openstack_info{project_id=~\"${project_id}\"}",
           "hide": false,
           "legendFormat": "{{instance_name}}",
           "range": true,
@@ -857,11 +886,13 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 23,
             "gradientMode": "none",
@@ -893,8 +924,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -927,10 +957,12 @@
           "sortDesc": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
+      "pluginVersion": "12.0.1+security-01",
       "targets": [
         {
           "datasource": {
@@ -938,7 +970,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "libvirt_domain_memory_stats_used_percent * on(domain) group_left(instance_name,project_name,project_uuid) libvirt_domain_info_meta{project_uuid=~\"${project_id}\"}",
+          "expr": "libvirt_domain_memory_stats_used_percent * on(domain) group_left(instance_name,project_name,project_id) libvirt_domain_openstack_info{project_id=~\"${project_id}\"}",
           "hide": false,
           "legendFormat": "{{instance_name}}",
           "range": true,
@@ -960,11 +992,13 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": true,
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 23,
             "gradientMode": "none",
@@ -997,8 +1031,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1030,10 +1063,12 @@
           "sortDesc": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
+      "pluginVersion": "12.0.1+security-01",
       "targets": [
         {
           "datasource": {
@@ -1041,7 +1076,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "rate(libvirt_domain_block_stats_read_time_seconds_total[5m]) * on(domain) group_left(instance_name,project_name,project_uuid) libvirt_domain_info_meta{project_uuid=~\"${project_id}\"}",
+          "expr": "rate(libvirt_domain_block_stats_read_time_seconds_total[5m]) * on(domain) group_left(instance_name,project_name,project_id) libvirt_domain_openstack_info{project_id=~\"${project_id}\"}",
           "hide": false,
           "legendFormat": "{{instance_name}} : read {{target_device}}",
           "range": true,
@@ -1053,7 +1088,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "avg(rate(libvirt_domain_block_stats_write_time_seconds_total[5m]) * on(domain) group_left(instance_name,project_name,project_uuid) libvirt_domain_info_meta{project_uuid=~\"${project_id}\"} * -1) by (project_name)",
+          "expr": "rate(libvirt_domain_block_stats_write_time_seconds_total[5m]) * on(domain) group_left(instance_name,project_name,project_id) libvirt_domain_openstack_info{project_id=~\"${project_id}\"} * -1",
           "hide": false,
           "legendFormat": "{{instance_name}} : write {{target_device}}",
           "range": true,
@@ -1064,10 +1099,9 @@
       "type": "timeseries"
     }
   ],
+  "preload": false,
   "refresh": "",
-  "revision": 1,
-  "schemaVersion": 38,
-  "style": "dark",
+  "schemaVersion": 41,
   "tags": [
     "capacity",
     "azimuth"
@@ -1076,27 +1110,21 @@
     "list": [
       {
         "current": {
-          "selected": false,
           "text": "Prometheus",
           "value": "PBFA97CFB590B2093"
         },
         "description": "The prometheus datasource used for queries.",
-        "hide": 0,
         "includeAll": false,
         "label": "datasource",
-        "multi": false,
         "name": "datasource",
         "options": [],
         "query": "prometheus",
-        "queryValue": "",
         "refresh": 1,
         "regex": "",
-        "skipUrlSync": false,
         "type": "datasource"
       },
       {
         "current": {
-          "selected": true,
           "text": [
             "All"
           ],
@@ -1109,7 +1137,6 @@
           "uid": "${datasource}"
         },
         "definition": "openstack_project_usage",
-        "hide": 0,
         "includeAll": true,
         "label": "Project",
         "multi": true,
@@ -1121,8 +1148,6 @@
         },
         "refresh": 1,
         "regex": "/project_name=\"(?<text>[^\"]+)|project_id=\"(?<value>[^\"]+)/g",
-        "skipUrlSync": false,
-        "sort": 0,
         "type": "query"
       }
     ]
@@ -1135,7 +1160,6 @@
   "timezone": "",
   "title": "OpenStack Project Metrics",
   "uid": "mXiuBDe7z",
-  "version": 1,
-  "weekStart": ""
+  "version": 1
 }
 {% endraw %}

--- a/releasenotes/notes/fix-libvirt-dashboard-b33327f804bea5f9.yaml
+++ b/releasenotes/notes/fix-libvirt-dashboard-b33327f804bea5f9.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixed broken panels in the project metrics Grafana dashboard by updating
+    the Prometheus Libvirt exporter and editing the dashboard queries.
+    
+    The exporter was updated from ``v1.6.0`` to ``v2.2.0``. A full breakdown of
+    changes can be found `here
+    <https://github.com/inovex/prometheus-libvirt-exporter/compare/v1.6.0...v2.2.0>`__


### PR DESCRIPTION
Adds new prometheus libvirt exporter container with correct metrics and edits to the PromQL queries to use the new metrics (some of them use different names to the first exporter we used)

Fixed dashboard example:
<img width="2229" height="1137" alt="image" src="https://github.com/user-attachments/assets/e50202fa-5b3e-4274-8457-19167d59219c" />

I'm submitting this for Caracal first because the kolla pins haven't been bumped yet in Epoxy, see https://github.com/stackhpc/stackhpc-kayobe-config/pull/1836
