### PR TITLE
Grafana: Add more link speed mappings to node exporter dashboard

### DIFF
--- a/etc/kayobe/kolla/config/grafana/dashboards/openstack/node_exporter_full.json
+++ b/etc/kayobe/kolla/config/grafana/dashboards/openstack/node_exporter_full.json
@@ -19722,6 +19722,22 @@
                 "1250000000": {
                   "index": 3,
                   "text": "10G"
+                },
+                "3125000000": {
+                  "index": 4,
+                  "text": "25G"
+                },
+                "6250000000": {
+                  "index": 5,
+                  "text": "50G"
+                },
+                "12500000000": {
+                  "index": 6,
+                  "text": "100G"
+                },
+                "25000000000": {
+                  "index": 7,
+                  "text": "200G"
                 }
               },
               "type": "value"
@@ -19771,7 +19787,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "max by (device)(node_network_speed_bytes{instance=\"$node\",job=\"$job\", device!~\"tap.*\"})",
+          "expr": "max by (device)(node_network_speed_bytes{instance=\"$node\",job=\"$job\", device=~\"(en.*|eth.*|bond.*)\"})",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 2,


### PR DESCRIPTION
Also, display only physical link speeds + bonds for combined speed of individual links.