### PR TITLE
Fix CIS play skipping kolla user on non-Kolla hosts

### DIFF
--- a/etc/kayobe/ansible/maintenance/cis.yml
+++ b/etc/kayobe/ansible/maintenance/cis.yml
@@ -20,6 +20,12 @@
         state: present
       when: ansible_facts.distribution == 'Ubuntu'
 
+    - name: Gather passwd entries
+      ansible.builtin.getent:
+        database: passwd
+      become: true
+      changed_when: false
+
     - name: Ensure service accounts have no expiry options set
       # This is to workaround an issue where we set the expiry to 365 days on kayobe
       # service accounts in a previous iteration of the CIS benchmark hardening
@@ -30,6 +36,7 @@
       with_items:
         - "{{ kayobe_ansible_user }}"
         - "{{ kolla_ansible_user }}"
+      when: item in ansible_facts.getent_passwd
 
 - name: Security hardening
   hosts: cis-hardening

--- a/releasenotes/notes/cis-overcloud-non-kolla-hosts-62a00002451e9f4d.yaml
+++ b/releasenotes/notes/cis-overcloud-non-kolla-hosts-62a00002451e9f4d.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    CIS hardening playbook skips service accounts that do not exist on the host
+    (e.g. kolla on non-Kolla/Ceph-only nodes) to avoid errors.


### PR DESCRIPTION
For example non-hyperconverged Ceph nodes are not member of kolla inventory, at it fails there:

```
PRE PATCH:

TASK [Ensure service accounts have no expiry options set] *********************************************************************************************************************************
Thursday 27 November 2025  13:00:42 +0000 (0:00:00.075)       0:00:12.333 *****
ok: [ctrl-02] => (item=stack)
ok: [ctrl-03] => (item=stack)
ok: [ctrl-01] => (item=stack)
ok: [ceph-03] => (item=stack)
ok: [ceph-02] => (item=stack)
ok: [ceph-04] => (item=stack)
ok: [ceph-01] => (item=stack)
ok: [ctrl-02] => (item=kolla)
ok: [ctrl-03] => (item=kolla)
ok: [ctrl-01] => (item=kolla)
failed: [ceph-03] (item=kolla) =>
    ansible_loop_var: item
    changed: false
    cmd:
    - chage
    - -m
    - '0'
    - -M
    - '99999'
    - -W
    - '7'
    - -I
    - '-1'
    - kolla
    delta: '0:00:00.007108'
    end: '2025-11-27 14:00:42.557068'
    item: kolla
    msg: non-zero return code
    rc: 1
    start: '2025-11-27 14:00:42.549960'
    stderr: 'chage: user ''kolla'' does not exist in /etc/passwd'
    stderr_lines: <omitted>
    stdout: ''
    stdout_lines: <omitted>


POST PATCH:

TASK [Ensure service accounts have no expiry options set] *********************************************************************************************************************************
Thursday 27 November 2025  20:31:47 +0100 (0:00:00.074)       0:00:01.471 *****
ok: [ctrl-01] => (item=stack)
ok: [ctrl-02] => (item=stack)
ok: [ctrl-03] => (item=stack)
ok: [os-seed] => (item=stack)
ok: [ceph-04] => (item=stack)
ok: [ceph-01] => (item=stack)
ok: [ceph-02] => (item=stack)
ok: [ceph-03] => (item=stack)
skipping: [ceph-04] => (item=kolla)
skipping: [ceph-01] => (item=kolla)
skipping: [ceph-02] => (item=kolla)
skipping: [ceph-03] => (item=kolla)
ok: [ctrl-01] => (item=kolla)
ok: [ctrl-02] => (item=kolla)
ok: [ctrl-03] => (item=kolla)
ok: [os-seed] => (item=kolla)
```

inspired by https://github.com/openstack/kayobe/blob/645a3074063f9df8c958c2b241d62b3fa4aef9ea/ansible/kolla-ansible-user.yml#L19