### PR TITLE
ovn chassis priority playbook: Fix gateway chassis prefix stripping

### DIFF
--- a/etc/kayobe/ansible/fixes/ovn-fix-chassis-priorities.yml
+++ b/etc/kayobe/ansible/fixes/ovn-fix-chassis-priorities.yml
@@ -81,8 +81,8 @@
             gateway_info=$(ovn-nbctl lrp-get-gateway-chassis "$ext_port" 2>/dev/null || true)
 
             while IFS= read -r line; do
-                # Strip prefix
-                chassis=$(echo "$line" | awk '{print $1}' | cut -d'_' -f2-)
+                # Strip prefix, allowing '-' or '_' separator
+                chassis=$(echo "$line" | awk '{print $1}' | sed "s/^${ext_port}[-_]//")
                 gateway_chassis="$gateway_chassis $chassis"
             done <<< "$gateway_info"
 


### PR DESCRIPTION
on some environment gateway chassis is delimited with "-" instead of "_" (maybe from older ovn?) - take into account both options:

`
(ovn-nb-db)[root@controller42 /]# ovn-nbctl --no-leader-only lrp-get-gateway-chassis lrp-c8821294-a9e7-4b95-a7fc-5ed2bb947ab2
lrp-c8821294-a9e7-4b95-a7fc-5ed2bb947ab2-node2     3
lrp-c8821294-a9e7-4b95-a7fc-5ed2bb947ab2-node0     2
lrp-c8821294-a9e7-4b95-a7fc-5ed2bb947ab2-node1     1

(ovn-nb-db)[root@controller42 /]# ovn-nbctl --no-leader-only lrp-get-gateway-chassis lrp-fb5d5639-f1e9-4ae7-8cdf-e9fa0c587826
lrp-fb5d5639-f1e9-4ae7-8cdf-e9fa0c587826_node0     3
lrp-fb5d5639-f1e9-4ae7-8cdf-e9fa0c587826_node1     2
lrp-fb5d5639-f1e9-4ae7-8cdf-e9fa0c587826_node2     1
`