### PR TITLE
Fix rocky 9 overcloud host image minor version

### DIFF
--- a/etc/kayobe/pulp-host-image-versions.yml
+++ b/etc/kayobe/pulp-host-image-versions.yml
@@ -1,5 +1,5 @@
 ---
 # Overcloud host image versioning tags
 # These images must be in SMS, since they are used by our AIO CI runners
-stackhpc_rocky_9_overcloud_host_image_version: "2025.1-20251216T122459"
+stackhpc_rocky_9_overcloud_host_image_version: "2025.1-20260113T105634"
 stackhpc_ubuntu_noble_overcloud_host_image_version: "2025.1-20250930T144255"

--- a/etc/kayobe/stackhpc-overcloud-dib.yml
+++ b/etc/kayobe/stackhpc-overcloud-dib.yml
@@ -37,12 +37,18 @@ stackhpc_overcloud_dib_elements:
 # StackHPC overcloud DIB image environment variables.
 stackhpc_overcloud_dib_env_vars: "{{ stackhpc_overcloud_dib_env_vars_default | combine(stackhpc_overcloud_dib_env_vars_ark if stackhpc_build_overcloud_image_from_pulp_package_mirrors | bool else {}) }}"
 
+# By default the :9 tag is used as base image. Here we want a specific minor version.
+stackhpc_overcloud_dib_container_opts_default: >-
+    --build-arg=ROCKY_VERSION=9.{{ stackhpc_pulp_repo_rocky_9_minor_version }}
+
 stackhpc_overcloud_dib_env_vars_default:
   DIB_BLOCK_DEVICE_CONFIG: "{{ stackhpc_overcloud_dib_block_device_config_uefi_lvm }}"
   DIB_BOOTLOADER_DEFAULT_CMDLINE: "nofb nomodeset gfxpayload=text net.ifnames=1 rd.auto"
   DIB_GRUB_TIMEOUT: "5"
   DIB_GRUB_TIMEOUT_STYLE: "menu"
   DIB_CLOUD_INIT_DATASOURCES: "OpenStack, ConfigDrive"
+  DIB_CONTAINERFILE_BUILDOPTS: >-
+    {{ stackhpc_overcloud_dib_container_opts_default }}
   DIB_CONTAINERFILE_RUNTIME: "docker"
   DIB_CONTAINERFILE_NETWORK_DRIVER: "host"
   DIB_CONTAINERFILE_DOCKERFILE: "/opt/kayobe/src/stackhpc-image-elements/elements/rocky-container-stackhpc/containerfiles/9-stackhpc"
@@ -62,6 +68,7 @@ stackhpc_overcloud_dib_env_vars_ark:
   DIB_CONTAINERFILE_BUILDOPTS: >-
     --build-arg=ROCKY_USE_CUSTOM_DNF_MIRRORS=true
     --build-arg=ROCKY_CUSTOM_DNF_MIRROR_URLS={{ [stackhpc_repo_rocky_9_baseos_url, stackhpc_repo_rocky_9_appstream_url] | join(',') }}
+    {{ stackhpc_overcloud_dib_container_opts_default }}
   DIB_DISTRIBUTION_MIRROR: "{{ stackhpc_repo_ubuntu_noble_url if os_distribution == 'ubuntu' else '' }}"
   # Ensure upstream repofiles are re-enabled after image build, otherwise `yum.repos.d` is left empty
   DIB_ROCKY_CONTAINER_STACKHPC_RESTORE_UPSTREAM_REPOFILES: true

--- a/etc/kayobe/stackhpc.yml
+++ b/etc/kayobe/stackhpc.yml
@@ -208,5 +208,5 @@ stackhpc_ca_secret_store: openbao
 stackhpc_dib_image_elements_repos:
   - repo: "https://github.com/stackhpc/stackhpc-image-elements"
     local: "{{ source_checkout_path }}/stackhpc-image-elements"
-    version: "v1.6.4"
+    version: "v1.6.5"
     elements_path: "elements"


### PR DESCRIPTION
Ensure we use the right tag (eg. `rockylinux:9.6`) docker base image,
instead of just the major version (eg. `rockylinux:9`).