### PR TITLE
Changing the IPA compression algorithm and updating the IPA image tag to use new compressed images

### DIFF
--- a/etc/kayobe/ipa.yml
+++ b/etc/kayobe/ipa.yml
@@ -47,7 +47,9 @@ ipa_build_dib_elements_extra:
 
 # Dictionary of additional environment variables to provide to Diskimage
 # Builder (DIB) during IPA image build.
-#ipa_build_dib_env_extra:
+#TODO(ClaudiaWatson): remove DIB_IPA_COMPRESS_CMD for Flamingo
+ipa_build_dib_env_extra:
+  DIB_IPA_COMPRESS_CMD: 'zstd -19'
 
 # Dictionary of environment variables to provide to Diskimage Builder (DIB)
 # during IPA image build.

--- a/etc/kayobe/pulp-ipa-image-versions.yml
+++ b/etc/kayobe/pulp-ipa-image-versions.yml
@@ -1,4 +1,4 @@
 ---
 # IPA image versioning tags
-stackhpc_rocky_9_ipa_image_version: "2025.1-20250924T145101"
-stackhpc_ubuntu_noble_ipa_image_version: "2025.1-20250924T145101"
+stackhpc_rocky_9_ipa_image_version: "2025.1-20250929T120332"
+stackhpc_ubuntu_noble_ipa_image_version: "2025.1-20250929T120332"

--- a/releasenotes/notes/change-IPA-compression-algorithm-to-zstd-19-3be452025b781fbb.yaml
+++ b/releasenotes/notes/change-IPA-compression-algorithm-to-zstd-19-3be452025b781fbb.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Changed the IPA (Ironic Python Agent) image compression
+    algorithm from the default ``gzip`` to ``zstd``. This
+    improves provisioning performance by reducing the size of the
+    IPA boot ISO transferred from the Ironic conductor to the
+    baremetal nodes.


### PR DESCRIPTION
Updates the IPA (Ironic Python Agent) compression algorithm from the default gzip to use instead zstd -19. This change will reduce the transfer size of the IPA boot ISO from the Ironic conductor to the baremetal nodes during provisioning. The IPA image tag has been updated to reference the new compressed IPA images. 