### PR TITLE
ceph: Disable bluestore_elastic_shared_blobs

### DIFF
--- a/etc/kayobe/cephadm.yml
+++ b/etc/kayobe/cephadm.yml
@@ -83,10 +83,11 @@ cephadm_cluster_network: "{{ storage_mgmt_net_name | net_cidr }}"
 # stackhpc.cephadm.commands for format. Pre commands run before the rest of the
 # post-deployment configuration, post commands run after the rest of the
 # post-deployment configuration.
-cephadm_commands_pre: "{{ cephadm_commands_pre_default + cephadm_commands_pre_extra }}"
-cephadm_commands_post: "{{ cephadm_commands_post_default + cephadm_commands_post_extra }}"
+cephadm_commands_pre: "{{ (cephadm_commands_pre_default + cephadm_commands_pre_extra) | select | list }}"
+cephadm_commands_post: "{{ (cephadm_commands_post_default + cephadm_commands_post_extra) | select | list }}"
 
-cephadm_commands_pre_default: []
+cephadm_commands_pre_default:
+  - "{{ 'config set osd bluestore_elastic_shared_blobs 0' if cephadm_ceph_release == 'squid' else '' }}"
 cephadm_commands_pre_extra: []
 
 cephadm_commands_post_default: "{{ ['mgr module enable prometheus'] if kolla_enable_prometheus_ceph_mgr_exporter | default(False) | bool else [] }}"

--- a/releasenotes/notes/ceph-squid-disable-elastic-shared-blobs-2d9e059f3046182c.yaml
+++ b/releasenotes/notes/ceph-squid-disable-elastic-shared-blobs-2d9e059f3046182c.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Disable ``bluestore_elastic_shared_blobs`` when running Squid. OSDs created
+    with this setting enabled can experience crashes when using erasure coding.
+    OSDs created under Squid with ``bluestore_elastic_shared_blobs`` enabled
+    will have to be recreated.


### PR DESCRIPTION
Disable bluestore_elastic_shared_blobs when running Squid. OSDs created with this setting enabled can experience crashes when using erasure coding.

OSDs created under Squid with bluestore_elastic_shared_blobs enabled will have to be recreated.

[1] https://docs.clyso.com/blog/#squid-deployed-osds-are-crashing
[2] https://tracker.ceph.com/issues/70390