### PR TITLE
Bump stackhpc-openstack-gh-workflows to 1.5.0 (Caracal)

### DIFF
--- a/.github/workflows/stackhpc-multinode.yml
+++ b/.github/workflows/stackhpc-multinode.yml
@@ -56,7 +56,7 @@ name: Multinode
 jobs:
   multinode:
     name: Multinode
-    uses: stackhpc/stackhpc-openstack-gh-workflows/.github/workflows/multinode.yml@1.4.1
+    uses: stackhpc/stackhpc-openstack-gh-workflows/.github/workflows/multinode.yml@1.5.0
     with:
       multinode_name: ${{ inputs.multinode_name }}
       os_distribution: ${{ inputs.os_distribution }}
@@ -72,4 +72,5 @@ jobs:
       # NOTE(upgrade): Reference the PREVIOUS release here.
       stackhpc_kayobe_config_previous_version: ${{ inputs.upgrade == 'major' && 'stackhpc/2023.1' || 'stackhpc/2024.1' }}
       terraform_kayobe_multinode_version: ${{ inputs.terraform_kayobe_multinode_version }}
+      terraform_kayobe_multinode_previous_version: ${{ inputs.upgrade == 'major' && 'stackhpc/2023.1' || 'stackhpc/2024.1' }}
     secrets: inherit


### PR DESCRIPTION
This bump allows SKC to use terraform-kayobe-multinode from previous release when running multinode test with major upgrade