### PR TITLE
Update prometheus rules for job rename

### DIFF
--- a/etc/kayobe/kolla/config/prometheus/prometheus.rules
+++ b/etc/kayobe/kolla/config/prometheus/prometheus.rules
@@ -7,7 +7,7 @@ groups:
   rules:
 
   - alert: PrometheusTargetMissing
-    expr: up{job!="redfish-exporter-seed"} == 0
+    expr: up{job!="redfish-exporter"} == 0
     for: 5m
     labels:
       severity: critical
@@ -16,7 +16,7 @@ groups:
       description: "A Prometheus target has disappeared. An exporter might have crashed."
 
   - alert: PrometheusTargetMissing
-    expr: up{job="redfish-exporter-seed"} == 0
+    expr: up{job="redfish-exporter"} == 0
     for: 15m
     labels:
       severity: critical


### PR DESCRIPTION
redfish-exporter-seed was renamed redfish-exporter in:

https://github.com/stackhpc/stackhpc-kayobe-config/commit/782f689e606f71286e40ebced364549e32024e70

This updates the rules to match and thereby reduces the sensitivity of the alert.