### PR TITLE
Bump Trivy version to v0.66.0

### DIFF
--- a/.github/workflows/stackhpc-container-image-build.yml
+++ b/.github/workflows/stackhpc-container-image-build.yml
@@ -155,7 +155,7 @@ jobs:
 
       - name: Install Trivy
         run: |
-          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin v0.62.1
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin v0.66.0
 
       - name: Install yq
         run: |

--- a/tools/scan-images.sh
+++ b/tools/scan-images.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
+# Disable telemetry and version check:
+# https://github.com/aquasecurity/trivy/discussions/8945
+export TRIVY_DISABLE_TELEMETRY=true
+export TRIVY_SKIP_VERSION_CHECK=true
+
 # Global variables
 scan_common_args=" \
                   --exit-code 1 \

--- a/tools/scan-images.sh
+++ b/tools/scan-images.sh
@@ -22,7 +22,7 @@ usage() {
 # Check dependencies are installed, print installation instructions otherwise
 check_deps_installed() {
   if ! trivy --version > /dev/null; then
-    echo 'Please install trivy: curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin v0.62.1'
+    echo 'Please install trivy: curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin v0.66.0'
     exit 1
   fi
   if ! yq --version > /dev/null; then


### PR DESCRIPTION
Disable Trivy telemetry and version check [introduced in v0.63.0](https://github.com/aquasecurity/trivy/discussions/8945).