### PR TITLE
Support Vault to OpenBao migration

### DIFF
--- a/doc/source/configuration/openbao.rst
+++ b/doc/source/configuration/openbao.rst
@@ -30,7 +30,7 @@ OpenBao/Hashicorp Vault may also be used as the secret store for Barbican.
     To configure Hashicorp Vault instead set ``stackhpc_ca_secret_store: vault``,
     then follow the instruction.
 
-    Currently the migration path from Hashicorp Vault to OpenBao is in development
+    Migration method can be found at :ref:`Hashicorp Vault to OpenBao migration <vault-bao-migration>`
 
 Background
 ==========
@@ -580,3 +580,27 @@ Deploy Barbican
    .. code-block:: bash
 
       kayobe overcloud service deploy -kt barbican
+
+.. _vault-bao-migration:
+
+Hashicorp Vault to OpenBao Migration
+====================================
+
+You can migrate your secret store from Vault to OpenBao by using a playbook.
+
+.. code-block:: bash
+
+   kayobe playbook run $KAYOBE_CONFIG_PATH/ansible/secret-store/vault-bao-migration-all.yml
+
+The playbook runs three playbooks that can be run separately.
+
+1. Migrate seed Vault to OpenBao - ``$KAYOBE_CONFIG_PATH/ansible/secret-store/vault-bao-migration-seed.yml``
+2. Migrate overcloud Vault to OpenBao - ``$KAYOBE_CONFIG_PATH/ansible/secret-store/vault-bao-migration-overcloud.yml``
+3. Automatically update SKC to target OpenBao - ``$KAYOBE_CONFIG_PATH/ansible/secret-store/vault-bao-migration-change-config.yml``
+
+Seed migration is a single node migration and API calls to seed secret store can be disrupted.
+However, end users of OpenStack will not be affected.
+
+Overcloud migration is HA migration and no downtime is expected.
+
+It is recommended to run ``vault-bao-migration-change-config.yml`` after all Vault deployments have been migrated to OpenBao.

--- a/etc/kayobe/ansible/requirements.yml
+++ b/etc/kayobe/ansible/requirements.yml
@@ -7,7 +7,7 @@ collections:
   - name: stackhpc.pulp
     version: 0.6.0
   - name: stackhpc.hashicorp
-    version: 2.7.1
+    version: 2.8.2
   - name: stackhpc.kayobe_workflows
     version: 1.2.0
 roles:

--- a/etc/kayobe/ansible/secret-store/vault-bao-migration-all.yml
+++ b/etc/kayobe/ansible/secret-store/vault-bao-migration-all.yml
@@ -1,6 +1,9 @@
 # Using lookup because Kayobe variable ``kayobe_config_path`` is not initialised at this stage
-- import_playbook: "{{ lookup('env', 'KAYOBE_CONFIG_PATH') }}/ansible/secret-store/vault-bao-migration-seed.yml"
+- name: Migrate seed Vault to OpenBao
+  ansible.builtin.import_playbook: "{{ lookup('env', 'KAYOBE_CONFIG_PATH') }}/ansible/secret-store/vault-bao-migration-seed.yml"
 
-- import_playbook: "{{ lookup('env', 'KAYOBE_CONFIG_PATH') }}/ansible/secret-store/vault-bao-migration-overcloud.yml"
+- name: Migrate overcloud Vault to OpenBao
+  ansible.builtin.import_playbook: "{{ lookup('env', 'KAYOBE_CONFIG_PATH') }}/ansible/secret-store/vault-bao-migration-overcloud.yml"
 
-- import_playbook: "{{ lookup('env', 'KAYOBE_CONFIG_PATH') }}/ansible/secret-store/vault-bao-migration-change-config.yml"
+- name: Change SKC config to use OpenBao
+  ansible.builtin.import_playbook: "{{ lookup('env', 'KAYOBE_CONFIG_PATH') }}/ansible/secret-store/vault-bao-migration-change-config.yml"

--- a/etc/kayobe/ansible/secret-store/vault-bao-migration-all.yml
+++ b/etc/kayobe/ansible/secret-store/vault-bao-migration-all.yml
@@ -1,0 +1,6 @@
+# Using lookup because Kayobe variable ``kayobe_config_path`` is not initialised at this stage
+- import_playbook: "{{ lookup('env', 'KAYOBE_CONFIG_PATH') }}/ansible/secret-store/vault-bao-migration-seed.yml"
+
+- import_playbook: "{{ lookup('env', 'KAYOBE_CONFIG_PATH') }}/ansible/secret-store/vault-bao-migration-overcloud.yml"
+
+- import_playbook: "{{ lookup('env', 'KAYOBE_CONFIG_PATH') }}/ansible/secret-store/vault-bao-migration-change-config.yml"

--- a/etc/kayobe/ansible/secret-store/vault-bao-migration-change-config.yml
+++ b/etc/kayobe/ansible/secret-store/vault-bao-migration-change-config.yml
@@ -1,0 +1,66 @@
+---
+- name: Change SKC secret store configuration from Vault to OpenBao
+  hosts: localhost
+  tasks:
+    - name: Check if Vault directory exists
+      ansible.builtin.stat:
+        path: "{{ kayobe_env_config_path }}/vault"
+      register: vault_dir
+
+    - name: Copy contents in Vault directory to OpenBao directory
+      ansible.builtin.copy:
+        src: "{{ kayobe_env_config_path }}/vault/"
+        dest: "{{ kayobe_env_config_path }}/openbao/"
+        remote_src: true
+        mode: '0775'
+      when:
+        - vault_dir.stat.exists
+        - vault_dir.stat.isdir
+
+    - name: Check if Vault keys exists under OpenBao directory
+      ansible.builtin.stat:
+        path: "{{ kayobe_env_config_path }}/openbao/{{ item }}"
+      loop:
+        - seed-vault-keys.json
+        - overcloud-vault-keys.json
+      register: vault_keys
+
+    - name: Make copy of Vault keys
+      ansible.builtin.copy:
+        src: "{{ kayobe_env_config_path }}/openbao/{{ item.src }}"
+        dest: "{{ kayobe_env_config_path }}/openbao/{{ item.dest }}"
+        remote_src: true
+        mode: '0600'
+      loop:
+        - { src: seed-vault-keys.json, dest: seed-openbao-keys.json }
+        - { src: overcloud-vault-keys.json, dest: overcloud-openbao-keys.json }
+      loop_control:
+        index_var: key_index
+      when:
+        - vault_keys.results[key_index].stat.exists
+        - vault_keys.results[key_index].stat.isreg
+
+    - name: Remove Vault directory
+      ansible.builtin.file:
+        path: "{{ kayobe_env_config_path }}/vault"
+        state: absent
+
+    - name: Remove Vault keys
+      ansible.builtin.file:
+        path: "{{ kayobe_env_config_path }}/openbao/{{ item }}"
+        state: absent
+      loop:
+        - seed-vault-keys.json
+        - overcloud-vault-keys.json
+
+    - name: Ensure stackhpc.yml exists under environment directory
+      ansible.builtin.file:
+        path: "{{ kayobe_env_config_path }}/stackhpc.yml"
+        state: touch
+        mode: '0664'
+
+    - name: Set stackhpc_ca_secret_store to openbao
+      ansible.builtin.lineinfile:
+        path: "{{ kayobe_env_config_path }}/stackhpc.yml"
+        regexp: "stackhpc_ca_secret_store.+"
+        line: "stackhpc_ca_secret_store: openbao"

--- a/etc/kayobe/ansible/secret-store/vault-bao-migration-change-config.yml
+++ b/etc/kayobe/ansible/secret-store/vault-bao-migration-change-config.yml
@@ -6,6 +6,7 @@
       ansible.builtin.stat:
         path: "{{ kayobe_env_config_path }}/vault"
       register: vault_dir
+      failed_when: not (vault_dir.stat.exists and vault_dir.stat.isdir)
 
     - name: Copy contents in Vault directory to OpenBao directory
       ansible.builtin.copy:
@@ -13,9 +14,6 @@
         dest: "{{ kayobe_env_config_path }}/openbao/"
         remote_src: true
         mode: preserve
-      when:
-        - vault_dir.stat.exists
-        - vault_dir.stat.isdir
 
     - name: Check if Vault keys exists under OpenBao directory
       ansible.builtin.stat:
@@ -52,6 +50,28 @@
       loop:
         - seed-vault-keys.json
         - overcloud-vault-keys.json
+
+    - name: Check if Vault CA for OpenStack services exists
+      ansible.builtin.stat:
+        path: "{{ kayobe_env_config_path }}/kolla/certificates/ca/vault.crt"
+      register: kolla_ca
+
+    - name: Move Vault CA to OpenBao CA
+      when:
+        - kolla_ca.stat.exists
+        - kolla_ca.stat.isreg
+      block:
+        - name: Copy Vault CA to OpenBao CA
+          ansible.builtin.copy:
+            src: "{{ kayobe_env_config_path }}/kolla/certificates/ca/vault.crt"
+            dest: "{{ kayobe_env_config_path }}/kolla/certificates/ca/openbao.crt"
+            remote_src: true
+            mode: preserve
+
+        - name: Remove Vault CA
+          ansible.builtin.file:
+            path: "{{ kayobe_env_config_path }}/kolla/certificates/ca/vault.crt"
+            state: absent
 
     - name: Set stackhpc_ca_secret_store to openbao
       ansible.builtin.lineinfile:

--- a/etc/kayobe/ansible/secret-store/vault-bao-migration-change-config.yml
+++ b/etc/kayobe/ansible/secret-store/vault-bao-migration-change-config.yml
@@ -12,7 +12,7 @@
         src: "{{ kayobe_env_config_path }}/vault/"
         dest: "{{ kayobe_env_config_path }}/openbao/"
         remote_src: true
-        mode: '0775'
+        mode: preserve
       when:
         - vault_dir.stat.exists
         - vault_dir.stat.isdir
@@ -30,7 +30,7 @@
         src: "{{ kayobe_env_config_path }}/openbao/{{ item.src }}"
         dest: "{{ kayobe_env_config_path }}/openbao/{{ item.dest }}"
         remote_src: true
-        mode: '0600'
+        mode: preserve
       loop:
         - { src: seed-vault-keys.json, dest: seed-openbao-keys.json }
         - { src: overcloud-vault-keys.json, dest: overcloud-openbao-keys.json }

--- a/etc/kayobe/ansible/secret-store/vault-bao-migration-change-config.yml
+++ b/etc/kayobe/ansible/secret-store/vault-bao-migration-change-config.yml
@@ -53,14 +53,10 @@
         - seed-vault-keys.json
         - overcloud-vault-keys.json
 
-    - name: Ensure stackhpc.yml exists under environment directory
-      ansible.builtin.file:
-        path: "{{ kayobe_env_config_path }}/stackhpc.yml"
-        state: touch
-        mode: '0664'
-
     - name: Set stackhpc_ca_secret_store to openbao
       ansible.builtin.lineinfile:
         path: "{{ kayobe_env_config_path }}/stackhpc.yml"
         regexp: "stackhpc_ca_secret_store.+"
         line: "stackhpc_ca_secret_store: openbao"
+        create: true
+        mode: '0664'

--- a/etc/kayobe/ansible/secret-store/vault-bao-migration-overcloud.yml
+++ b/etc/kayobe/ansible/secret-store/vault-bao-migration-overcloud.yml
@@ -1,0 +1,57 @@
+---
+- name: Migrate Overcloud Vault to OpenBao
+  any_errors_fatal: true
+  gather_facts: true
+  hosts: controllers
+  vars:
+    secret_store_bind_interface: "{{ internal_net_name | net_interface }}"
+    secret_store_bind_address: "{{ ansible_facts[secret_store_bind_interface].ipv4.address }}"
+    secret_store_api_address: "https://{{ secret_store_bind_address }}:8200"
+  tasks:
+    - name: Set a fact about the virtualenv on the remote system
+      ansible.builtin.set_fact:
+        virtualenv: "{{ ansible_python_interpreter | dirname | dirname }}"
+      when:
+        - ansible_python_interpreter is defined
+        - not ansible_python_interpreter.startswith('/bin/')
+        - not ansible_python_interpreter.startswith('/usr/bin/')
+
+    - name: Ensure Python hvac module is installed
+      ansible.builtin.pip:
+        name: hvac
+        state: latest
+        extra_args: "{% if pip_upper_constraints_file %}-c {{ pip_upper_constraints_file }}{% endif %}"
+        virtualenv: "{{ virtualenv is defined | ternary(virtualenv, omit) }}"
+      become: "{{ virtualenv is not defined }}"
+
+    - name: Include secret store keys
+      ansible.builtin.include_vars:
+        file: "{{ kayobe_env_config_path }}/{{ stackhpc_ca_secret_store }}/overcloud-{{ stackhpc_ca_secret_store }}-keys.json"
+        name: secret_store_keys
+
+- name: Migrate Vault to Openbao
+  import_playbook: stackhpc.hashicorp.vault_bao_migration
+  vars:
+    vault_hosts_group: controllers
+    secret_store_bind_interface: "{{ internal_net_name | net_interface }}"
+    secret_store_bind_address: "{{ ansible_facts[secret_store_bind_interface].ipv4.address }}"
+    secret_store_api_address: "https://{{ secret_store_bind_address }}:8200"
+    migration_consul_docker_image: "{{ seed_consul_docker_image }}"
+    migration_common_root_token: "{{ secret_store_keys.root_token }}"
+    migration_common_unseal_keys: "{{ secret_store_keys.keys_base64 }}"
+    migration_common_bind_addr: "{{ secret_store_bind_address }}"
+    migration_common_api_addr: "{{ secret_store_api_address }}"
+    migration_vault_config_dir: /opt/kayobe/vault
+    migration_common_cluster_name: overcloud
+    migration_vault_docker_image: "{{ seed_vault_docker_image }}"
+    migration_vault_docker_tag: "{{ seed_vault_docker_tag }}"
+    vault_unseal_timeout: 10
+    migration_openbao_config_dir: /opt/kayobe/openbao
+    migration_openbao_docker_image: "{{ seed_openbao_docker_image }}"
+    migration_openbao_docker_tag: "{{ seed_openbao_docker_tag }}"
+    migration_common_tls_cert: "{% if kolla_internal_fqdn != kolla_internal_vip_address %}{{ kolla_internal_fqdn }}{% else %}overcloud{% endif %}.crt"
+    migration_common_tls_key: "{% if kolla_internal_fqdn != kolla_internal_vip_address %}{{ kolla_internal_fqdn }}{% else %}overcloud{% endif %}.key"
+    migration_common_tls_ca: "OS-TLS-INT.crt"
+    migration_openbao_registry_url: "{{ overcloud_openbao_registry_url }}"
+    migration_openbao_registry_username: "{{ overcloud_openbao_registry_username }}"
+    migration_openbao_registry_password: "{{ overcloud_openbao_registry_password }}"

--- a/etc/kayobe/ansible/secret-store/vault-bao-migration-overcloud.yml
+++ b/etc/kayobe/ansible/secret-store/vault-bao-migration-overcloud.yml
@@ -25,7 +25,7 @@
     - name: Ensure Python hvac module is installed
       ansible.builtin.pip:
         name: hvac
-        state: latest
+        state: present
         extra_args: "{% if pip_upper_constraints_file %}-c {{ pip_upper_constraints_file }}{% endif %}"
         virtualenv: "{{ virtualenv is defined | ternary(virtualenv, omit) }}"
       become: "{{ virtualenv is not defined }}"

--- a/etc/kayobe/ansible/secret-store/vault-bao-migration-overcloud.yml
+++ b/etc/kayobe/ansible/secret-store/vault-bao-migration-overcloud.yml
@@ -9,7 +9,7 @@
     secret_store_api_address: "https://{{ secret_store_bind_address }}:8200"
   tasks:
     - name: Fail if secret store is already configured to be OpenBao
-      fail:
+      ansible.builtin.fail:
         msg: Please check if OpenBao is already running on the host.
              If it's not, please set the variable 'stackhpc_ca_secret_store' to 'vault'
       when: stackhpc_ca_secret_store == "openbao"
@@ -36,7 +36,7 @@
         name: secret_store_keys
 
 - name: Migrate Vault to Openbao
-  import_playbook: stackhpc.hashicorp.vault_bao_migration
+  ansible.builtin.import_playbook: stackhpc.hashicorp.vault_bao_migration
   vars:
     vault_hosts_group: controllers
     secret_store_bind_interface: "{{ internal_net_name | net_interface }}"

--- a/etc/kayobe/ansible/secret-store/vault-bao-migration-overcloud.yml
+++ b/etc/kayobe/ansible/secret-store/vault-bao-migration-overcloud.yml
@@ -42,19 +42,19 @@
     secret_store_bind_interface: "{{ internal_net_name | net_interface }}"
     secret_store_bind_address: "{{ ansible_facts[secret_store_bind_interface].ipv4.address }}"
     secret_store_api_address: "https://{{ secret_store_bind_address }}:8200"
-    migration_consul_docker_image: "{{ seed_consul_docker_image }}"
+    migration_consul_docker_image: "{{ overcloud_consul_docker_image }}"
     migration_common_root_token: "{{ secret_store_keys.root_token }}"
     migration_common_unseal_keys: "{{ secret_store_keys.keys_base64 }}"
     migration_common_bind_addr: "{{ secret_store_bind_address }}"
     migration_common_api_addr: "{{ secret_store_api_address }}"
     migration_vault_config_dir: /opt/kayobe/vault
     migration_common_cluster_name: overcloud
-    migration_vault_docker_image: "{{ seed_vault_docker_image }}"
-    migration_vault_docker_tag: "{{ seed_vault_docker_tag }}"
+    migration_vault_docker_image: "{{ overcloud_vault_docker_image }}"
+    migration_vault_docker_tag: "{{ overcloud_vault_docker_tag }}"
     vault_unseal_timeout: 10
     migration_openbao_config_dir: /opt/kayobe/openbao
-    migration_openbao_docker_image: "{{ seed_openbao_docker_image }}"
-    migration_openbao_docker_tag: "{{ seed_openbao_docker_tag }}"
+    migration_openbao_docker_image: "{{ overcloud_openbao_docker_image }}"
+    migration_openbao_docker_tag: "{{ overcloud_openbao_docker_tag }}"
     migration_common_tls_cert: "{% if kolla_internal_fqdn != kolla_internal_vip_address %}{{ kolla_internal_fqdn }}{% else %}overcloud{% endif %}.crt"
     migration_common_tls_key: "{% if kolla_internal_fqdn != kolla_internal_vip_address %}{{ kolla_internal_fqdn }}{% else %}overcloud{% endif %}.key"
     migration_common_tls_ca: "OS-TLS-INT.crt"

--- a/etc/kayobe/ansible/secret-store/vault-bao-migration-overcloud.yml
+++ b/etc/kayobe/ansible/secret-store/vault-bao-migration-overcloud.yml
@@ -8,6 +8,12 @@
     secret_store_bind_address: "{{ ansible_facts[secret_store_bind_interface].ipv4.address }}"
     secret_store_api_address: "https://{{ secret_store_bind_address }}:8200"
   tasks:
+    - name: Fail if secret store is already configured to be OpenBao
+      fail:
+        msg: Please check if OpenBao is already running on the host.
+             If it's not, please set the variable 'stackhpc_ca_secret_store' to 'vault'
+      when: stackhpc_ca_secret_store == "openbao"
+
     - name: Set a fact about the virtualenv on the remote system
       ansible.builtin.set_fact:
         virtualenv: "{{ ansible_python_interpreter | dirname | dirname }}"

--- a/etc/kayobe/ansible/secret-store/vault-bao-migration-seed.yml
+++ b/etc/kayobe/ansible/secret-store/vault-bao-migration-seed.yml
@@ -8,6 +8,12 @@
     secret_store_bind_address: "{{ ansible_facts[secret_store_bind_interface].ipv4.address }}"
     secret_store_api_address: "http://{{ secret_store_bind_address }}:8200"
   tasks:
+    - name: Fail if secret store is already configured to be OpenBao
+      fail:
+        msg: Please check if OpenBao is already running on the host.
+             If it's not, please set the variable 'stackhpc_ca_secret_store' to 'vault'
+      when: stackhpc_ca_secret_store == "openbao"
+
     - name: Set a fact about the virtualenv on the remote system
       ansible.builtin.set_fact:
         virtualenv: "{{ ansible_python_interpreter | dirname | dirname }}"

--- a/etc/kayobe/ansible/secret-store/vault-bao-migration-seed.yml
+++ b/etc/kayobe/ansible/secret-store/vault-bao-migration-seed.yml
@@ -55,3 +55,6 @@
     migration_openbao_config_dir: /opt/kayobe/openbao
     migration_openbao_docker_image: "{{ seed_openbao_docker_image }}"
     migration_openbao_docker_tag: "{{ seed_openbao_docker_tag }}"
+    migration_openbao_registry_url: "{{ seed_openbao_registry_url }}"
+    migration_openbao_registry_username: "{{ seed_openbao_registry_username }}"
+    migration_openbao_registry_password: "{{ seed_openbao_registry_password }}"

--- a/etc/kayobe/ansible/secret-store/vault-bao-migration-seed.yml
+++ b/etc/kayobe/ansible/secret-store/vault-bao-migration-seed.yml
@@ -25,7 +25,7 @@
     - name: Ensure Python hvac module is installed
       ansible.builtin.pip:
         name: hvac
-        state: latest
+        state: present
         extra_args: "{% if pip_upper_constraints_file %}-c {{ pip_upper_constraints_file }}{% endif %}"
         virtualenv: "{{ virtualenv is defined | ternary(virtualenv, omit) }}"
       become: "{{ virtualenv is not defined }}"

--- a/etc/kayobe/ansible/secret-store/vault-bao-migration-seed.yml
+++ b/etc/kayobe/ansible/secret-store/vault-bao-migration-seed.yml
@@ -9,7 +9,7 @@
     secret_store_api_address: "http://{{ secret_store_bind_address }}:8200"
   tasks:
     - name: Fail if secret store is already configured to be OpenBao
-      fail:
+      ansible.builtin.fail:
         msg: Please check if OpenBao is already running on the host.
              If it's not, please set the variable 'stackhpc_ca_secret_store' to 'vault'
       when: stackhpc_ca_secret_store == "openbao"
@@ -36,7 +36,7 @@
         name: secret_store_keys
 
 - name: Migrate Vault to Openbao
-  import_playbook: stackhpc.hashicorp.vault_bao_migration
+  ansible.builtin.import_playbook: stackhpc.hashicorp.vault_bao_migration
   vars:
     vault_hosts_group: seed
     secret_store_bind_interface: lo

--- a/etc/kayobe/ansible/secret-store/vault-bao-migration-seed.yml
+++ b/etc/kayobe/ansible/secret-store/vault-bao-migration-seed.yml
@@ -1,0 +1,51 @@
+---
+- name: Migrate Seed Vault to OpenBao
+  any_errors_fatal: true
+  gather_facts: true
+  hosts: seed
+  vars:
+    secret_store_bind_interface: lo
+    secret_store_bind_address: "{{ ansible_facts[secret_store_bind_interface].ipv4.address }}"
+    secret_store_api_address: "http://{{ secret_store_bind_address }}:8200"
+  tasks:
+    - name: Set a fact about the virtualenv on the remote system
+      ansible.builtin.set_fact:
+        virtualenv: "{{ ansible_python_interpreter | dirname | dirname }}"
+      when:
+        - ansible_python_interpreter is defined
+        - not ansible_python_interpreter.startswith('/bin/')
+        - not ansible_python_interpreter.startswith('/usr/bin/')
+
+    - name: Ensure Python hvac module is installed
+      ansible.builtin.pip:
+        name: hvac
+        state: latest
+        extra_args: "{% if pip_upper_constraints_file %}-c {{ pip_upper_constraints_file }}{% endif %}"
+        virtualenv: "{{ virtualenv is defined | ternary(virtualenv, omit) }}"
+      become: "{{ virtualenv is not defined }}"
+
+    - name: Include secret store keys
+      ansible.builtin.include_vars:
+        file: "{{ kayobe_env_config_path }}/{{ stackhpc_ca_secret_store }}/seed-{{ stackhpc_ca_secret_store }}-keys.json"
+        name: secret_store_keys
+
+- name: Migrate Vault to Openbao
+  import_playbook: stackhpc.hashicorp.vault_bao_migration
+  vars:
+    vault_hosts_group: seed
+    secret_store_bind_interface: lo
+    secret_store_bind_address: "{{ ansible_facts[secret_store_bind_interface].ipv4.address }}"
+    secret_store_api_address: "http://{{ secret_store_bind_address }}:8200"
+    migration_consul_docker_image: "{{ seed_consul_docker_image }}"
+    migration_common_root_token: "{{ secret_store_keys.root_token }}"
+    migration_common_unseal_keys: "{{ secret_store_keys.keys_base64 }}"
+    migration_common_bind_addr: "{{ secret_store_bind_address }}"
+    migration_common_api_addr: "{{ secret_store_api_address }}"
+    migration_vault_config_dir: /opt/kayobe/vault
+    migration_common_cluster_name: seed
+    migration_vault_docker_image: "{{ seed_vault_docker_image }}"
+    migration_vault_docker_tag: "{{ seed_vault_docker_tag }}"
+    vault_unseal_timeout: 10
+    migration_openbao_config_dir: /opt/kayobe/openbao
+    migration_openbao_docker_image: "{{ seed_openbao_docker_image }}"
+    migration_openbao_docker_tag: "{{ seed_openbao_docker_tag }}"

--- a/releasenotes/notes/support-vault-openbao-migration-b6f9973cddc1e04c.yaml
+++ b/releasenotes/notes/support-vault-openbao-migration-b6f9973cddc1e04c.yaml
@@ -1,0 +1,22 @@
+---
+features:
+  - |
+    Added four playbooks for migrating secret store from Hashicorp Vault to
+    OpenBao.
+
+    ``vault-bao-migration-seed.yml`` does Vault to OpenBao migration on seed
+    node. This is single node migration, so API calls to seed secret-store can
+    be disruptive for short period of time.
+
+    ``vault-bao-migration-overcloud.yml`` does Vault to OpenBao migration on
+    overcloud. (Default: controller nodes)
+    This is HA migration, so no downtime is expected.
+
+    ``vault-bao-migration-change-config.yml`` automatically update SKC to
+    target OpenBao. It is recommended to use this playbook after all Vault
+    deployments are migrated to OpenBao.
+
+    ``vault-bao-migration-all.yml`` runs all other three playbooks in order.
+
+    As Hashicorp Vault will no longer be supported from OpenStack 2026.1, it is
+    strongly recommended to migrate to OpenBao before upgrading.


### PR DESCRIPTION
Adds four playbooks used for migrating Vault to OpenBao.

The version of ``stackhpc.hashicorp`` collection needs to be bumped after https://github.com/stackhpc/ansible-collection-hashicorp/pull/85 is merged and released.

But as SKC's contents are ready, marked as ready.