### PR TITLE
Docs: Update vip failover commands

### DIFF
--- a/doc/source/operations/ubuntu-noble.rst
+++ b/doc/source/operations/ubuntu-noble.rst
@@ -153,8 +153,8 @@ long enough).
 
 .. code-block:: bash
 
-   sudo docker stop keepalived
-   sudo docker start keepalived
+   sudo sudo systemctl stop kolla-keepalived-container.service
+   sudo sudo systemctl start kolla-keepalived-container.service
 
 Always back up the overcloud DB before starting:
 

--- a/doc/source/operations/ubuntu-noble.rst
+++ b/doc/source/operations/ubuntu-noble.rst
@@ -153,8 +153,8 @@ long enough).
 
 .. code-block:: bash
 
-   sudo sudo systemctl stop kolla-keepalived-container.service
-   sudo sudo systemctl start kolla-keepalived-container.service
+   sudo systemctl stop kolla-keepalived-container.service
+   sudo systemctl start kolla-keepalived-container.service
 
 Always back up the overcloud DB before starting:
 


### PR DESCRIPTION
It is best practice to use systemctl to stop and start containers.