### PR TITLE
Revert RL9 crypto policy to DEFAULT

### DIFF
--- a/etc/kayobe/inventory/group_vars/cis-hardening/cis
+++ b/etc/kayobe/inventory/group_vars/cis-hardening/cis
@@ -26,8 +26,9 @@ rhel9cis_rule_3_4_1_2: false
 # Don't configure selinux
 rhel9cis_selinux_disable: true
 
-# NOTE: FUTURE breaks wazuh agent repo metadata download
-rhel9cis_crypto_policy: FIPS
+# NOTE: Using DEFAULT crypto policy. FIPS breaks ed25519 SSH keys, and FUTURE
+# breaks wazuh agent repo metadata download.
+rhel9cis_crypto_policy: DEFAULT
 
 # Skip package updates
 rhel9cis_rule_1_9: false

--- a/releasenotes/notes/rhel9cis-crypto-policy-default-2de03e6a67a9efae.yaml
+++ b/releasenotes/notes/rhel9cis-crypto-policy-default-2de03e6a67a9efae.yaml
@@ -1,0 +1,6 @@
+---
+security:
+  - |
+    Updates the default CIS hardening configuration to set
+    ``rhel9cis_crypto_policy`` to ``DEFAULT`` instead of ``FIPS``. This
+    resolves SSH issues with some modern key types such as ``ed25519``.


### PR DESCRIPTION
This should resolve SSH issues with some modern key types such as ed25519.