### PR TITLE
imag-build workflows: remove unused step

### DIFF
--- a/.github/workflows/ipa-image-build.yml
+++ b/.github/workflows/ipa-image-build.yml
@@ -61,11 +61,6 @@ jobs:
         with:
           path: src/kayobe-config
 
-      - name: Output image tag of the builder
-        id: builder_image_tag
-        run: |
-          echo image_tag=$(grep stackhpc_rocky_9_overcloud_host_image_version: etc/kayobe/pulp-host-image-versions.yml | awk '{print $2}') >> $GITHUB_OUTPUT
-
       - name: Determine OpenStack release
         id: openstack_release
         run: |

--- a/.github/workflows/overcloud-host-image-build.yml
+++ b/.github/workflows/overcloud-host-image-build.yml
@@ -72,11 +72,6 @@ jobs:
         with:
           path: src/kayobe-config
 
-      - name: Output image tag of the builder
-        id: builder_image_tag
-        run: |
-          echo image_tag=$(grep stackhpc_rocky_9_overcloud_host_image_version: etc/kayobe/pulp-host-image-versions.yml | awk '{print $2}') >> $GITHUB_OUTPUT
-
       - name: Determine OpenStack release
         id: openstack_release
         run: |


### PR DESCRIPTION
the step was broken because git clone is in src/kayobe-config.
