### PR TITLE
Fix Read the Docs builds

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,6 +1,9 @@
+# TODO(priteau): Remove myst-parser dependency and bump Sphinx once
+# compatibility is resolved
+myst-parser>=4.0.0,<5 # MIT
 reno>=3.4.0 # Apache-2.0
 sphinx-copybutton # MIT
 sphinx-substitution-extensions # MIT
-sphinx>=4.2.0 # BSD
+sphinx>=4.2.0,<9 # BSD
 sphinxcontrib-svg2pdfconverter>=0.1.0 # BSD
 sphinx-immaterial # MIT


### PR DESCRIPTION
Documentation builds on Read the Docs have been failing following the release of myst-parser 5.0.0. Cap requirement to use myst-parser 4.x instead, which is not compatible with Sphinx 9.