### PR TITLE
Add extra delay to reboot playbook

### DIFF
--- a/etc/kayobe/ansible/maintenance/reboot.yml
+++ b/etc/kayobe/ansible/maintenance/reboot.yml
@@ -5,6 +5,7 @@
   gather_facts: false
   vars:
     reboot_timeout_s: "{{ 20 * 60 }}"
+    post_reboot_delay_s: 5 # Extra delay to ensure SSH is working reliably
     reboot_with_bootstrap_user: false
     ansible_user: "{{ bootstrap_user if reboot_with_bootstrap_user | bool else kayobe_ansible_user }}"
     ansible_ssh_common_args: "{{ '-o StrictHostKeyChecking=no' if reboot_with_bootstrap_user | bool else '' }}"
@@ -32,7 +33,8 @@
     - name: Reboot and wait
       become: true
       ansible.builtin.reboot:
-        reboot_timeout: "{{ reboot_timeout_s }}"
+        post_reboot_delay: "{{ post_reboot_delay_s | int }}"
+        reboot_timeout: "{{ reboot_timeout_s | int }}"
         search_paths:
           # Systems running molly-guard hang waiting for confirmation before rebooting without this.
           - /lib/molly-guard

--- a/releasenotes/notes/add-post-reboot-delay-2ac3fa99badf4601.yaml
+++ b/releasenotes/notes/add-post-reboot-delay-2ac3fa99badf4601.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Adds an extra delay after reboot in the ``maintenance/reboot.yml`` playbook
+    to ensure hosts can be reached reliably. The default delay is 5 seconds and
+    can be customised with the ``post_reboot_delay_s`` variable.


### PR DESCRIPTION
We often see CI failures where the reboot playbook is successful, but the growroot playbook invoked immediately after it fails with a `Connection timed out` error.

Add an extra delay after the reboot to ensure host has finished booting successfully.