### PR TITLE
CIS: skip enabling gpgcheck on all yum repos

### DIFF
--- a/etc/kayobe/inventory/group_vars/cis-hardening/cis
+++ b/etc/kayobe/inventory/group_vars/cis-hardening/cis
@@ -11,6 +11,10 @@ update_audit_template: true
 # Allow IP forwarding
 rhel9cis_is_router: true
 
+# Skip enabling gpgcheck on all yum repos.
+# This conflicts with our configured doca repos, which need gpgcheck disabled.
+rhel9cis_rule_1_2_2: false
+
 # Skip configuration of chrony
 rhel9cis_rule_2_1_1: false
 rhel9cis_rule_2_1_2: false

--- a/releasenotes/notes/cis-disable-gpg-check-d993f0c0dfd36fcd.yaml
+++ b/releasenotes/notes/cis-disable-gpg-check-d993f0c0dfd36fcd.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    The RHEL9 CIS Rule 1.2.2 has been disabled, to stop globally enabling
+    gpgchecks on all yum repos. This fixes an issue where custom repos
+    would have the check incorrectly enabled, even when explicitly
+    configured not to.


### PR DESCRIPTION
This conflicts with our configured doca repos, which need gpgcheck disabled.