### PR TITLE
Bump Kayobe to 14.7.0.23

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-kayobe@git+https://github.com/stackhpc/kayobe@stackhpc/14.7.0.22
+kayobe@git+https://github.com/stackhpc/kayobe@stackhpc/14.7.0.23
 ansible-modules-hashivault>=5.2.1
 jmespath


### PR DESCRIPTION
Fixes Kayobe failing to install ansible-collection-kolla due to it changing tag name to 2023.1-eol