### PR TITLE
Ubuntu Noble rabbitmq image rebuild with correct Erlang

### DIFF
--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -11,6 +11,7 @@ kolla_image_tags:
     ubuntu-noble: 2025.1-ubuntu-noble-20250805T134044
   kolla_toolbox:
     rocky-9: 2025.1-rocky-9-20250905T151507
+    ubuntu-noble: 2025.1-ubuntu-noble-20250905T151507
   magnum:
     rocky-9: 2025.1-rocky-9-20250811T111154
     ubuntu-noble: 2025.1-ubuntu-noble-20250811T111154
@@ -19,3 +20,4 @@ kolla_image_tags:
     ubuntu-noble: 2025.1-ubuntu-noble-20250822T151934
   rabbitmq:
     rocky-9: 2025.1-rocky-9-20250905T151507
+    ubuntu-noble: 2025.1-ubuntu-noble-20250905T151507

--- a/releasenotes/notes/ubuntu-noble-erlang-fix-5c2ed340ac6c5e74.yaml
+++ b/releasenotes/notes/ubuntu-noble-erlang-fix-5c2ed340ac6c5e74.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Ubuntu Noble rabbitmq image rebuild with correct Erlang PPA suite for
+    Erlang 26/27 from "jammy" to "noble". Followed upstream [1].
+    [1] https://review.opendev.org/c/openstack/kolla/+/959426


### PR DESCRIPTION
Followed upstream [1].

[1] https://review.opendev.org/c/openstack/kolla/+/959426