### PR TITLE
Add playbook and kayobe automation breaking change info

### DIFF
--- a/doc/source/operations/upgrading-openstack.rst
+++ b/doc/source/operations/upgrading-openstack.rst
@@ -132,7 +132,7 @@ For example:
       enabled: "{{ seed_pulp_container_enabled | bool }}"
 
 Ansible playbook subdirectories
---------------------------------------
+-------------------------------
 
 The playbooks under ``etc/kayobe/ansible`` have been subdivided into different
 categories to make them easier to navigate. This change may result in merge
@@ -146,6 +146,10 @@ To mitigate the impact of these changes, two scripts have been added:
   deploy-os-capacity-exporter.yml`` returns ``deployment/``
 * ``tools/magic-symlink-fix.sh`` - Uses the previous script to attempt to fix
   any broken symlinks in the kayobe configuration.
+
+If playbooks are referenced in different methods other than symlinks, they'll
+need to be manually resolved by operators. (e.g. Shell scripts running
+playbooks with file paths, ``import_playbook`` command in custom playbooks)
 
 Known issues
 ============
@@ -369,6 +373,14 @@ You can find more information from the :ref:`beokay` documentation.
 
    For Rocky Linux 9, ``beokay create`` must be used with the ``--python python3.12``
    option to specify Beokay to use Python 3.12 as it is not the default.
+
+Kayobe Automation
+~~~~~~~~~~~~~~~~~
+
+For CI, Kayobe Automation image also needs to be rebuilt with Python 3.12.
+Running the workflow from ``.github/workflows/build-kayobe-docker-image.yml``
+(For GitLab CI, use the workflow from ``.gitlab/workflows/build-kayobe-docker-image.yml``)
+will automatically rebuild the image with Python 3.12.
 
 Preparation
 ===========

--- a/doc/source/operations/upgrading-openstack.rst
+++ b/doc/source/operations/upgrading-openstack.rst
@@ -377,10 +377,10 @@ You can find more information from the :ref:`beokay` documentation.
 Kayobe Automation
 ~~~~~~~~~~~~~~~~~
 
-For CI, Kayobe Automation image also needs to be rebuilt with Python 3.12.
-Running the workflow from ``.github/workflows/build-kayobe-docker-image.yml``
-(For GitLab CI, use the workflow from ``.gitlab/workflows/build-kayobe-docker-image.yml``)
-will automatically rebuild the image with Python 3.12.
+For deployments using Kayobe Automation CI, the Kayobe Docker image also needs
+to be rebuilt with Python 3.12. In GitHub, run the ``Build Kayobe Docker
+Image`` workflow. In GitLab, run the ``build_kayobe_image`` pipeline. In either
+case, the image will automatically be rebuilt with Python 3.12.
 
 Preparation
 ===========


### PR DESCRIPTION
Added more detail about two breaking changes on Epoxy.
1. Any playbook reference other than symlinks can break with new subdirectories of playbooks.
2. Kayobe Automation image needs to be rebuilt with Python 3.12.