### PR TITLE
CI: Fix container image build workflow

### DIFF
--- a/.github/workflows/stackhpc-container-image-build.yml
+++ b/.github/workflows/stackhpc-container-image-build.yml
@@ -175,7 +175,12 @@ jobs:
       # Normally installed during host configure.
       - name: Install Docker Python SDK
         run: |
-          sudo pip install docker 'requests<2.32.0'
+          . /etc/os-release
+          if [[ $VERSION_ID == 22.04 ]]; then
+              sudo pip install docker 'requests<2.32.0'
+          else
+              sudo pip install docker 'requests<2.32.0' --break-system-packages
+          fi
 
       - name: Get Kolla tag
         id: write-kolla-tag


### PR DESCRIPTION
Ubuntu Noble runners now need the `--break-system-packages` option to install system-wide Python packages. However this option is absent from pip on our Ubuntu Jammy arm64 runners.

Detect the distribution version and run the appropriate command.