### PR TITLE
Modernise SKC docs theme

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -3,3 +3,4 @@ sphinx-copybutton # MIT
 sphinx-substitution-extensions # MIT
 sphinx>=4.2.0 # BSD
 sphinxcontrib-svg2pdfconverter>=0.1.0 # BSD
+sphinx-immaterial # MIT

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -52,6 +52,7 @@ rst_prolog = """
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
+    'sphinx_immaterial',
     'reno.sphinxext',
     #'sphinx.ext.autodoc',
     'sphinx.ext.extlinks',
@@ -89,7 +90,7 @@ pygments_style = 'native'
 # The theme to use for HTML and HTML Help pages.  Major themes that come with
 # Sphinx are currently 'default' and 'sphinxdoc'.
 # html_theme_path = []
-html_theme = 'default'
+html_theme = 'sphinx_immaterial'
 # html_static_path = ['static']
 
 # Add any paths that contain "extra" files, such as .htaccess or
@@ -97,7 +98,15 @@ html_theme = 'default'
 # html_extra_path = ['_extra']
 
 html_theme_options = {
-    # "show_other_versions": True,
+    "features": [
+        "navigation.expand",
+        "navigation.top",
+        "navigation.footer",
+        "search.suggest",
+        "content.code.copy",
+        "toc.follow",
+        "toc.sticky",
+    ]
 }
 
 # Output file base name for HTML help builder.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -98,6 +98,25 @@ html_theme = 'sphinx_immaterial'
 # html_extra_path = ['_extra']
 
 html_theme_options = {
+    "palette": [
+
+        {
+            "media": "(prefers-color-scheme: light)",
+            "scheme": "default",
+            "toggle": {
+                "icon": "material/weather-sunny",
+                "name": "Switch to dark mode",
+            }
+        },
+        {
+            "media": "(prefers-color-scheme: dark)",
+            "scheme": "slate",
+            "toggle": {
+                "icon": "material/weather-night",
+                "name": "Switch to system preference",
+            }
+        },
+    ],
     "features": [
         "navigation.expand",
         "navigation.top",


### PR DESCRIPTION
I've never liked the default Sphinx docs theme.

This PR switches to more modern look. I'm happy to try other themes as well. I just picked one that I liked.
There's a great gallery here: https://sphinx-themes.org/#themes

Credit goes to @jackhodgkiss  for suggesting this a while ago

This is what the new theme looks like:
<img width="2112" height="1341" alt="image" src="https://github.com/user-attachments/assets/ab13b82f-b031-4f9d-a4a6-eb3314ef34a2" />

Light theme:
<img width="2112" height="1341" alt="image" src="https://github.com/user-attachments/assets/02e34cd6-88e9-4a3f-b8ee-8782732a881b" />

Old theme for comparison:
<img width="2112" height="1341" alt="image" src="https://github.com/user-attachments/assets/b5d0b0fb-00ad-466b-846d-1a8a3295017f" />
