### PR TITLE
Bump Trivy to v0.67.2

### DIFF
--- a/.github/workflows/stackhpc-container-image-build.yml
+++ b/.github/workflows/stackhpc-container-image-build.yml
@@ -155,7 +155,7 @@ jobs:
 
       - name: Install Trivy
         run: |
-          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin v0.66.0
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin v0.67.2
 
       - name: Install yq
         run: |

--- a/tools/scan-images.sh
+++ b/tools/scan-images.sh
@@ -27,7 +27,7 @@ usage() {
 # Check dependencies are installed, print installation instructions otherwise
 check_deps_installed() {
   if ! trivy --version > /dev/null; then
-    echo 'Please install trivy: curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin v0.66.0'
+    echo 'Please install trivy: curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin v0.67.2'
     exit 1
   fi
   if ! yq --version > /dev/null; then


### PR DESCRIPTION
Release notes for v0.67.0:
https://github.com/aquasecurity/trivy/discussions/9550