### PR TITLE
Update azimuth_ops collection FQCN

### DIFF
--- a/doc/source/configuration/magnum-capi.rst
+++ b/doc/source/configuration/magnum-capi.rst
@@ -72,7 +72,7 @@ To deploy the CAPI management cluster using this site-specific environment, run
     # Run the provision playbook from the azimuth-ops collection
     # NOTE: THIS COMMAND RUNS A DIFFERENT PLAYBOOK FROM
     # THE STANDARD AZIMUTH DEPLOYMENT INSTRUCTIONS
-    ansible-playbook stackhpc.azimuth_ops.provision_capi_mgmt
+    ansible-playbook azimuth_cloud.azimuth_ops.provision_capi_mgmt
 
 The general running order of the provisioning playbook is the following:
 


### PR DESCRIPTION
The azimuth_ops collection namespace has changed from stackhpc to azimuth_cloud. Update the documentation to reflect this change.