### PR TITLE
Fix DOCA OFED build

### DIFF
--- a/.github/workflows/package-build-ofed.yml
+++ b/.github/workflows/package-build-ofed.yml
@@ -233,7 +233,7 @@ jobs:
         run: |
           source venvs/kayobe/bin/activate &&
           source src/kayobe-config/kayobe-env --environment ci-doca-builder &&
-          kayobe playbook run src/kayobe-config/etc/kayobe/ansible/push-ofed.yml \
+          kayobe playbook run src/kayobe-config/etc/kayobe/ansible/tools/push-ofed.yml \
           -e "ofed_tag=${{ steps.ofed_tag.outputs.ofed_tag }}"
         env:
           KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}

--- a/etc/kayobe/environments/ci-doca-builder/stackhpc-ci.yml
+++ b/etc/kayobe/environments/ci-doca-builder/stackhpc-ci.yml
@@ -7,3 +7,6 @@ stackhpc_repos_enabled: true
 enable_docker_repo: false
 dnf_install_doca: true
 dnf_enable_doca_modules: false
+
+# Disable Pulp auth proxy (deployed too late for DOCA DNF repository setup).
+stackhpc_repo_mirror_auth_proxy_enabled: false


### PR DESCRIPTION
This commit fixes two issues:

- fix path to push-ofed.yml missed from Ansible playbook refactor
- disable Pulp auth proxy (deployed too late for DOCA DNF repository)