### PR TITLE
Use versioned terraform-kayobe-multinode (Antelope)

### DIFF
--- a/.github/workflows/stackhpc-multinode.yml
+++ b/.github/workflows/stackhpc-multinode.yml
@@ -52,7 +52,7 @@ name: Multinode
       terraform_kayobe_multinode_version:
         description: terraform-kayobe-multinode version
         type: string
-        default: stackhpc/2024.1 # This branch is targeted to be compatible with Caracal or older OpenStack releases
+        default: stackhpc/2023.1
 jobs:
   multinode:
     name: Multinode

--- a/.github/workflows/stackhpc-multinode.yml
+++ b/.github/workflows/stackhpc-multinode.yml
@@ -52,7 +52,7 @@ name: Multinode
       terraform_kayobe_multinode_version:
         description: terraform-kayobe-multinode version
         type: string
-        default: main
+        default: stackhpc/2024.1 # This branch is targeted to be compatible with Caracal or older OpenStack releases
 jobs:
   multinode:
     name: Multinode


### PR DESCRIPTION
Recent Ansible playbook path change on stackhpc/2025.1 requires Caracal or older release to use different version of terraform-kayobe-multinode for Multinode deployment.