### PR TITLE
Make Gemini less verbose

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,3 @@
+code_review:
+  pull_request_opened:
+    summary: false


### PR DESCRIPTION
Disable the initial Gemini comment ("Summary of Changes") which often provides little useful information.

See Gemini Code Assist documentation for details [1].

[1] https://developers.google.com/gemini-code-assist/docs/customize-gemini-behavior-github#default-configuration