### PR TITLE
Fix top_level_group_map comment

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -504,22 +504,8 @@ kolla_build_args: {}
 #         kolla-ansible group.
 # NOTE(Alex-Welsh): If you want to extend the map rather than replace it, you
 # must include the Kayobe defaults in the mapping.
-# Standard Kayobe defaults:
-#  compute:
-#    groups:
-#      - "compute"
-#  control:
-#    groups:
-#      - "controllers"
-#  monitoring:
-#    groups:
-#      - "controllers"
-#  network:
-#    groups:
-#      - "controllers"
-#  storage:
-#    groups:
-#      - "controllers"
+# The standard Kayobe defaults can be found here:
+# https://github.com/stackhpc/kayobe/blob/stackhpc/<release>/ansible/inventory/group_vars/all/kolla
 #kolla_overcloud_inventory_top_level_group_map:
 
 # List of names of top level kolla-ansible groups. Any of these groups which


### PR DESCRIPTION
The Kayobe monitoring group, not the contollers group, is mapped to the Kolla-Ansible monitoring group by default.