### PR TITLE
Fix OVN leader detection in chassis priority fix

### DIFF
--- a/etc/kayobe/ansible/fixes/ovn-fix-chassis-priorities.yml
+++ b/etc/kayobe/ansible/fixes/ovn-fix-chassis-priorities.yml
@@ -25,15 +25,18 @@
       when: kolla_enable_ovn | bool
       block:
         - name: Find the OVN NB DB leader
-          ansible.builtin.command: docker exec ovn_nb_db ovn-nbctl get-connection
+          ansible.builtin.command: >-
+            docker exec ovn_nb_db
+            ovs-appctl -t /var/run/ovn/ovnnb_db.ctl
+            cluster/status OVN_Northbound
           changed_when: false
           failed_when: false
-          register: ovn_check_result
+          register: ovn_cluster_status
           check_mode: false
 
         - name: Group hosts by leader/follower role
           ansible.builtin.group_by:
-            key: ovn_nb_{{ 'leader' if ovn_check_result.rc == 0 else 'follower' }}
+            key: "{{ 'ovn_nb_leader' if 'Role: leader' in ovn_cluster_status.stdout else 'ovn_nb_follower' }}"
           changed_when: false
 
         - name: Assert one leader exists

--- a/releasenotes/notes/ovn-fix-chassis-leader-check-551d0e94cbb94ac4.yaml
+++ b/releasenotes/notes/ovn-fix-chassis-leader-check-551d0e94cbb94ac4.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Updated the OVN chassis priority fix playbook to detect the northbound
+    database leader via ``ovs-appctl cluster/status``, ensuring only the true
+    leader runs the priority alignment.


### PR DESCRIPTION
After kolla-ansible patch [1] ovn commands can run on all nodes. Changing method of getting the leader.

[1] https://review.opendev.org/c/openstack/kolla-ansible/+/963412


error in previous method - multiple "leaders":

```
TASK [Assert one leader exists] ***************************************************************************************************************************************************************************************************
Tuesday 04 November 2025  20:19:54 +0000 (0:00:00.024)       0:00:06.813 ******
fatal: [HOST1]: FAILED! =>
    assertion: groups['ovn_nb_leader'] | default([]) | length == 1
    changed: false
    evaluated_to: false
    msg: 'Expected exactly 1 OVN NB leader, but found 4: [''''HOST1'', ''HOST2',
        ''HOST3'', ''HOST4'']'
fatal: [HOST2]: FAILED! =>
    assertion: groups['ovn_nb_leader'] | default([]) | length == 1
    changed: false
    evaluated_to: false
    msg: 'Expected exactly 1 OVN NB leader, but found 4: [''HOST1'', ''HOST2',
        ''HOST3'', ''HOST4''']'
fatal: [HOST3]: FAILED! =>
    assertion: groups['ovn_nb_leader'] | default([]) | length == 1
    changed: false
    evaluated_to: false
    msg: 'Expected exactly 1 OVN NB leader, but found 4: ['''HOST1'', ''HOST2',
        ''HOST3'', ''HOST4'']'
fatal: [HOST4]: FAILED! =>
    assertion: groups['ovn_nb_leader'] | default([]) | length == 1
    changed: false
    evaluated_to: false
    msg: 'Expected exactly 1 OVN NB leader, but found 4: [''HOST1'', ''HOST2',
        ''HOST3'', ''HOST4'']'
```