### PR TITLE
CI: Fix job step condition

### DIFF
--- a/.github/workflows/stackhpc-container-image-build.yml
+++ b/.github/workflows/stackhpc-container-image-build.yml
@@ -325,7 +325,7 @@ jobs:
 
       - name: Fail when images failed to push
         run: if [ $(wc -l < image-build-logs/push-failed-images.txt) -gt 0 ]; then cat image-build-logs/push-failed-images.txt && exit 1; fi
-        if: ${{ !cancelled() }}
+        if: ${{ inputs.push && !cancelled() }}
 
       # NOTE(seunghun1ee): Currently we want to mark the job fail only when critical CVEs are detected.
       # This can be used again instead of "Fail when critical vulnerabilities are found" when it's


### PR DESCRIPTION
The shell command would fail if pushing images was disabled:

    image-build-logs/push-failed-images.txt: No such file or directory
    [: -gt: unary operator expected