### PR TITLE
Bump Nova container images to fix LP#2098892

### DIFF
--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -40,8 +40,8 @@ kolla_image_tags:
     rocky-9: 2023.1-rocky-9-20250321T110513
     ubuntu-jammy: 2023.1-ubuntu-jammy-20250321T110513
   nova:
-    rocky-9: 2023.1-rocky-9-20250321T110513
-    ubuntu-jammy: 2023.1-ubuntu-jammy-20250321T110513
+    rocky-9: 2023.1-rocky-9-20251028T202026
+    ubuntu-jammy: 2023.1-ubuntu-jammy-20251028T202026
   octavia:
     rocky-9: 2023.1-rocky-9-20250321T110513
     ubuntu-jammy: 2023.1-ubuntu-jammy-20250321T110513

--- a/releasenotes/notes/nova-bug-2098892-146511cd0c4a6175.yaml
+++ b/releasenotes/notes/nova-bug-2098892-146511cd0c4a6175.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Bumps Nova images to fix `Launchpad bug 2098892
+    <https://bugs.launchpad.net/nova/+bug/2098892>`__.


### PR DESCRIPTION
Bump nova image tag to resolve this bug: https://bugs.launchpad.net/nova/+bug/2098892 
Fix https://github.com/stackhpc/nova/pull/158/commits/458b443e5ffc828a827dbff1d2db85c77bdd47b9 included in this PR: https://github.com/stackhpc/nova/pull/158