### PR TITLE
Add files to Zuul CI ignore list

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -11,7 +11,19 @@
     timeout: 10800
     secrets:
       - aio_vault_password
-
+    irrelevant-files:
+      - ^\..*
+      - ^doc/.*
+      - ^kayobe-env$
+      - ^LICENSE$
+      - ^README.rst$
+      - ^releasenotes/.*
+      - ^tox.ini$
+      - ^etc/kayobe/environments/aufn-ceph/.*
+      - ^etc/kayobe/environments/ci-aio/.*
+      - ^etc/kayobe/environments/ci-builder/.*
+      - ^etc/kayobe/environments/ci-doca-builder/.*
+      - ^etc/kayobe/environments/ci-multinode/.*
 - job:
     name: tenks-ubuntu-noble
     parent: tenks-base


### PR DESCRIPTION
It'll mainly stop CI from running when we just want to update docs or one of the environments that isn't ci-tenks

There's a lot more fine tuning we could do to this but it's a good start