### PR TITLE
Add container image scanning script

### DIFF
--- a/releasenotes/notes/wazuh-scan-images-script-f9eff2f21768f969.yaml
+++ b/releasenotes/notes/wazuh-scan-images-script-f9eff2f21768f969.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Added ``wazuh-scan-images.sh``, a script to scan container images for
+    vulnerabilities. In a future release, this script can be integrated into
+    Wazuh for continuous scanning.

--- a/tools/wazuh-scan-images.sh
+++ b/tools/wazuh-scan-images.sh
@@ -7,24 +7,30 @@ SBOM_DIR="/opt/kayobe/stackhpc/sboms"
 mkdir -p "$SBOM_DIR"
 
 # Ensure the custom output template exists
-cat <<EOL > "$SBOM_DIR/trivy-custom.tmpl"
-"Package","Version Installed","Vulnerability ID","Severity","Title"
-{{- range \$ri, \$r := . }}
-{{- range \$vi, \$v := .Vulnerabilities }}
+if [[ ! -f "$SBOM_DIR/trivy-custom.tmpl" ]]; then
+cat <<'EOL' > "$SBOM_DIR/trivy-custom.tmpl"
+{{- range $ri, $r := . -}}
+{{- range $vi, $v := .Vulnerabilities -}}
 "{{ $v.PkgName }}","{{$v.InstalledVersion }}","{{ $v.VulnerabilityID }}","{{$v.Severity }}","{{$v.Title }}"
-{{- end}}
-{{- end }}
+{{- end -}}
+{{- end -}}
 EOL
+fi
+
+echo "Package","Version Installed","Vulnerability ID","Severity","Title"
 
 # Loop through each container image and process its SBOM
-docker image ls --format "{{.Repository}}:{{.Tag}}" | sort | uniq | while read -r image; do
+docker image ls --format "{{.Repository}}:{{.Tag}}:{{.Image ID}}" | sort | uniq | while read -r image; do
+    # Split image ID
+    image_id=$(echo "$image" | awk -F: '{print $NF}')
+
     # Generate SBOM filename
     sbom_file="$SBOM_DIR/$(echo "$image" | tr '/:' '_').sbom"
 
     # Generate SBOM if missing
     if [[ ! -f "$sbom_file" ]]; then
         echo "Generating SBOM for $image"
-        if ! trivy image --quiet --format spdx-json --output "$sbom_file" "$image"; then
+        if ! trivy image --quiet --format spdx-json --output "$sbom_file" "$image_id"; then
             echo "Failed to generate SBOM for $image. Skipping."
             continue
         fi

--- a/tools/wazuh-scan-images.sh
+++ b/tools/wazuh-scan-images.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# SBOM directory path
+SBOM_DIR="/opt/kayobe/stackhpc/sboms"
+
+# Ensure the SBOM directory exists
+mkdir -p "$SBOM_DIR"
+
+# Ensure the custom output template exists
+cat <<EOL > "$SBOM_DIR/trivy-custom.tmpl"
+"Package","Version Installed","Vulnerability ID","Severity","Title"
+{{- range \$ri, \$r := . }}
+{{- range \$vi, \$v := .Vulnerabilities }}
+"{{ $v.PkgName }}","{{$v.InstalledVersion }}","{{ $v.VulnerabilityID }}","{{$v.Severity }}","{{$v.Title }}"
+{{- end}}
+{{- end }}
+EOL
+
+# Loop through each container image and process its SBOM
+docker image ls --format "{{.Repository}}:{{.Tag}}" | sort | uniq | while read -r image; do
+    # Generate SBOM filename
+    sbom_file="$SBOM_DIR/$(echo "$image" | tr '/:' '_').sbom"
+
+    # Generate SBOM if missing
+    if [[ ! -f "$sbom_file" ]]; then
+        echo "Generating SBOM for $image"
+        if ! trivy image --quiet --format spdx-json --output "$sbom_file" "$image"; then
+            echo "Failed to generate SBOM for $image. Skipping."
+            continue
+        fi
+    fi
+    
+    echo "Scanning SBOM: $sbom_file"
+    # Scan SBOM and prepend image info to each output line
+    trivy sbom \
+      --scanners vuln \
+      --severity CRITICAL,HIGH \
+      --ignore-unfixed \
+      --quiet \
+      --format template \
+      --template "@$SBOM_DIR/trivy-custom.tmpl" \
+      "$sbom_file" | \
+    awk -v img="$image" '{print "Trivy:\"" img "\"," $0}'
+done


### PR DESCRIPTION
Added `tools/wazuh-scan-images.sh` to scan all the container images on a host. The script will be used in the future to scan images on a schedule using Wazuh.

The script first checks if an SBOM exists for the image, if not it'll generate one and scan that rather than the image directly. That makes it much quicker to re-scan images

See also https://wazuh.com/blog/container-image-security-with-wazuh-and-trivy/