### PR TITLE
Update Nova containers in stackhpc/2024.1

### DIFF
--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -77,9 +77,9 @@ kolla_image_tags:
     ubuntu-jammy: 2024.1-ubuntu-jammy-20250529T081147
     ubuntu-noble: 2024.1-ubuntu-noble-20250529T081147
   nova:
-    rocky-9: 2024.1-rocky-9-20250717T094248
-    ubuntu-jammy: 2024.1-ubuntu-jammy-20250627T102805
-    ubuntu-noble: 2024.1-ubuntu-noble-20250627T102805
+    rocky-9: 2024.1-rocky-9-20251127T132821
+    ubuntu-jammy: 2024.1-ubuntu-jammy-20251127T132821
+    ubuntu-noble: 2024.1-ubuntu-noble-20251127T132821
   octavia:
     rocky-9: 2024.1-rocky-9-20250717T094248
     ubuntu-jammy: 2024.1-ubuntu-jammy-20250627T102805

--- a/releasenotes/notes/bump-nova-ede0cd4cfffe7d4e.yaml
+++ b/releasenotes/notes/bump-nova-ede0cd4cfffe7d4e.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Updates Nova container images to pick up various bug fixes. One of
+    these should improve API performance:
+    `LP#2122036 <https://bugs.launchpad.net/nova/+bug/2122036>`__.


### PR DESCRIPTION
Use these new Nova images:

https://github.com/stackhpc/stackhpc-kayobe-config/actions/runs/19737871728/job/56554086024

Arcus require this for an API performance fix