### PR TITLE
fix(docs): correct playbook commands and minor inconsistencies in Ubuntu Noble upgrade guide

### DIFF
--- a/doc/source/operations/ubuntu-noble.rst
+++ b/doc/source/operations/ubuntu-noble.rst
@@ -79,7 +79,9 @@ To sync host packages:
 
 .. code-block:: console
 
-   kayobe playbook run $KAYOBE_CONFIG_PATH/ansible/pulp-repo-sync.yml -e stackhpc_pulp_sync_ubuntu_jammy=true -e stackhpc_pulp_sync_ubuntu_noble=true
+   kayobe playbook run $KAYOBE_CONFIG_PATH/ansible/pulp-repo-sync.yml \
+       -e stackhpc_pulp_sync_ubuntu_jammy=true \
+       -e stackhpc_pulp_sync_ubuntu_noble=true
    kayobe playbook run $KAYOBE_CONFIG_PATH/ansible/pulp-repo-publish.yml \
        -e stackhpc_pulp_sync_ubuntu_jammy=true \
        -e stackhpc_pulp_sync_ubuntu_noble=true

--- a/doc/source/operations/ubuntu-noble.rst
+++ b/doc/source/operations/ubuntu-noble.rst
@@ -87,7 +87,9 @@ may be promoted to production:
 
 .. code-block:: console
 
-   kayobe playbook run $KAYOBE_CONFIG_PATH/ansible/pulp-repo-promote-production.yml -e stackhpc_pulp_sync_ubuntu_jammy=true -e stackhpc_pulp_sync_ubuntu_noble=true
+   kayobe playbook run $KAYOBE_CONFIG_PATH/ansible/pulp-repo-promote-production.yml \
+       -e stackhpc_pulp_sync_ubuntu_jammy=true \
+       -e stackhpc_pulp_sync_ubuntu_noble=true
 
 To sync container images:
 

--- a/doc/source/operations/ubuntu-noble.rst
+++ b/doc/source/operations/ubuntu-noble.rst
@@ -79,21 +79,15 @@ To sync host packages:
 
 .. code-block:: console
 
-   kayobe playbook run $KAYOBE_CONFIG_PATH/ansible/pulp-repo-sync.yml \
-       -e stackhpc_pulp_sync_ubuntu_jammy=true \
-       -e stackhpc_pulp_sync_ubuntu_noble=true
-   kayobe playbook run $KAYOBE_CONFIG_PATH/ansible/pulp-repo-publish.yml \
-       -e stackhpc_pulp_sync_ubuntu_jammy=true \
-       -e stackhpc_pulp_sync_ubuntu_noble=true
+   kayobe playbook run $KAYOBE_CONFIG_PATH/ansible/pulp-repo-sync.yml -e stackhpc_pulp_sync_ubuntu_noble=true
+   kayobe playbook run $KAYOBE_CONFIG_PATH/ansible/pulp-repo-publish.yml -e stackhpc_pulp_sync_ubuntu_noble=true
 
 Once the host package content has been tested in a test/staging environment, it
 may be promoted to production:
 
 .. code-block:: console
 
-   kayobe playbook run $KAYOBE_CONFIG_PATH/ansible/pulp-repo-promote-production.yml \
-       -e stackhpc_pulp_sync_ubuntu_jammy=true \
-       -e stackhpc_pulp_sync_ubuntu_noble=true
+   kayobe playbook run $KAYOBE_CONFIG_PATH/ansible/pulp-repo-promote-production.yml -e stackhpc_pulp_sync_ubuntu_noble=true
 
 To sync container images:
 

--- a/doc/source/operations/ubuntu-noble.rst
+++ b/doc/source/operations/ubuntu-noble.rst
@@ -80,7 +80,9 @@ To sync host packages:
 .. code-block:: console
 
    kayobe playbook run $KAYOBE_CONFIG_PATH/ansible/pulp-repo-sync.yml -e stackhpc_pulp_sync_ubuntu_jammy=true -e stackhpc_pulp_sync_ubuntu_noble=true
-   kayobe playbook run $KAYOBE_CONFIG_PATH/ansible/pulp-repo-publish.yml -e stackhpc_pulp_sync_ubuntu_jammy=true -e stackhpc_pulp_sync_ubuntu_noble=true
+   kayobe playbook run $KAYOBE_CONFIG_PATH/ansible/pulp-repo-publish.yml \
+       -e stackhpc_pulp_sync_ubuntu_jammy=true \
+       -e stackhpc_pulp_sync_ubuntu_noble=true
 
 Once the host package content has been tested in a test/staging environment, it
 may be promoted to production:

--- a/doc/source/operations/ubuntu-noble.rst
+++ b/doc/source/operations/ubuntu-noble.rst
@@ -80,14 +80,14 @@ To sync host packages:
 .. code-block:: console
 
    kayobe playbook run $KAYOBE_CONFIG_PATH/ansible/pulp-repo-sync.yml -e stackhpc_pulp_sync_ubuntu_jammy=true -e stackhpc_pulp_sync_ubuntu_noble=true
-   kayobe playbook run $KAYOBE_CONFIG_PATH/ansible/pulp-repo-publish.yml
+   kayobe playbook run $KAYOBE_CONFIG_PATH/ansible/pulp-repo-publish.yml -e stackhpc_pulp_sync_ubuntu_jammy=true -e stackhpc_pulp_sync_ubuntu_noble=true
 
 Once the host package content has been tested in a test/staging environment, it
 may be promoted to production:
 
 .. code-block:: console
 
-   kayobe playbook run $KAYOBE_CONFIG_PATH/ansible/pulp-repo-promote-production.yml
+   kayobe playbook run $KAYOBE_CONFIG_PATH/ansible/pulp-repo-promote-production.yml -e stackhpc_pulp_sync_ubuntu_jammy=true -e stackhpc_pulp_sync_ubuntu_noble=true
 
 To sync container images:
 
@@ -165,7 +165,7 @@ Always back up the overcloud DB before starting:
 Potential issues
 ----------------
 
--  If the system uses OVS as a network driver, there's a change that kolla
+-  If the system uses OVS as a network driver, there's a chance that kolla
    services can struggle to find reply queues from RabbitMQ during the upgrade.
    Currently this could be observed when rolling reboot of controllers are done
    or deploying Ubuntu Noble based Kolla containers are deployed after all
@@ -236,7 +236,7 @@ Full procedure for one controller
 
       .. code-block:: console
 
-         kayobe playbook run $KAYOBE_CONFIG_PATH/ansible/ceph-enter-maintenance.yml --limit <host>
+         kayobe playbook run $KAYOBE_CONFIG_PATH/ansible/ceph-exit-maintenance.yml --limit <host>
 
    3. Make sure that everything is back in working condition before moving
       on to the next host:
@@ -321,7 +321,7 @@ Full procedure for one batch of hosts
 
       .. code-block:: console
 
-         kayobe playbook run $KAYOBE_CONFIG_PATH/ansible/ceph-enter-maintenance.yml --limit <hosts>
+         kayobe playbook run $KAYOBE_CONFIG_PATH/ansible/ceph-exit-maintenance.yml --limit <hosts>
 
    3. Make sure that everything is back in working condition before moving
       on to the next host:


### PR DESCRIPTION
- Add missing `-e` flags to `pulp-repo-publish.yml` and `pulp-repo-promote-production.yml` playbook commands (without these flags, Noble repos are not promoted, causing apt failures on upgraded systems)
- Fix incorrect `ceph-enter-maintenance.yml` usage where `ceph-exit-maintenance.yml` should be used when taking hosts out of maintenance mode
- Fix typo: "change" -> "chance" in storage section potential issues