### PR TITLE
Update echo commands to use -e for escape sequences

### DIFF
--- a/tools/rabbitmq-queue-migration.sh
+++ b/tools/rabbitmq-queue-migration.sh
@@ -9,17 +9,17 @@ RABBITMQ_SERVICES_TO_RESTART=barbican,blazar,cinder,cloudkitty,designate,heat,ir
 RABBITMQ_CONTAINER_NAME=rabbitmq
 
 if [[ ! $KAYOBE_CONFIG_PATH ]]; then
-    echo "${RED}Environment variable \$KAYOBE_CONFIG_PATH is not defined"
-    echo "${RED}Ensure your environment is set up to run kayobe commands"
+    echo -e "${RED}Environment variable \$KAYOBE_CONFIG_PATH is not defined"
+    echo -e "${RED}Ensure your environment is set up to run kayobe commands"
     exit 2
 fi
 
 if [[ ! "$1" = "--skip-checks" ]]; then
     # Fail if clocks are not synced
     if ! ( kayobe overcloud host command run -l controllers -b --command "timedatectl status | grep 'synchronized: yes'" ); then
-        echo "${RED}Failed precheck: Time not synced on controllers"
-        echo "${RED}Use 'timedatectl status' to check sync state"
-        echo "${RED}Either wait for sync or use 'chronyc makestep'"
+        echo -e "${RED}Failed precheck: Time not synced on controllers"
+        echo -e "${RED}Use 'timedatectl status' to check sync state"
+        echo -e "${RED}Either wait for sync or use 'chronyc makestep'"
         exit 1
     fi
     kayobe overcloud service configuration generate --node-config-dir /tmp/rabbit-migration --kolla-tags none
@@ -28,7 +28,7 @@ if [[ ! "$1" = "--skip-checks" ]]; then
            grep 'om_enable_rabbitmq_quorum_queues: true' $KOLLA_CONFIG_PATH/globals.yml && \
            grep 'om_enable_rabbitmq_transient_quorum_queue: true' $KOLLA_CONFIG_PATH/globals.yml && \
            grep 'om_enable_rabbitmq_stream_fanout: true' $KOLLA_CONFIG_PATH/globals.yml ); then
-              echo "${RED}Failed precheck: The following must be enabled: om_enable_queue_manager, om_enable_rabbitmq_quorum_queues, om_enable_rabbitmq_transient_quorum_queue, om_enable_rabbitmq_stream_fanout"
+              echo -e "${RED}Failed precheck: The following must be enabled: om_enable_queue_manager, om_enable_rabbitmq_quorum_queues, om_enable_rabbitmq_transient_quorum_queue, om_enable_rabbitmq_stream_fanout"
               exit 1
     fi
 fi


### PR DESCRIPTION
Fix colored output on errors. It is quite easy to miss the failures otherwise.

Co-authored-by: pescobar.it@gmail.com