### PR TITLE
GT-1561: Add basic Dell SONiC driver

### DIFF
--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -70,9 +70,9 @@ kolla_image_tags:
     ubuntu-jammy: 2024.1-ubuntu-jammy-20250627T102805
     ubuntu-noble: 2024.1-ubuntu-noble-20250627T102805
   neutron:
-    rocky-9: 2024.1-rocky-9-20250717T094248
-    ubuntu-jammy: 2024.1-ubuntu-jammy-20250627T102805
-    ubuntu-noble: 2024.1-ubuntu-noble-20250627T102805
+    rocky-9: 2024.1-rocky-9-20251113T114107
+    ubuntu-jammy: 2024.1-ubuntu-jammy-20251113T114107
+    ubuntu-noble: 2024.1-ubuntu-noble-20251113T114107
   neutron_bgp_dragent:
     ubuntu-jammy: 2024.1-ubuntu-jammy-20250529T081147
     ubuntu-noble: 2024.1-ubuntu-noble-20250529T081147

--- a/releasenotes/notes/dell-sonic-support-a1dd2edd958bbe9d.yaml
+++ b/releasenotes/notes/dell-sonic-support-a1dd2edd958bbe9d.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Adds a basic NGS driver for Dell SONiC switches.


### PR DESCRIPTION
Basic support for Dell SONiC switches for Arcus.

Build: https://github.com/stackhpc/stackhpc-kayobe-config/actions/runs/19330333096/job/55291529233
Patch: https://github.com/stackhpc/networking-generic-switch/pull/130