### PR TITLE
Rebuild Rocky and Ubuntu Nova and Neutron images for 2024.1

### DIFF
--- a/.github/workflows/stackhpc-container-image-build.yml
+++ b/.github/workflows/stackhpc-container-image-build.yml
@@ -158,7 +158,7 @@ jobs:
 
       - name: Install Trivy
         run: |
-          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin v0.49.0
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin v0.68.2
 
       - name: Install yq
         run: |

--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -70,16 +70,16 @@ kolla_image_tags:
     ubuntu-jammy: 2024.1-ubuntu-jammy-20250627T102805
     ubuntu-noble: 2024.1-ubuntu-noble-20250627T102805
   neutron:
-    rocky-9: 2024.1-rocky-9-20251113T114107
-    ubuntu-jammy: 2024.1-ubuntu-jammy-20251113T114107
-    ubuntu-noble: 2024.1-ubuntu-noble-20251113T114107
+    rocky-9: 2024.1-rocky-9-20260128T142402
+    ubuntu-jammy: 2024.1-ubuntu-jammy-20260128T065158
+    ubuntu-noble: 2024.1-ubuntu-noble-20260128T065158
   neutron_bgp_dragent:
     ubuntu-jammy: 2024.1-ubuntu-jammy-20250529T081147
     ubuntu-noble: 2024.1-ubuntu-noble-20250529T081147
   nova:
-    rocky-9: 2024.1-rocky-9-20251127T132821
-    ubuntu-jammy: 2024.1-ubuntu-jammy-20251127T132821
-    ubuntu-noble: 2024.1-ubuntu-noble-20251127T132821
+    rocky-9: 2024.1-rocky-9-20260128T142402
+    ubuntu-jammy: 2024.1-ubuntu-jammy-20260128T065158
+    ubuntu-noble: 2024.1-ubuntu-noble-20260128T065158
   octavia:
     rocky-9: 2024.1-rocky-9-20250717T094248
     ubuntu-jammy: 2024.1-ubuntu-jammy-20250627T102805

--- a/tools/scan-images.sh
+++ b/tools/scan-images.sh
@@ -11,7 +11,7 @@ set -u
 
 # Check that trivy is installed
 if ! trivy --version; then
-  echo 'Please install trivy: curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.49.1'
+  echo 'Please install trivy: curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.68.2'
 fi
 
 # Clear any previous outputs


### PR DESCRIPTION
Manifests for previous images were corrupted during a failed Pulp database migration - these replace the previous images, and their corrupted tags will be withdrawn from the StackHPC Pulp service.

A bump to Trivy was required to scan aarch64 images for vulnerabilities, the Docker client in Trivy v0.49.0 was too old for the Docker API version running on the arm64 runner.