### PR TITLE
Remove use of ovn-octavia-provider fork

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -163,14 +163,6 @@ kolla_sources:
     type: git
     location: https://github.com/stackhpc/octavia.git
     reference: stackhpc/{{ openstack_release }}
-  octavia-api-plugin-ovn-octavia-provider:
-    type: git
-    location: https://github.com/stackhpc/ovn-octavia-provider.git
-    reference: stackhpc/{{ openstack_release }}
-  octavia-driver-agent-plugin-ovn-octavia-provider:
-    type: git
-    location: https://github.com/stackhpc/ovn-octavia-provider.git
-    reference: stackhpc/{{ openstack_release }}
   blazar-base:
     type: git
     location: https://github.com/stackhpc/blazar.git


### PR DESCRIPTION
Bug fix was merged in 2024.1 [1].

[1] https://review.opendev.org/c/openstack/ovn-octavia-provider/+/965800