### PR TITLE
Clarify comment about Ansible YAML output

### DIFF
--- a/etc/kayobe/ansible.cfg
+++ b/etc/kayobe/ansible.cfg
@@ -1,6 +1,6 @@
 [defaults]
 forks = 20
-# Use the YAML stdout callback plugin.
+# Use YAML stdout callback output.
 callback_result_format = yaml
 # Use the stdout_callback when running ad-hoc commands.
 bin_ansible_callbacks = True


### PR DESCRIPTION
The plugin has been superseded by the option `result_format=yaml` in callback plugin ansible.builtin.default from ansible-core 2.13 onwards.