### PR TITLE
Fix container scanning script's docker image ls output

### DIFF
--- a/tools/scan-images.sh
+++ b/tools/scan-images.sh
@@ -45,8 +45,14 @@ file_prep() {
 
 # Gather image lists
 get_images() {
-  docker image ls --filter "reference=ark.stackhpc.com/stackhpc-dev/*:$2*" > $1-scanned-container-images.txt
-  grep --invert-match --no-filename ^REPOSITORY $1-scanned-container-images.txt | sed 's/ \+/:/g' | cut -f 1,2 -d:
+  local output_file="$1-scanned-container-images.txt"
+  
+  docker image ls \
+    --filter "reference=ark.stackhpc.com/stackhpc-dev/*:$2*" \
+    --format "{{.Repository}}:{{.Tag}}" \
+    > "$output_file"
+    
+  cat "$output_file"
 }
 
 # Generate ignored vulnerabilities file


### PR DESCRIPTION
Docker's standard tabular output isn't designed for scripting, so inevitably has broken builds

Fixed it by using proper output formatting

See [broken](https://github.com/stackhpc/stackhpc-kayobe-config/actions/runs/19665475330/job/56321220497) [fixed](https://github.com/stackhpc/stackhpc-kayobe-config/actions/runs/19665481523)