### PR TITLE
Update deprecated stdout_callback option (Antelope)

### DIFF
--- a/etc/kayobe/ansible.cfg
+++ b/etc/kayobe/ansible.cfg
@@ -1,8 +1,8 @@
 [defaults]
 forks = 20
-# Use the YAML stdout callback plugin.
-stdout_callback = yaml
-# Use the stdout_callback when running ad-hoc commands.
+# Use the YAML callback to format output.
+callback_result_format = yaml
+# Use the callback plugin when running ad-hoc commands
 bin_ansible_callbacks = True
 # Disable fact variable injection to improve performance.
 inject_facts_as_vars = False


### PR DESCRIPTION
The option stadout_callback is deprecated and replaced by callback_result_format

(cherry picked from commit 7a0f3acd918cd40dc60817babddb5cd7634c6bbd)