### PR TITLE
Bump kayobe-automation

### DIFF
--- a/etc/kayobe/ansible/diagnostics.yml
+++ b/etc/kayobe/ansible/diagnostics.yml
@@ -9,10 +9,17 @@
 - name: Collect diagnostic information
   hosts: seed-hypervisor:seed:overcloud:infra-vms
   vars:
-    diagnostics_path_local: "{{ lookup('env', 'PWD') }}/diagnostics"
+    diagnostics_path_local: "{{ lookup('env', 'HOME') }}/diagnostics"
   tasks:
     - name: Run diagnostics
       block:
+        - name: Create a local directory to sync diagnostics
+          ansible.builtin.file:
+            path: "{{ diagnostics_path_local }}"
+            state: directory
+          delegate_to: localhost
+          run_once: true
+
         - name: Create a temporary directory for diagnostics
           ansible.builtin.tempfile:
             state: directory

--- a/releasenotes/notes/kayobe-automation-change-directory-dddf4772b3ee81af.yaml
+++ b/releasenotes/notes/kayobe-automation-change-directory-dddf4772b3ee81af.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    `Bump kayobe-automation <https://github.com/stackhpc/kayobe-automation/pull/78>`__
+    to include fix that runs kayobe commands from the directory
+    specified in ``KAYOBE_CONFIG_PATH``.


### PR DESCRIPTION
Bump kayobe-automation to include fix that runs kayobe commands from the directory specified in
KAYOBE_CONFIG_PATH [1].

[1] https://github.com/stackhpc/kayobe-automation/pull/78