### PR TITLE
Move database TLS disable config to general kolla config

### DIFF
--- a/etc/kayobe/environments/ci-multinode/kolla/globals.yml
+++ b/etc/kayobe/environments/ci-multinode/kolla/globals.yml
@@ -15,10 +15,6 @@ kolla_enable_tls_backend: "yes"
 # Enable RabbitMQ TLS
 rabbitmq_enable_tls: "yes"
 
-# Disable database TLS
-database_enable_tls_internal: false
-database_enable_tls_backend: false
-
 ############################################################################
 # Most development environments will use nested virtualisation, and we can't
 # guarantee that nested KVM support is available. Use QEMU as a lowest common

--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -60,3 +60,8 @@ prometheus_blackbox_exporter_endpoints_kayobe:
 prometheus_openstack_exporter_interval: "{{ stackhpc_prometheus_openstack_exporter_interval }}s"
 
 rabbitmq_image: "{% raw %}{{ docker_registry ~ '/' if docker_registry else '' }}{{ docker_namespace }}/rabbitmq-4-1{% endraw %}"
+
+# NOTE(seunghun1ee) Disable database TLS until ProxySQL 2.7 gets bug fix for
+# https://github.com/sysown/proxysql/issues/4877 or K-A bumps ProxySQL to 3.x.
+database_enable_tls_internal: false
+database_enable_tls_backend: false


### PR DESCRIPTION
These two Kolla config options need to be in general one to actually have an effect on customer systems.