### PR TITLE
Updating policy for neutron and nova to include role: baremetaluser

### DIFF
--- a/etc/kayobe/environments/baremetal-policy/README.rst
+++ b/etc/kayobe/environments/baremetal-policy/README.rst
@@ -1,0 +1,13 @@
+Policy for a baremetaluser role
+===============================
+
+When deploying Slurm on baremetal nodes, it is typical to select a specific
+baremetal node, and give it the expected hostname. We allow this via a tweak to
+Nova policy.
+
+Similarly, it is common that the IP address has to match the expected one for
+the given node. We tweak neutron policy to allow fixed IPs, even when we do
+not own the network.
+
+We should never use the admin role to do these operations, as it has far too
+much privilege.

--- a/etc/kayobe/environments/baremetal-policy/kolla/config/neutron/policy.yml
+++ b/etc/kayobe/environments/baremetal-policy/kolla/config/neutron/policy.yml
@@ -1,0 +1,5 @@
+# Comments show default policy for neutron.
+#"create_port:fixed_ips:ip_address": "(rule:admin_only) or (rule:service_api) or role:manager and project_id:%(project_id)s or role:member and rule:network_owner"
+"create_port:fixed_ips:ip_address": "(rule:admin_only) or (rule:service_api) or role:manager and project_id:%(project_id)s or role:member and rule:network_owner or role:baremetaluser"
+#"create_port:mac_address": "(rule:admin_only) or (rule:service_api) or role:manager and project_id:%(project_id)s or role:member and rule:network_owner"
+"create_port:mac_address": "(rule:admin_only) or (rule:service_api) or role:manager and project_id:%(project_id)s or role:member and rule:network_owner or role:baremetaluser"

--- a/etc/kayobe/environments/baremetal-policy/kolla/config/nova/policy.yml
+++ b/etc/kayobe/environments/baremetal-policy/kolla/config/nova/policy.yml
@@ -1,0 +1,5 @@
+# Comments show default policy for nova.
+#"os_compute_api:servers:create:forced_host": "rule:context_is_admin"
+"os_compute_api:servers:create:forced_host": "rule:context_is_admin or role:baremetaluser"
+#"compute:servers:create:requested_destination": "rule:context_is_admin"
+"compute:servers:create:requested_destination": "rule:context_is_admin or role:baremetaluser"

--- a/releasenotes/notes/baremetaluser-neutron-and-nova-policy-321b73327546ceec.yaml
+++ b/releasenotes/notes/baremetaluser-neutron-and-nova-policy-321b73327546ceec.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Adds a mixin environment that includes policy overrides to enable a
+    ``baremetaluser`` role, that is able to create servers on specific
+    baremetal nodes, with specific IP addresses on a shared network.


### PR DESCRIPTION
Updating policy to allow role: baremetaluser to map baremetal instances to specific ironic nodes (this is desirable so that the instance name = ironic node name, making debugging less confusing)