### PR TITLE
Fix empty yum.repos.d in overcloud host image

### DIFF
--- a/etc/kayobe/pulp-host-image-versions.yml
+++ b/etc/kayobe/pulp-host-image-versions.yml
@@ -1,5 +1,5 @@
 ---
 # Overcloud host image versioning tags
 # These images must be in SMS, since they are used by our AIO CI runners
-stackhpc_rocky_9_overcloud_host_image_version: "2025.1-20251027T102633"
+stackhpc_rocky_9_overcloud_host_image_version: "2025.1-20251216T122459"
 stackhpc_ubuntu_noble_overcloud_host_image_version: "2025.1-20250930T144255"

--- a/etc/kayobe/stackhpc-overcloud-dib.yml
+++ b/etc/kayobe/stackhpc-overcloud-dib.yml
@@ -56,11 +56,17 @@ stackhpc_overcloud_dib_env_vars_default:
   # Workaround for stack user home ownership bug
   DIB_IMAGE_CACHE: "/tmp/yum"
 
+# NB: use --build-arg to pass arguments only to the Dockerfile.
+# Use stackhpc_overcloud_dib_env_vars_ark keys directly for elements (eg 80-cleanup-and-restore-repofiles)
 stackhpc_overcloud_dib_env_vars_ark:
   DIB_CONTAINERFILE_BUILDOPTS: >-
     --build-arg=ROCKY_USE_CUSTOM_DNF_MIRRORS=true
     --build-arg=ROCKY_CUSTOM_DNF_MIRROR_URLS={{ [stackhpc_repo_rocky_9_baseos_url, stackhpc_repo_rocky_9_appstream_url] | join(',') }}
   DIB_DISTRIBUTION_MIRROR: "{{ stackhpc_repo_ubuntu_noble_url if os_distribution == 'ubuntu' else '' }}"
+  # DIB_ROCKY_CONTAINER_STACKHPC_RESTORE_UPSTREAM_REPOFILES=true is important for
+  # the multinode workflow, where we need to install packages (tmux) in cloudinit
+  # or deploy-openstack-config.yml: /etc/yum.repos.d is empty in the built image.
+  DIB_ROCKY_CONTAINER_STACKHPC_RESTORE_UPSTREAM_REPOFILES: true
 
 # StackHPC overcloud DIB image packages.
 stackhpc_overcloud_dib_packages:

--- a/etc/kayobe/stackhpc-overcloud-dib.yml
+++ b/etc/kayobe/stackhpc-overcloud-dib.yml
@@ -63,9 +63,7 @@ stackhpc_overcloud_dib_env_vars_ark:
     --build-arg=ROCKY_USE_CUSTOM_DNF_MIRRORS=true
     --build-arg=ROCKY_CUSTOM_DNF_MIRROR_URLS={{ [stackhpc_repo_rocky_9_baseos_url, stackhpc_repo_rocky_9_appstream_url] | join(',') }}
   DIB_DISTRIBUTION_MIRROR: "{{ stackhpc_repo_ubuntu_noble_url if os_distribution == 'ubuntu' else '' }}"
-  # DIB_ROCKY_CONTAINER_STACKHPC_RESTORE_UPSTREAM_REPOFILES=true is important for
-  # the multinode workflow, where we need to install packages (tmux) in cloudinit
-  # or deploy-openstack-config.yml: /etc/yum.repos.d is empty in the built image.
+  # Ensure upstream repofiles are re-enabled after image build, otherwise `yum.repos.d` is left empty
   DIB_ROCKY_CONTAINER_STACKHPC_RESTORE_UPSTREAM_REPOFILES: true
 
 # StackHPC overcloud DIB image packages.

--- a/releasenotes/notes/restore-rocky-repos-c33ee54809836851.yaml
+++ b/releasenotes/notes/restore-rocky-repos-c33ee54809836851.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    The default Rocky 9 overcloud host image has been updated to include
+    upstream package repos out of the box


### PR DESCRIPTION
no repos causes installation of tmux fail in terraform-kayobe-multinode. This regression was introduced by commit e0d1d6d