### PR TITLE
Remove config for the cherry-pick bot

### DIFF
--- a/.github/cherry-pick-bot.yml
+++ b/.github/cherry-pick-bot.yml
@@ -1,3 +1,0 @@
----
-enabled: true
-preservePullRequestTitle: true


### PR DESCRIPTION
The bot has been shutdown [1].

1. https://github.com/apps/gcp-cherry-pick-bot