### PR TITLE
Fix docker image ls output - 2024.1 backport

### DIFF
--- a/tools/scan-images.sh
+++ b/tools/scan-images.sh
@@ -21,10 +21,12 @@ rm -rf image-scan-output
 mkdir -p image-scan-output
 
 # Get built container images
-docker image ls --filter "reference=ark.stackhpc.com/stackhpc-dev/*:$2*" > $1-scanned-container-images.txt
+images=$(docker image ls \
+  --filter "reference=ark.stackhpc.com/stackhpc-dev/*:$2*" \
+  --format "{{.Repository}}:{{.Tag}}")
 
-# Make a file of imagename:tag
-images=$(grep --invert-match --no-filename ^REPOSITORY $1-scanned-container-images.txt | sed 's/ \+/:/g' | cut -f 1,2 -d:)
+# Save list of images to file
+echo "$images" > "$1-scanned-container-images.txt"
 
 # Ensure output files exist
 touch image-scan-output/clean-images.txt image-scan-output/dirty-images.txt image-scan-output/critical-images.txt


### PR DESCRIPTION
Same issue as #2000 similar fix, but the scanning script was refactored in 2025.1

Test in progress https://github.com/stackhpc/stackhpc-kayobe-config/actions/runs/19732940444