### PR TITLE
Add Github CI runner proxy support

### DIFF
--- a/etc/kayobe/ansible/deployment/deploy-github-runner.yml
+++ b/etc/kayobe/ansible/deployment/deploy-github-runner.yml
@@ -7,11 +7,11 @@
     - role: geerlingguy.docker
   tasks:
     - name: Set custom_env fact if any proxy variable is defined
-      set_fact:
+      ansible.builtin.set_fact:
         custom_env: |
           http_proxy={{ http_proxy | default('') }}
           https_proxy={{ https_proxy | default('') }}
-          no_proxy={{ (['localhost', '127.0.0.1', '127.0.0.2'] + (no_proxy | default([]))) | join(',') }}
+          no_proxy={{ (['localhost', '127.0.0.1', '127.0.0.2'] + (no_proxy | default([]))) | unique | join(',') }}
       when: >
         http_proxy is defined or
         https_proxy is defined or

--- a/etc/kayobe/ansible/deployment/deploy-github-runner.yml
+++ b/etc/kayobe/ansible/deployment/deploy-github-runner.yml
@@ -6,6 +6,17 @@
     - role: geerlingguy.pip
     - role: geerlingguy.docker
   tasks:
+    - name: Set custom_env fact if any proxy variable is defined
+      set_fact:
+        custom_env: |
+          http_proxy={{ http_proxy | default('') }}
+          https_proxy={{ https_proxy | default('') }}
+          no_proxy=localhost,127.0.0.1,127.0.0.2,{{ no_proxy | default('') | join(',') }}
+      when: >
+        http_proxy is defined or
+        https_proxy is defined or
+        no_proxy is defined
+
     - name: Deploy runners
       ansible.builtin.include_role:
         name: monolithprojects.github_actions_runner
@@ -30,3 +41,4 @@
       with_dict: "{{ github_runners }}"
       loop_control:
         loop_var: runner
+

--- a/etc/kayobe/ansible/deployment/deploy-github-runner.yml
+++ b/etc/kayobe/ansible/deployment/deploy-github-runner.yml
@@ -2,6 +2,16 @@
 - name: Deploy GitHub Runner
   hosts: github-runners
   become: true
+  vars:
+    docker_daemon_options:
+      proxies:
+        http-proxy: "{{ http_proxy }}"
+        https-proxy: "{{ https_proxy }}"
+        no-proxy: "{{ (['localhost', '127.0.0.1', '127.0.0.2'] + (no_proxy | default([]))) | join(',') }}"
+  when: >
+    http_proxy is defined or
+    https_proxy is defined or
+    no_proxy is defined
   roles:
     - role: geerlingguy.pip
     - role: geerlingguy.docker

--- a/etc/kayobe/ansible/deployment/deploy-github-runner.yml
+++ b/etc/kayobe/ansible/deployment/deploy-github-runner.yml
@@ -11,7 +11,7 @@
         custom_env: |
           http_proxy={{ http_proxy | default('') }}
           https_proxy={{ https_proxy | default('') }}
-          no_proxy=localhost,127.0.0.1,127.0.0.2,{{ no_proxy | default('') | join(',') }}
+          no_proxy={{ (['localhost', '127.0.0.1', '127.0.0.2'] + (no_proxy | default([]))) | join(',') }}
       when: >
         http_proxy is defined or
         https_proxy is defined or
@@ -41,4 +41,3 @@
       with_dict: "{{ github_runners }}"
       loop_control:
         loop_var: runner
-


### PR DESCRIPTION
Conditionally sets custom_env fact to leverage
monolithprojects.github_actions_runner role support for seting proxy for deployed Github runners.

Confirmed working on environment with mandatory proxy ONLY - it would be great if someone could give this a go in non-proxy setup. With custom_env defined monolithprojects role creates .env file in /opt/actions*... directory (per runner) which is ingested by the running runner (ran on the runner VM ,)