### PR TITLE
Fix wazuh role pin (2023.1)

### DIFF
--- a/etc/kayobe/ansible/requirements.yml
+++ b/etc/kayobe/ansible/requirements.yml
@@ -26,7 +26,7 @@ roles:
     version: bugfix/inject-facts
   - name: wazuh-ansible
     src: https://github.com/stackhpc/wazuh-ansible
-    version: stackhpc
+    version: stackhpc-v4.3.10
   - name: geerlingguy.pip
     version: 2.2.0
   - name: monolithprojects.github_actions_runner


### PR DESCRIPTION
The `stackhpc` branch in the wazuh-ansible no longer exists for some reason.

This change updates the pin to a new `stackhpc-v4.3.10` branch.

The version should remain the same as before

Example error: https://github.com/stackhpc/stackhpc-kayobe-config/actions/runs/21627046230/job/62330402189#step:6:2494