### PR TITLE
Only create one PR when updating dependencies

### DIFF
--- a/.github/workflows/stackhpc-update-kolla.yml
+++ b/.github/workflows/stackhpc-update-kolla.yml
@@ -21,7 +21,7 @@ jobs:
             codename: Epoxy
     uses: ./.github/workflows/update-dependencies.yml
     with:
-      openstack_version: ${{ matrix.version }}
+      branch: ${{ matrix.version }}
       openstack_codename: ${{ matrix.codename }}
     permissions:
       contents: write

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Update and commit Kolla version if needed
         if: steps.latest_kolla_tag.outputs.latest_tag != steps.current_kolla_version.outputs.version
         run: |
-          sed -i "s/stackhpc_kolla_source_version\:.*$/stackhpc_kolla_source_version\: $(echo $TAG | sed 's/\//\\\//g')/g" etc/kayobe/stackhpc.yml
+          sed -i "s/stackhpc_kolla_source_version\:.*$/stackhpc_kolla_source_version\: $(echo $TAG | sed 's|/|\\/|g')/g" etc/kayobe/stackhpc.yml
           echo "- **Kolla** bumped from \`${{ steps.current_kolla_version.outputs.version }}\` to \`${{ steps.latest_kolla_tag.outputs.latest_tag }}\`" >> ../../pr_body.md
           echo "  - Changelog: https://github.com/stackhpc/kolla/releases/tag/${{ steps.latest_kolla_tag.outputs.latest_tag }}" >> ../../pr_body.md
           git add etc/kayobe/stackhpc.yml
@@ -113,7 +113,7 @@ jobs:
       - name: Update and commit Kolla Ansible version if needed
         if: steps.latest_kolla_ansible_tag.outputs.latest_tag != steps.current_kolla_ansible_version.outputs.version
         run: |
-          sed -i "s/stackhpc_kolla_ansible_source_version\:.*$/stackhpc_kolla_ansible_source_version\: $(echo $TAG | sed 's/\//\\\//g')/g" etc/kayobe/stackhpc.yml
+          sed -i "s/stackhpc_kolla_ansible_source_version\:.*$/stackhpc_kolla_ansible_source_version\: $(echo $TAG | sed 's|/|\\/|g')/g" etc/kayobe/stackhpc.yml
           echo "- **Kolla-Ansible** bumped from \`${{ steps.current_kolla_ansible_version.outputs.version }}\` to \`${{ steps.latest_kolla_ansible_tag.outputs.latest_tag }}\`" >> ../../pr_body.md
           echo "  - Changelog: https://github.com/stackhpc/kolla-ansible/releases/tag/${{ steps.latest_kolla_ansible_tag.outputs.latest_tag }}" >> ../../pr_body.md
           git add etc/kayobe/stackhpc.yml

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -3,92 +3,187 @@ name: Update dependencies
 on:
   workflow_call:
     inputs:
-      openstack_version:
-        description: OpenStack version
+      branch:
+        description: Branch to update. Must exist in all repositories. e.g. stackhpc/2025.1
         type: string
         required: true
       openstack_codename:
-        description: OpenStack codename
+        description: OpenStack codename e.g. Epoxy
+        type: string
+        required: true
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: Branch to update. Must exist in all repositories. e.g. stackhpc/2025.1
+        type: string
+        required: true
+      openstack_codename:
+        description: OpenStack codename e.g. Epoxy
         type: string
         required: true
 
 jobs:
-  propose_github_release_updates:
+  propose-dependency-updates:
     if: github.repository == 'stackhpc/stackhpc-kayobe-config'
-    runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        include:
-          - key: kolla
-            path: src/kayobe-config/etc/kayobe/stackhpc.yml
-            repository: stackhpc/kolla
-            search_regex: 'stackhpc_kolla_source_version\:.*$'
-            prefix: 'stackhpc_kolla_source_version\: '
-
-          - key: kolla-ansible
-            path: src/kayobe-config/etc/kayobe/stackhpc.yml
-            repository: stackhpc/kolla-ansible
-            search_regex: 'stackhpc_kolla_ansible_source_version\:.*$'
-            prefix: 'stackhpc_kolla_ansible_source_version\: '
-
-          - key: kayobe
-            path: src/kayobe-config/requirements.txt
-            repository: stackhpc/kayobe
-            search_regex: 'kayobe@stackhpc\/.*$'
-            prefix: 'kayobe@'
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
       pull-requests: write
-    name: ${{ matrix.key }}
+    name: Propose dependency updates
+    outputs:
+      kolla-tag: ${{ steps.latest_kolla_tag.outputs.latest_tag || steps.current_kolla_version.outputs.version }}
+      kolla-ansible-tag: ${{ steps.latest_kolla_ansible_tag.outputs.latest_tag || steps.current_kolla_ansible_version.outputs.version }}
+      kayobe-tag: ${{ steps.latest_kayobe_tag.outputs.latest_tag || steps.current_kayobe_version.outputs.version }}
     steps:
-      - name: Checkout
+      - name: Checkout Kayobe-config
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.openstack_version }}
-          path: ${{ github.workspace }}/src/kayobe-config
+          ref: ${{ inputs.branch }}
+          path: src/kayobe-config
 
-      - name: Checkout the dependency repo
+      - name: Set sanitised branch name
+        id: branch_name
+        run: |
+          sanitised_name=$(echo "update-dependencies-${{ inputs.branch }}" | tr '/' '-')
+          echo "name=${sanitised_name}" >> $GITHUB_OUTPUT
+
+      - name: Set up branch and Git config
+        run: |
+          git checkout -b ${{ steps.branch_name.outputs.name }}
+          git config user.name "stackhpc-ci"
+          git config user.email "22933334+stackhpc-ci@users.noreply.github.com"
+        working-directory: src/kayobe-config
+
+      - name: Initialise PR Body
+        run: |
+          echo "This PR was created automatically to update dependencies for the ${{ inputs.branch }} release." > pr_body.md
+          echo "" >> pr_body.md
+          echo "### Changes" >> pr_body.md
+
+      - name: Checkout Kolla repository
         uses: actions/checkout@v4
         with:
-          repository: ${{ matrix.repository }}
-          ref: ${{ inputs.openstack_version }}
+          repository: stackhpc/kolla
+          ref: ${{ inputs.branch }}
           fetch-tags: true
-          path: ${{ github.workspace }}/src/${{ matrix.key }}
+          path: src/kolla
 
-      - name: Get latest tag
-        id: latest_tag
-        run: |
-          TAG=$(git describe --tags --abbrev=0 --match stackhpc/\*)
-          echo latest_tag=${TAG} >> $GITHUB_OUTPUT
-        working-directory: ${{ github.workspace }}/src/${{ matrix.key }}
+      - name: Get latest Kolla tag
+        id: latest_kolla_tag
+        run: echo "latest_tag=$(git describe --tags --abbrev=0 --match stackhpc/\*)" >> $GITHUB_OUTPUT
+        working-directory: ${{ github.workspace }}/src/kolla
 
-      - name: Update dependency key
+      - name: Get current Kolla version
+        id: current_kolla_version
         run: |
-          TAG_OVERRIDE=$(echo $TAG | sed 's/\//\\\//g')
-          sed -i "s/$SEARCH/$PREFIX$TAG_OVERRIDE/g" $REQUIREMENTS
+          VERSION=$(awk -F': ' '/stackhpc_kolla_source_version:/ {print $2}' src/kayobe-config/etc/kayobe/stackhpc.yml | xargs)
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Update and commit Kolla version if needed
+        if: steps.latest_kolla_tag.outputs.latest_tag != steps.current_kolla_version.outputs.version
+        run: |
+          sed -i "s/stackhpc_kolla_source_version\:.*$/stackhpc_kolla_source_version\: $(echo $TAG | sed 's/\//\\\//g')/g" etc/kayobe/stackhpc.yml
+          echo "- **Kolla** bumped from \`${{ steps.current_kolla_version.outputs.version }}\` to \`${{ steps.latest_kolla_tag.outputs.latest_tag }}\`" >> ../../pr_body.md
+          echo "  - Changelog: https://github.com/stackhpc/kolla/releases/tag/${{ steps.latest_kolla_tag.outputs.latest_tag }}" >> ../../pr_body.md
+          git add etc/kayobe/stackhpc.yml
+          git commit -m "(automated) Bump kolla to ${{ steps.latest_kolla_tag.outputs.latest_tag }}"
         env:
-          PREFIX: ${{ matrix.prefix }}
-          TAG: ${{ steps.latest_tag.outputs.latest_tag }}
-          REQUIREMENTS: ${{ github.workspace }}/${{ matrix.path }}
-          SEARCH: ${{ matrix.search_regex }}
+          TAG: ${{ steps.latest_kolla_tag.outputs.latest_tag }}
+        working-directory: src/kayobe-config
 
-      - name: Propose changes via PR if required
-        uses: peter-evans/create-pull-request@v7
+      - name: Checkout Kolla Ansible repository
+        uses: actions/checkout@v4
         with:
-          path: ${{ github.workspace }}/src/kayobe-config
-          commit-message: >-
-            Bump ${{ matrix.key }} to ${{ steps.latest_tag.outputs.latest_tag }}
-          author: stackhpc-ci <22933334+stackhpc-ci@users.noreply.github.com>
-          branch: update-dependency/${{ matrix.key }}/${{ inputs.openstack_version }}
-          delete-branch: true
-          title: >-
-            Bump ${{ matrix.key }} to ${{ steps.latest_tag.outputs.latest_tag }}
-          body: >
-            This PR was created automatically to update ${{ inputs.openstack_version }}
-            ${{ matrix.key }} to ${{ steps.latest_tag.outputs.latest_tag }}.
+          repository: stackhpc/kolla-ansible
+          ref: ${{ inputs.branch }}
+          fetch-tags: true
+          path: src/kolla-ansible
 
-            GitHub Release Changelog:
-            https://github.com/stackhpc/${{ matrix.key }}/releases/tag/${{ steps.latest_tag.outputs.latest_tag }}
-          labels: |
-            automated
-            ${{ inputs.openstack_codename }}
+      - name: Get latest Kolla Ansible tag
+        id: latest_kolla_ansible_tag
+        run: echo "latest_tag=$(git describe --tags --abbrev=0 --match stackhpc/\*)" >> $GITHUB_OUTPUT
+        working-directory: ${{ github.workspace }}/src/kolla-ansible
+
+      - name: Get current Kolla Ansible version
+        id: current_kolla_ansible_version
+        run: |
+          VERSION=$(awk -F': ' '/stackhpc_kolla_ansible_source_version:/ {print $2}' src/kayobe-config/etc/kayobe/stackhpc.yml | xargs)
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Update and commit Kolla Ansible version if needed
+        if: steps.latest_kolla_ansible_tag.outputs.latest_tag != steps.current_kolla_ansible_version.outputs.version
+        run: |
+          sed -i "s/stackhpc_kolla_ansible_source_version\:.*$/stackhpc_kolla_ansible_source_version\: $(echo $TAG | sed 's/\//\\\//g')/g" etc/kayobe/stackhpc.yml
+          echo "- **Kolla-Ansible** bumped from \`${{ steps.current_kolla_ansible_version.outputs.version }}\` to \`${{ steps.latest_kolla_ansible_tag.outputs.latest_tag }}\`" >> ../../pr_body.md
+          echo "  - Changelog: https://github.com/stackhpc/kolla-ansible/releases/tag/${{ steps.latest_kolla_ansible_tag.outputs.latest_tag }}" >> ../../pr_body.md
+          git add etc/kayobe/stackhpc.yml
+          git commit -m "(automated) Bump kolla-ansible to ${{ steps.latest_kolla_ansible_tag.outputs.latest_tag }}"
+        env:
+          TAG: ${{ steps.latest_kolla_ansible_tag.outputs.latest_tag }}
+        working-directory: src/kayobe-config
+
+      - name: Checkout Kayobe repository
+        uses: actions/checkout@v4
+        with:
+          repository: stackhpc/kayobe
+          ref: ${{ inputs.branch }}
+          fetch-tags: true
+          path: src/kayobe
+
+      - name: Get latest Kayobe tag
+        id: latest_kayobe_tag
+        run: echo "latest_tag=$(git describe --tags --abbrev=0 --match stackhpc/\*)" >> $GITHUB_OUTPUT
+        working-directory: ${{ github.workspace }}/src/kayobe
+
+      - name: Get current Kayobe version
+        id: current_kayobe_version
+        run: |
+          VERSION=$(grep 'kayobe@stackhpc/' src/kayobe-config/requirements.txt | sed 's/.*@//' | xargs)
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Update and commit Kayobe version if needed
+        if: steps.latest_kayobe_tag.outputs.latest_tag != steps.current_kayobe_version.outputs.version
+        run: |
+          sed -i "s|kayobe@stackhpc/.*$|kayobe@$(echo $TAG | sed 's|/|\\/|g')|g" requirements.txt
+          echo "- **Kayobe** bumped from \`${{ steps.current_kayobe_version.outputs.version }}\` to \`${{ steps.latest_kayobe_tag.outputs.latest_tag }}\`" >> ../../pr_body.md
+          echo "  - Changelog: https://github.com/stackhpc/kayobe/releases/tag/${{ steps.latest_kayobe_tag.outputs.latest_tag }}" >> ../../pr_body.md
+          git add requirements.txt
+          git commit -m "(automated) Bump kayobe to ${{ steps.latest_kayobe_tag.outputs.latest_tag }}"
+        env:
+          TAG: ${{ steps.latest_kayobe_tag.outputs.latest_tag }}
+        working-directory: src/kayobe-config
+
+      - name: Check for new commits
+        id: check_commits
+        run: |
+          count=$(git rev-list --count ${{ inputs.branch }}..HEAD)
+          if [ "$count" -gt 0 ]; then
+            echo "has_commits=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_commits=false" >> $GITHUB_OUTPUT
+          fi
+        working-directory: src/kayobe-config
+
+      - name: Push commits
+        if: steps.check_commits.outputs.has_commits == 'true'
+        run: git push --force origin ${{ steps.branch_name.outputs.name }}
+        working-directory: src/kayobe-config
+
+      - name: Create or Update Pull Request
+        if: steps.check_commits.outputs.has_commits == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        working-directory: src/kayobe-config
+        run: |
+          EXISTING_PR=$(gh pr list --head "${{ steps.branch_name.outputs.name }}" --json number -q '.[0].number')
+          if [ -n "$EXISTING_PR" ]; then
+            gh pr close $EXISTING_PR
+          fi
+          gh pr create \
+            --base "${{ inputs.branch }}" \
+            --head "${{ steps.branch_name.outputs.name }}" \
+            --title "(automated) Bump dependencies for OpenStack ${{ inputs.branch }}" \
+            --body-file ../../pr_body.md \
+            --label "automated" \
+            --label "${{ inputs.openstack_codename }}"
+


### PR DESCRIPTION
Usually every Tuesday, I have to go through all the open dependency bump PRs and merge the changes that target the same branch. This saves CI resources and PR spam.

This PR automates that process, so only one PR will be created per branch, with one commit for each dependency that gets bumped.

Some changes made with Gemini. I've manually checked everything though.

Also includes a few minor tweaks like changing the name of input var and moving to an Ubuntu Noble runner

Tested & working:
[1] https://github.com/stackhpc/stackhpc-kayobe-config/pull/1937
[2] https://github.com/stackhpc/stackhpc-kayobe-config/pull/1936