### PR TITLE
Update epoxy upgrade doc

### DIFF
--- a/doc/source/operations/upgrading-openstack.rst
+++ b/doc/source/operations/upgrading-openstack.rst
@@ -152,15 +152,6 @@ if using environments) to 3.43.1,
 or pulling all custom built images before destroying pulp then push them again
 after pulp upgrade is done.
 
-Let's Encrypt
--------------
-
-`Let's Encrypt TLS settings fix <https://review.opendev.org/c/openstack/kolla-ansible/+/925971>`__
-brought a breaking change to Let’s Encrypt ansible role. Now users have to explicitly set the target
-Let’s Encrypt ACME server as a kolla ansible variable ``letsencrypt_external_cert_server``/
-``letsencrypt_internal_cert_server`` if they were using Let’s Encrypt as a CA of their
-external/internal TLS certificates.
-
 Cinder
 ------
 

--- a/doc/source/operations/upgrading-openstack.rst
+++ b/doc/source/operations/upgrading-openstack.rst
@@ -362,25 +362,15 @@ For Rocky Linux 9, install Python 3.12 manually.
 
 For both Operating Systems, Kayobe and Kolla-Ansible Python virtual environments
 created with older Python version will not work with OpenStack 2025.1.
-Create new Kayobe Python virtual environment with Python 3.12.
 
-.. code-block:: bash
+Create new Kayobe environment and bootstrap Ansible control host with Python 3.12.
+Beokay is recommended when creating and managing local Kayobe environment.
+You can find more information from :ref:`beokay` documentation.
 
-   # Ubuntu 24.04
-   python3 -m venv venvs/kayobe
+.. note::
 
-   # Rocky Linux 9 need to specify python3.12 as it is not the default
-   python3.12 -m venv venvs/kayobe
-
-Activate the Kayobe Python virtual environment and then install Kayobe.
-
-.. code-block:: bash
-
-   source venvs/kayobe/bin/activate
-   pip install -r $KAYOBE_CONFIG_PATH/../../requirements.txt
-
-Run ``kayobe control host bootstrap`` to populate Kolla-Ansible Python virtual
-environment and bootstrap Ansible control host.
+   For Rocky Linux 9, ``beokay create`` need ``--python python3.12`` option
+   to specify Beokay to use Python 3.12 as it is not the default.
 
 Preparation
 ===========
@@ -508,8 +498,9 @@ The local Kayobe environment should be either recreated or upgraded to use the
 new release. It may be beneficial to keep a Kayobe environment for the old
 release in case it is necessary before the upgrade begins.
 
-In general it is safer to rebuild an environment than upgrade, but for
-completeness the following shows how to upgrade an existing local Kayobe
+In general it is safer to rebuild an environment than upgrade. You can follow
+instructions from :ref:`beokay` documentation.
+But for completeness the following shows how to upgrade an existing local Kayobe
 environment.
 
 Change to the Kayobe configuration directory:

--- a/doc/source/operations/upgrading-openstack.rst
+++ b/doc/source/operations/upgrading-openstack.rst
@@ -489,9 +489,10 @@ configuration.  The output of the command may be restricted using the
 Upgrading local Kayobe environment
 ----------------------------------
 
-.. note::
+.. warning::
 
-   For OpenStack 2025.1 Kayobe environment, Python 3.12 is required.
+   Python 3.12 is required for OpenStack 2025.1 Kayobe environments.
+   The environment cannot be upgraded for this release, it must be rebuilt.
    You can find more information at :ref:`python-3-12`
 
 The local Kayobe environment should be either recreated or upgraded to use the

--- a/doc/source/operations/upgrading-openstack.rst
+++ b/doc/source/operations/upgrading-openstack.rst
@@ -351,7 +351,7 @@ Python 3.12
 
 From OpenStack 2025.1, Kayobe and Kolla-Ansible require Python 3.12.
 
-Ubuntu 24.04 has default Python of version 3.12.
+Ubuntu 24.04 has a default Python of version 3.12.
 You can find the upgrade procedure from :ref:`upgrading-to-ubuntu-noble`
 
 For Rocky Linux 9, install Python 3.12 manually.
@@ -361,16 +361,16 @@ For Rocky Linux 9, install Python 3.12 manually.
    dnf install python3.12
 
 For both Operating Systems, Kayobe and Kolla-Ansible Python virtual environments
-created with older Python version will not work with OpenStack 2025.1.
+created with older Python versions will not work with OpenStack 2025.1.
 
-Create new Kayobe environment and bootstrap Ansible control host with Python 3.12.
-Beokay is recommended when creating and managing local Kayobe environment.
-You can find more information from :ref:`beokay` documentation.
+Create a new Kayobe environment and bootstrap the Ansible control host with Python 3.12.
+Beokay is recommended when creating and managing the local Kayobe environment.
+You can find more information from the :ref:`beokay` documentation.
 
 .. note::
 
-   For Rocky Linux 9, ``beokay create`` need ``--python python3.12`` option
-   to specify Beokay to use Python 3.12 as it is not the default.
+   For Rocky Linux 9, ``beokay create`` must be used with the ``--python python3.12``
+   option to specify Beokay to use Python 3.12 as it is not the default.
 
 Preparation
 ===========
@@ -500,7 +500,7 @@ new release. It may be beneficial to keep a Kayobe environment for the old
 release in case it is necessary before the upgrade begins.
 
 In general it is safer to rebuild an environment than upgrade. You can follow
-instructions from :ref:`beokay` documentation.
+instructions from the :ref:`beokay` documentation.
 But for completeness the following shows how to upgrade an existing local Kayobe
 environment.
 

--- a/doc/source/operations/upgrading-openstack.rst
+++ b/doc/source/operations/upgrading-openstack.rst
@@ -353,6 +353,44 @@ After the queue migration is finished, upgrade RabbitMQ to 4.1.
 
       kayobe kolla ansible run "rabbitmq-upgrade 4.1"
 
+.. _python-3-12:
+
+Python 3.12
+-----------
+
+From OpenStack 2025.1, Kayobe and Kolla-Ansible require Python 3.12.
+
+Ubuntu 24.04 has default Python of version 3.12.
+You can find the upgrade procedure from :ref:`upgrading-to-ubuntu-noble`
+
+For Rocky Linux 9, install Python 3.12 manually.
+
+.. code-block:: bash
+
+   dnf install python3.12
+
+For both Operating Systems, Kayobe and Kolla-Ansible Python virtual environments
+created with older Python version will not work with OpenStack 2025.1.
+Create new Kayobe Python virtual environment with Python 3.12.
+
+.. code-block:: bash
+
+   # Ubuntu 24.04
+   python3 -m venv venvs/kayobe
+
+   # Rocky Linux 9 need to specify python3.12 as it is not the default
+   python3.12 -m venv venvs/kayobe
+
+Activate the Kayobe Python virtual environment and then install Kayobe.
+
+.. code-block:: bash
+
+   source venvs/kayobe/bin/activate
+   pip install -r $KAYOBE_CONFIG_PATH/../../requirements.txt
+
+Run ``kayobe control host bootstrap`` to populate Kolla-Ansible Python virtual
+environment and bootstrap Ansible control host.
+
 Preparation
 ===========
 
@@ -470,9 +508,14 @@ configuration.  The output of the command may be restricted using the
 Upgrading local Kayobe environment
 ----------------------------------
 
+.. note::
+
+   For OpenStack 2025.1 Kayobe environment, Python 3.12 is required.
+   You can find more information at :ref:`python-3-12`
+
 The local Kayobe environment should be either recreated or upgraded to use the
 new release. It may be beneficial to keep a Kayobe environment for the old
-release in case it is necessary before the uprade begins.
+release in case it is necessary before the upgrade begins.
 
 In general it is safer to rebuild an environment than upgrade, but for
 completeness the following shows how to upgrade an existing local Kayobe

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -58,6 +58,8 @@ The intention is to avoid merge conflicts where possible, but there may be
 cases where this is difficult. We are open to discussion on how best to
 approach this on both sides.
 
+.. _beokay:
+
 Beokay
 ------
 
@@ -87,6 +89,17 @@ Kayobe environments can also be specified, for example, to create an AIO environ
    --kayobe-config-env-name ci-aio \
    --vault-password-file ~/vault-pw \
    --kayobe-in-requirements
+
+Python executable can also be specified, for example, to use Python 3.12:
+
+.. code-block:: console
+
+   beokay.py create \
+   --base-path skc-environment \
+   --kayobe-config-repo https://github.com/stackhpc/stackhpc-kayobe-config.git \
+   --kayobe-config-branch |current_release_git_branch_name| \
+   --kayobe-in-requirements
+   --python python3.12
 
 When Beokay environments are no longer required, they can be deleted by running:
 


### PR DESCRIPTION
- Added Prerequisite section about using Python 3.12
- Removed Known issue section of Let's Encrypt because the issue was resolved