### PR TITLE
CI: Set RL9 crypto policy to DEFAULT (Antelope)

### DIFF
--- a/etc/kayobe/ansible/cis.yml
+++ b/etc/kayobe/ansible/cis.yml
@@ -13,7 +13,7 @@
         that:
           - ssh_key_type != 'ed25519'
         fail_msg: FIPS policy does not currently support ed25519 SSH keys on RHEL family systems
-      when: ansible_facts.os_family == 'RedHat'
+      when: ansible_facts.os_family == 'RedHat' and rhel9cis_crypto_policy == 'FIPS'
 
     - name: Ensure the cron package is installed on ubuntu
       package:

--- a/etc/kayobe/environments/ci-aio/inventory/group_vars/cis-hardening/cis
+++ b/etc/kayobe/environments/ci-aio/inventory/group_vars/cis-hardening/cis
@@ -1,0 +1,9 @@
+---
+##############################################################################
+# Rocky 9 CIS Hardening Configuration
+
+# NOTE: Using DEFAULT crypto policy in CI. FIPS breaks ed25519 SSH keys, and
+# FUTURE breaks wazuh agent repo metadata download.
+rhel9cis_crypto_policy: DEFAULT
+
+##############################################################################

--- a/etc/kayobe/environments/ci-multinode/inventory/group_vars/cis-hardening/cis
+++ b/etc/kayobe/environments/ci-multinode/inventory/group_vars/cis-hardening/cis
@@ -1,0 +1,9 @@
+---
+##############################################################################
+# Rocky 9 CIS Hardening Configuration
+
+# NOTE: Using DEFAULT crypto policy in CI. FIPS breaks ed25519 SSH keys, and
+# FUTURE breaks wazuh agent repo metadata download.
+rhel9cis_crypto_policy: DEFAULT
+
+##############################################################################


### PR DESCRIPTION
This should resolve SSH issues with some modern key types such as ed25519.

(cherry picked from commit f4b85ef6068187df0f5bd0773eec5f0c65f516da)