### PR TITLE
Bump glance-store requirement to 4.7.1.1

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -403,7 +403,7 @@ kolla_build_customizations_common:
     - /additions/*
   glance_base_pip_packages_override:
     - "/glance"
-    - "glance_store[cinder,vmware,swift,s3]@git+https://github.com/stackhpc/glance_store@stackhpc/4.7.0.6"
+    - "glance_store[cinder,vmware,swift,s3]@git+https://github.com/stackhpc/glance_store@stackhpc/4.7.1.1"
   ironic_inspector_pip_packages_append:
     - /additions/*
   magnum_base_pip_packages_override:


### PR DESCRIPTION
No functional change: the version number should already have been higher than 4.7.1 but it was not bumped because of missing tags in our fork.