### PR TITLE
Improve colour thresholds for certificate expiry

### DIFF
--- a/etc/kayobe/kolla/config/grafana/grafana_home_dashboard.json
+++ b/etc/kayobe/kolla/config/grafana/grafana_home_dashboard.json
@@ -2412,11 +2412,11 @@
                     },
                     {
                       "color": "semi-dark-yellow",
-                      "value": 12096000
+                      "value": 604800
                     },
                     {
                       "color": "semi-dark-green",
-                      "value": 25920000
+                      "value": 2592000
                     }
                   ]
                 }


### PR DESCRIPTION
The existing thresholds were:

- expiry in more than 300 days: green
- expiry between 140 and 300 days: yellow
- expiry in less than 140 days: red

These large values mean that Let's Encrypt certificates are always displayed in red because they are currently valid for 90 days.

Adjust thresholds to be more useful:

- expiry in more than 30 days: green
- expiry between 7 and 30 days: yellow
- expiry in less than 7 days: red