### PR TITLE
Tweaks to Ubuntu Noble Upgrade (2024.1)

### DIFF
--- a/doc/source/operations/ubuntu-noble.rst
+++ b/doc/source/operations/ubuntu-noble.rst
@@ -45,8 +45,10 @@ The following types of hosts will be covered in the future:
 
 .. warning::
 
-   Ceph node upgrades have not yet been performed outside of a virtualised test
-   environment. Proceed with caution.
+   Due to `Bug 66389 <https://tracker.ceph.com/issues/66389>`__, do not upgrade
+   Ceph hosts to Noble until the Ceph cluster has been upgraded to at least
+   Reef v18.2.5. Upgrading a host prematurely will prevent its Ceph daemons
+   from starting, and it will not be able to rejoin the cluster.
 
 Prerequisites
 =============
@@ -78,14 +80,14 @@ To sync host packages:
 .. code-block:: console
 
    kayobe playbook run $KAYOBE_CONFIG_PATH/ansible/pulp-repo-sync.yml -e stackhpc_pulp_sync_ubuntu_jammy=true -e stackhpc_pulp_sync_ubuntu_noble=true
-   kayobe playbook run $KAYOBE_CONFIG_PATH/ansible/pulp-repo-publish.yml
+   kayobe playbook run $KAYOBE_CONFIG_PATH/ansible/pulp-repo-publish.yml -e stackhpc_pulp_sync_ubuntu_jammy=true -e stackhpc_pulp_sync_ubuntu_noble=true
 
 Once the host package content has been tested in a test/staging environment, it
 may be promoted to production:
 
 .. code-block:: console
 
-   kayobe playbook run $KAYOBE_CONFIG_PATH/ansible/pulp-repo-promote-production.yml
+   kayobe playbook run $KAYOBE_CONFIG_PATH/ansible/pulp-repo-promote-production.yml -e stackhpc_pulp_sync_ubuntu_jammy=true -e stackhpc_pulp_sync_ubuntu_noble=true
 
 To sync container images:
 
@@ -351,6 +353,8 @@ Storage
 Potential issues
 ----------------
 
+-  Ensure the Ceph cluster is running at least Reef v18.2.5.
+   Upgrading hosts with an older Ceph version will cause daemons to fail.
 -  It is recommended that you upgrade the bootstrap host last.
 -  Before upgrading the bootstrap host, it can be beneficial to backup
    ``/etc/ceph`` and ``/var/lib/ceph``, as sometimes the keys, config, etc.

--- a/etc/kayobe/ansible/ubuntu-upgrade.yml
+++ b/etc/kayobe/ansible/ubuntu-upgrade.yml
@@ -54,18 +54,7 @@
       become: true
       when: file_status.stat.exists
 
-    # NOTE: We cannot use apt_repository here because definitions must exist within the standard repos.list
-    - name: Ensure Noble repo definitions exist in sources.list
-      ansible.builtin.blockinfile:
-        path: /etc/apt/sources.list
-        block: |
-          deb {{ stackhpc_repo_ubuntu_noble_url }} noble main restricted universe multiverse
-          deb {{ stackhpc_repo_ubuntu_noble_url }} noble-updates main restricted universe multiverse
-          deb {{ stackhpc_repo_ubuntu_noble_url }} noble-backports main restricted universe multiverse
-          deb {{ stackhpc_repo_ubuntu_noble_security_url }} noble-security main restricted universe multiverse
-      become: true
-
-    - name: Enusre /tmp is mounted with exec
+    - name: Ensure /tmp is mounted with exec
       ansible.posix.mount:
         path: /tmp
         opts: exec
@@ -80,6 +69,17 @@
         group: root
       become: true
       when: inventory_hostname in groups['ceph']
+
+    # NOTE: We cannot use apt_repository here because definitions must exist within the standard repos.list
+    - name: Ensure Noble repo definitions exist in sources.list
+      ansible.builtin.blockinfile:
+        path: /etc/apt/sources.list
+        block: |
+          deb {{ stackhpc_repo_ubuntu_noble_url }} noble main restricted universe multiverse
+          deb {{ stackhpc_repo_ubuntu_noble_url }} noble-updates main restricted universe multiverse
+          deb {{ stackhpc_repo_ubuntu_noble_url }} noble-backports main restricted universe multiverse
+          deb {{ stackhpc_repo_ubuntu_noble_security_url }} noble-security main restricted universe multiverse
+      become: true
 
 - name: Upgrade hosts from Ubuntu Jammy 22.04 to Noble 24.04
   hosts: overcloud:infra-vms:seed:seed-hypervisor
@@ -242,7 +242,7 @@
         filter: "{{ kayobe_ansible_setup_filter }}"
         gather_subset: "{{ kayobe_ansible_setup_gather_subset }}"
 
-    - name: Assert that hosts are now using Ubuntu 24
+    - name: Assert that hosts are now using Ubuntu 24.04
       ansible.builtin.assert:
         that:
           - ansible_facts.distribution_major_version == '24'


### PR DESCRIPTION
Implements commits: 9c85c3d66dafdd207e367c3b84a683f02462e572 and f23399c2624b16689f95a78082528b63423cd0e0

Update docs to get pulp to also publish and promote noble images

Move repo additions to happen before do-release-upgrade

Moves the addition of new Ubuntu repositories to directly before the call to do-release-upgrade. This ensures that any any failures after that point are only due to the upgrade itself, and not due to missing mounts (such as /tmp not being mounted).