### PR TITLE
Fix Read the Docs builds (backport to 2024.1)

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,9 +1,8 @@
-# The order of packages is significant, because pip processes them in the order
-# of appearance. Changing the order has an impact on the overall integration
-# process, which may cause wedges in the gate later.
-
+# TODO(priteau): Remove myst-parser dependency and bump Sphinx once
+# compatibility is resolved
+myst-parser>=4.0.0,<5 # MIT
 reno>=3.4.0 # Apache-2.0
-sphinx>=4.2.0 # BSD
-sphinxcontrib-svg2pdfconverter>=0.1.0 # BSD
-Sphinx-Substitution-Extensions # Apache-2.0
+sphinx>=4.2.0,<9 # BSD
 sphinx-immaterial # MIT
+sphinx-substitution-extensions # MIT
+sphinxcontrib-svg2pdfconverter>=0.1.0 # BSD


### PR DESCRIPTION
Documentation builds on Read the Docs have been failing following the release of myst-parser 5.0.0. Cap requirement to use myst-parser 4.x instead, which is not compatible with Sphinx 9.

(cherry picked from commit 81e957f474d9defd1633a0e5940de61cf8a4cf42)