### PR TITLE
Fix permissions for promote workflow

### DIFF
--- a/.github/workflows/stackhpc-promote.yml
+++ b/.github/workflows/stackhpc-promote.yml
@@ -10,7 +10,8 @@ jobs:
     name: Trigger Pulp promotion workflows
     if: github.repository == 'stackhpc/stackhpc-kayobe-config'
     runs-on: ubuntu-latest
-    permissions: {}
+    permissions:
+      actions: write
     steps:
       # NOTE(mgoddard): Trigger another CI workflow in the
       # stackhpc-release-train repository.


### PR DESCRIPTION
Tested & working this time:

Main workflow: https://github.com/stackhpc/stackhpc-kayobe-config/actions/runs/18313354715/job/52147095993
Triggered workflows:
https://github.com/stackhpc/stackhpc-kayobe-config/actions/runs/18313357404
https://github.com/stackhpc/stackhpc-release-train/actions/runs/18313357185
https://github.com/stackhpc/stackhpc-release-train/actions/runs/18313357016