### PR TITLE
Fix Read the Docs builds (2024.1 Caracal)

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,9 +8,9 @@ version: 2
 build:
   apt_packages:
     - tox
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3.7"
+    python: "3.12"
   jobs:
     post_checkout:
       - git remote set-branches origin master stackhpc/2024.1 stackhpc/2023.1 stackhpc/zed stackhpc/yoga stackhpc/xena stackhpc/wallaby


### PR DESCRIPTION
Synchronise Python version with the one used in 2025.1.