### PR TITLE
Switch to official geerlingguy.docker role

### DIFF
--- a/etc/kayobe/ansible/requirements.yml
+++ b/etc/kayobe/ansible/requirements.yml
@@ -30,8 +30,7 @@ roles:
     src: https://github.com/MonolithProjects/ansible-github_actions_runner
     version: 1.25.1
   - name: geerlingguy.docker
-    src: https://github.com/stackhpc/ansible-role-docker.git
-    version: stackhpc/7.0.1.1
+    version: 7.9.0
     # (jackhodgkiss) Update once patch is merged and released upstream.
   - src: https://github.com/stackhpc/ansible-gitlab-runner
     name: riemers.gitlab-runner


### PR DESCRIPTION
The role was recently updated to use ansible_facts [1].

[1] https://github.com/geerlingguy/ansible-role-docker/commit/c0ddaa9d646e7dc7e10152559446c7d6ce378136