### PR TITLE
Remove use of keystone fork

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -135,10 +135,6 @@ kolla_sources:
     type: git
     location: https://github.com/stackhpc/stackhpc-inspector-plugins.git
     reference: 1.3.0
-  keystone-base:
-    type: git
-    location: https://github.com/stackhpc/keystone.git
-    reference: stackhpc/{{ openstack_release }}
   neutron-server-plugin-networking-mlnx:
     type: git
     location: https://github.com/stackhpc/networking-mlnx.git


### PR DESCRIPTION
Bug fix was merged in 2025.1 [1].

[1] https://review.opendev.org/c/openstack/keystone/+/972248