### PR TITLE
Add secret store unseal playbook for action runners

### DIFF
--- a/etc/kayobe/ansible/secret-store/secret-store-unseal-action-runners.yml
+++ b/etc/kayobe/ansible/secret-store/secret-store-unseal-action-runners.yml
@@ -1,0 +1,34 @@
+---
+- name: Unseal secret store on the ci-runners
+  any_errors_fatal: true
+  gather_facts: true
+  hosts: github-runners:gitlab-runners
+  vars:
+    vault_api_addr: http://127.0.0.1:8200
+  tasks:
+    - name: Set a fact about the virtualenv on the remote system
+      ansible.builtin.set_fact:
+        virtualenv: "{{ ansible_python_interpreter | dirname | dirname }}"
+      when:
+        - ansible_python_interpreter is defined
+        - not ansible_python_interpreter.startswith('/bin/')
+        - not ansible_python_interpreter.startswith('/usr/bin/')
+
+    - name: Ensure Python hvac module is installed
+      ansible.builtin.pip:
+        name: hvac
+        state: latest
+        extra_args: "{% if pip_upper_constraints_file %}-c {{ pip_upper_constraints_file }}{% endif %}"
+        virtualenv: "{{ virtualenv is defined | ternary(virtualenv, omit) }}"
+      become: "{{ virtualenv is not defined }}"
+
+    - name: Include secret store keys
+      ansible.builtin.include_vars:
+        file: "{{ kayobe_env_config_path }}/{{ stackhpc_ca_secret_store }}/kayobe-automation-keys.json"
+        name: secret_store_keys
+
+    - name: Apply unseal role
+      ansible.builtin.import_role:
+        name: stackhpc.hashicorp.vault_unseal
+      vars:
+        vault_unseal_keys: "{{ secret_store_keys.keys_base64 }}"

--- a/releasenotes/notes/add-secret-store-unseal-playbook-for-ci-runners-ec758e93a8984760.yaml
+++ b/releasenotes/notes/add-secret-store-unseal-playbook-for-ci-runners-ec758e93a8984760.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Added a playbook for unsealing secret store deployed at CI runners (Hosts
+    in github-runners or gitlab-runners inventory group).
+    To run CIs after rebooting CI runners, secret store needs to be unsealed
+    using this playbook.

--- a/releasenotes/notes/add-secret-store-unseal-playbook-for-ci-runners-ec758e93a8984760.yaml
+++ b/releasenotes/notes/add-secret-store-unseal-playbook-for-ci-runners-ec758e93a8984760.yaml
@@ -3,5 +3,5 @@ features:
   - |
     Added a playbook for unsealing secret store deployed at CI runners (Hosts
     in github-runners or gitlab-runners inventory group).
-    To run CIs after rebooting CI runners, secret store needs to be unsealed
+    To run CI after rebooting CI runners, secret store needs to be unsealed
     using this playbook.


### PR DESCRIPTION
When CI action runners are rebooted, their secret store needs to be unsealed.
Added unsealing playbook for them.