### PR TITLE
Update deprecated stdout_callback setting

### DIFF
--- a/etc/kayobe/ansible.cfg
+++ b/etc/kayobe/ansible.cfg
@@ -1,7 +1,7 @@
 [defaults]
 forks = 20
 # Use the YAML stdout callback plugin.
-stdout_callback = yaml
+callback_result_format = yaml
 # Use the stdout_callback when running ad-hoc commands.
 bin_ansible_callbacks = True
 # Disable fact variable injection to improve performance.


### PR DESCRIPTION
Fixes new deprecation notice:
 https://github.com/stackhpc/stackhpc-kayobe-config/actions/runs/18684607253/job/53274454273?pr=1920#step:38:39