### PR TITLE
add filebeat restart to complement the go-w on manifest.yml

### DIFF
--- a/etc/kayobe/ansible/deployment/wazuh-manager.yml
+++ b/etc/kayobe/ansible/deployment/wazuh-manager.yml
@@ -134,8 +134,15 @@
       ansible.builtin.file:
         path: "/usr/share/filebeat/module/wazuh/alerts/manifest.yml"
         mode: "go-w"
+      notify:
+        - Restart filebeat
 
   handlers:
+    - name: Restart filebeat
+      ansible.builtin.service:
+        name: filebeat
+        state: restarted
+
     - name: Restart wazuh
       ansible.builtin.service:
         name: wazuh-manager


### PR DESCRIPTION
After permission fix the filebeat service is still stopped, it needs to be restarted.