### PR TITLE
Use new ci-builder vault pw in workflows

### DIFF
--- a/.github/workflows/amphora-image-build.yml
+++ b/.github/workflows/amphora-image-build.yml
@@ -11,7 +11,7 @@ on:
           - SMS Lab
           - Leafcloud
     secrets:
-      KAYOBE_VAULT_PASSWORD:
+      KAYOBE_VAULT_PASSWORD_CI_BUILDER:
         required: true
       CLOUDS_YAML:
         required: true
@@ -23,7 +23,7 @@ on:
 env:
   ANSIBLE_FORCE_COLOR: True
   KAYOBE_ENVIRONMENT: ci-builder
-  KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
+  KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
 jobs:
   runner-selection:
     uses: ./.github/workflows/runner-selector.yml
@@ -196,7 +196,7 @@ jobs:
           kayobe seed host command run \
           --command "sudo apt update && sudo apt -y install gcc git libffi-dev python3-dev python-is-python3 python3-venv" --show-output
         env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
 
       - name: Create Amphora image output directory
         run: |
@@ -205,7 +205,7 @@ jobs:
           kayobe seed host command run \
           --command "mkdir -p /opt/kayobe/images/amphora" --show-output
         env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
 
       - name: Build Octavia Amphora image
         id: build_amphora
@@ -214,7 +214,7 @@ jobs:
           source src/kayobe-config/kayobe-env --environment ci-builder &&
           kayobe playbook run src/kayobe-config/etc/kayobe/ansible/maintenance/octavia-amphora-image-build.yml -e amphora_image_dest=/opt/kayobe/images/amphora/amphora-x64-haproxy.qcow2
         env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
 
       - name: Show last error logs
         continue-on-error: true
@@ -223,7 +223,7 @@ jobs:
           source src/kayobe-config/kayobe-env --environment ci-builder &&
           kayobe seed host command run --command "tail -200 /var/log/octavia-amphora-image-build.log" --show-output
         env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
         if: steps.build_amphora.outcome == 'failure'
 
       - name: Upload Octavia Amphora image to Ark
@@ -238,7 +238,7 @@ jobs:
           -e repository_name="amphora-images-${{ steps.openstack_release.outputs.openstack_release }}" \
           -e pulp_base_path="amphora-images/${{ steps.openstack_release.outputs.openstack_release }}"
         env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
         if: steps.build_amphora.outcome == 'success'
 
       - name: Copy logs back to runner

--- a/.github/workflows/amphora-image-promote.yml
+++ b/.github/workflows/amphora-image-promote.yml
@@ -66,4 +66,4 @@ jobs:
           -e pulp_base_path="amphora-images/${{ steps.openstack_release.outputs.openstack_release }}"
         env:
           ARTIFACT_TAG: ${{ inputs.image_tag }}
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}

--- a/.github/workflows/ipa-image-build.yml
+++ b/.github/workflows/ipa-image-build.yml
@@ -19,7 +19,7 @@ on:
           - SMS Lab
           - Leafcloud
     secrets:
-      KAYOBE_VAULT_PASSWORD:
+      KAYOBE_VAULT_PASSWORD_CI_BUILDER:
         required: true
       CLOUDS_YAML:
         required: true
@@ -31,7 +31,7 @@ on:
 env:
   ANSIBLE_FORCE_COLOR: True
   KAYOBE_ENVIRONMENT: ci-builder
-  KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
+  KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
 jobs:
   runner-selection:
     uses: ./.github/workflows/runner-selector.yml
@@ -196,7 +196,7 @@ jobs:
           -e seed_bootstrap_user=ubuntu \
           --skip-tags network,apt,docker,docker-registry
         env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
 
       - name: Install dependencies
         run: |
@@ -205,7 +205,7 @@ jobs:
           kayobe seed host command run \
           --command "sudo apt update && sudo apt -y install gcc git libffi-dev python3-dev python-is-python3 python3-venv" --show-output
         env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
 
       - name: Build a Ubuntu 24.04 Noble IPA image
         id: build_ubuntu_noble_ipa
@@ -219,7 +219,7 @@ jobs:
           -e ipa_ci_builder_distribution="ubuntu" \
           -e ipa_ci_builder_release="noble"
         env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
         if: inputs.ubuntu-noble
 
       - name: Show last error logs
@@ -229,7 +229,7 @@ jobs:
           source src/kayobe-config/kayobe-env --environment ci-builder &&
           kayobe seed host command run --command "tail -200 /opt/kayobe/images/ipa/ipa.stdout" --show-output
         env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
         if: steps.build_ubuntu_noble_ipa.outcome == 'failure'
 
       - name: Upload Ubuntu 24.04 Noble IPA kernel image to Ark
@@ -245,7 +245,7 @@ jobs:
           -e os_release="noble" \
           -e file_regex='*.kernel'
         env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
         if: inputs.ubuntu-noble && steps.build_ubuntu_noble_ipa.outcome == 'success'
 
       - name: Upload Ubuntu 24.04 Noble IPA ramdisk image to Ark
@@ -261,7 +261,7 @@ jobs:
           -e os_release="noble" \
           -e file_regex='*.initramfs'
         env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
         if: inputs.ubuntu-noble && steps.build_ubuntu_noble_ipa.outcome == 'success'
 
       - name: Build a Rocky 9 IPA image
@@ -276,7 +276,7 @@ jobs:
           -e ipa_ci_builder_distribution="rocky" \
           -e ipa_ci_builder_release="9"
         env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
         if: inputs.rocky9
 
       - name: Show last error logs
@@ -286,7 +286,7 @@ jobs:
           source src/kayobe-config/kayobe-env --environment ci-builder &&
           kayobe seed host command run --command "tail -200 /opt/kayobe/images/ipa/ipa.stdout" --show-output
         env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
         if: steps.build_rocky_9_ipa.outcome == 'failure'
 
       - name: Upload Rocky 9 IPA kernel image to Ark
@@ -302,7 +302,7 @@ jobs:
           -e os_release="9" \
           -e file_regex='*.kernel'
         env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
         if: inputs.rocky9 && steps.build_rocky_9_ipa.outcome == 'success'
 
       - name: Upload Rocky 9 IPA ramdisk image to Ark
@@ -318,7 +318,7 @@ jobs:
           -e os_release="9" \
           -e file_regex='*.initramfs'
         env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
         if: inputs.rocky9 && steps.build_rocky_9_ipa.outcome == 'success'
 
       - name: Copy logs back

--- a/.github/workflows/ipa-image-promote.yml
+++ b/.github/workflows/ipa-image-promote.yml
@@ -82,7 +82,7 @@ jobs:
           -e os_release='9'
         env:
           ARTIFACT_TAG: ${{ inputs.image_tag }}
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
         if: inputs.rocky9
 
       - name: Promote Ubuntu Noble 24.04 IPA image artifact
@@ -96,5 +96,5 @@ jobs:
           -e os_release='noble'
         env:
           ARTIFACT_TAG: ${{ inputs.image_tag }}
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
         if: inputs.ubuntu-noble

--- a/.github/workflows/overcloud-host-image-build.yml
+++ b/.github/workflows/overcloud-host-image-build.yml
@@ -23,7 +23,7 @@ on:
         type: boolean
         default: true
     secrets:
-      KAYOBE_VAULT_PASSWORD:
+      KAYOBE_VAULT_PASSWORD_CI_BUILDER:
         required: true
       CLOUDS_YAML:
         required: true
@@ -35,7 +35,7 @@ on:
 env:
   ANSIBLE_FORCE_COLOR: True
   KAYOBE_ENVIRONMENT: ci-builder
-  KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
+  KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
 jobs:
   runner-selection:
     uses: ./.github/workflows/runner-selector.yml
@@ -214,7 +214,7 @@ jobs:
           kayobe seed host command run \
           --command "sudo apt update && sudo apt -y install gcc git libffi-dev python3-dev python-is-python3 python3-venv containerd docker.io docker-buildx" --show-output
         env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
 
       - name: Create bifrost_httpboot Docker volume
         run: |
@@ -222,7 +222,7 @@ jobs:
           source src/kayobe-config/kayobe-env --environment ci-builder &&
           kayobe seed host command run --command "sudo mkdir -p /var/lib/docker/volumes/bifrost_httpboot/_data" --show-output
         env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
 
       - name: Build a Rocky Linux 9 overcloud host image
         id: build_rocky_9
@@ -235,7 +235,7 @@ jobs:
           -e os_release="9" \
           -e stackhpc_overcloud_dib_name=overcloud-rocky-9
         env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
         if: inputs.rocky9
 
       - name: Show last error logs
@@ -245,7 +245,7 @@ jobs:
           source src/kayobe-config/kayobe-env --environment ci-builder &&
           kayobe seed host command run --command "tail -200 /opt/kayobe/images/overcloud-rocky-9/overcloud-rocky-9.stdout" --show-output
         env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
         if: steps.build_rocky_9.outcome == 'failure'
 
       - name: Upload Rocky Linux 9 overcloud host image to current Dev Cloud (SMS/Leafcloud)
@@ -289,7 +289,7 @@ jobs:
           -e os_distribution="rocky" \
           -e os_release="9"
         env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
         if: inputs.rocky9 && steps.build_rocky_9.outcome == 'success'
 
       - name: Build an Ubuntu Noble 24.04 overcloud host image
@@ -303,7 +303,7 @@ jobs:
           -e os_release="noble" \
           -e stackhpc_overcloud_dib_name=overcloud-ubuntu-noble
         env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
         if: inputs.ubuntu-noble
 
       - name: Show last error logs
@@ -313,7 +313,7 @@ jobs:
           source src/kayobe-config/kayobe-env --environment ci-builder &&
           kayobe seed host command run --command "tail -200 /opt/kayobe/images/overcloud-ubuntu-noble/overcloud-ubuntu-noble.stdout" --show-output
         env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
         if: steps.build_ubuntu_noble.outcome == 'failure'
 
       - name: Upload Ubuntu Noble overcloud host image to current Dev Cloud (SMS/Leafcloud)
@@ -357,7 +357,7 @@ jobs:
           -e os_distribution="ubuntu" \
           -e os_release="noble"
         env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
         if: inputs.ubuntu-noble && steps.build_ubuntu_noble.outcome == 'success'
 
       - name: Copy logs back

--- a/.github/workflows/overcloud-host-image-promote.yml
+++ b/.github/workflows/overcloud-host-image-promote.yml
@@ -92,7 +92,7 @@ jobs:
           -e os_release='9' \
           -e promotion_tag=${{ steps.rocky9_image_tag.outputs.image_tag }}
         env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
         if: inputs.rocky9
 
       - name: Promote Ubuntu Noble 24.04 overcloud host image artifact
@@ -106,5 +106,5 @@ jobs:
           -e os_release='noble' \
           -e promotion_tag=${{ steps.ubuntu_noble_image_tag.outputs.image_tag }}
         env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
         if: inputs.ubuntu-noble

--- a/.github/workflows/overcloud-host-image-upload.yml
+++ b/.github/workflows/overcloud-host-image-upload.yml
@@ -23,7 +23,7 @@ on:
           - SMS Lab
           - Leafcloud
     secrets:
-      KAYOBE_VAULT_PASSWORD:
+      KAYOBE_VAULT_PASSWORD_CI_BUILDER:
         required: true
       CLOUDS_YAML:
         required: true
@@ -122,7 +122,7 @@ jobs:
           -e os_distribution="rocky" \
           -e os_release="9"
         env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
         if: inputs.rocky9 && steps.rocky_9_image_exists.outcome == 'failure'
 
       - name: Upload Rocky Linux 9 overcloud host image to Cloud
@@ -167,7 +167,7 @@ jobs:
           -e os_distribution="ubuntu" \
           -e os_release="noble"
         env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
         if: inputs.ubuntu-noble && steps.ubuntu_noble_image_exists.outcome == 'failure'
 
       - name: Upload Ubuntu Noble 24.04 overcloud host image to Cloud

--- a/.github/workflows/package-build-ofed.yml
+++ b/.github/workflows/package-build-ofed.yml
@@ -8,7 +8,7 @@ on:
         type: boolean
         default: true
     secrets:
-      KAYOBE_VAULT_PASSWORD:
+      KAYOBE_VAULT_PASSWORD_CI_BUILDER:
         required: true
       CLOUDS_YAML:
         required: true
@@ -20,7 +20,7 @@ on:
 env:
   ANSIBLE_FORCE_COLOR: True
   KAYOBE_ENVIRONMENT: ci-doca-builder
-  KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
+  KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
 jobs:
   overcloud-ofed-packages:
     name: Build OFED kernel modules
@@ -180,7 +180,7 @@ jobs:
           source src/kayobe-config/kayobe-env --environment ci-doca-builder &&
           kayobe playbook run src/kayobe-config/etc/kayobe/ansible/tools/growroot.yml
         env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
 
       - name: Configure the seed host (Builder VM)
         run: |
@@ -188,7 +188,7 @@ jobs:
           source src/kayobe-config/kayobe-env --environment ci-doca-builder &&
           kayobe seed host configure --skip-tags network,docker,docker-registry
         env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
 
       - name: Run a distro-sync
         run: |
@@ -196,7 +196,7 @@ jobs:
           source src/kayobe-config/kayobe-env --environment ci-doca-builder &&
           kayobe seed host command run --become --command "dnf distro-sync --refresh --assumeyes"
         env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
 
       - name: Reset BLS entries on the seed host
         run: |
@@ -205,7 +205,7 @@ jobs:
           kayobe playbook run src/kayobe-config/etc/kayobe/ansible/maintenance/reset-bls-entries.yml \
           -e "reset_bls_host=ofed-builder"
         env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
 
       - name: Disable noexec in /var/tmp
         run: |
@@ -213,7 +213,7 @@ jobs:
           source src/kayobe-config/kayobe-env --environment ci-doca-builder &&
           kayobe seed host command run --become --command "sed -i 's/noexec,//g' /etc/fstab"
         env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
 
       - name: Reboot to apply the kernel update
         run: |
@@ -221,7 +221,7 @@ jobs:
           source src/kayobe-config/kayobe-env --environment ci-doca-builder &&
           kayobe playbook run src/kayobe-config/etc/kayobe/ansible/maintenance/reboot.yml
         env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
 
       - name: Run OFED builder playbook
         run: |
@@ -229,7 +229,7 @@ jobs:
           source src/kayobe-config/kayobe-env --environment ci-doca-builder &&
           kayobe playbook run src/kayobe-config/etc/kayobe/ansible/tools/build-ofed-rocky.yml
         env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
 
       - name: Run OFED upload playbook
         run: |
@@ -238,7 +238,7 @@ jobs:
           kayobe playbook run src/kayobe-config/etc/kayobe/ansible/tools/push-ofed.yml \
           -e "ofed_tag=${{ steps.ofed_tag.outputs.ofed_tag }}"
         env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
 
       - name: Destroy
         run: terraform destroy -auto-approve

--- a/.github/workflows/stackhpc-container-image-build.yml
+++ b/.github/workflows/stackhpc-container-image-build.yml
@@ -223,7 +223,7 @@ jobs:
           source src/kayobe-config/kayobe-env --environment ci-builder &&
           kayobe overcloud container image build $args
         env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
         if: inputs.overcloud
 
       - name: Copy build configs to output directory
@@ -242,7 +242,7 @@ jobs:
           source src/kayobe-config/kayobe-env --environment ci-builder &&
           kayobe seed container image build $args
         env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
         if: inputs.seed && matrix.distro.arch == 'amd64'
 
       - name: Copy seed container image build logs to output directory
@@ -306,7 +306,7 @@ jobs:
           done < image-build-logs/push-attempt-images.txt
         shell: bash
         env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD }}
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
         if: inputs.push
 
       - name: Upload output artifact

--- a/doc/source/contributor/testing-ci-automation.rst
+++ b/doc/source/contributor/testing-ci-automation.rst
@@ -286,8 +286,9 @@ and `variables
 <https://docs.github.com/actions/deployment/targeting-different-environments/using-environments-for-deployment>`_
 are used to allow running jobs on different clouds.
 
-``KAYOBE_VAULT_PASSWORD`` is a repository-scoped GitHub secret containing the
-Ansible Vault password for the ``ci-builder`` Kayobe environment.
+``KAYOBE_VAULT_PASSWORD_CI_BUILDER`` is a repository-scoped GitHub secret
+containing the Ansible Vault password for the ``ci-builder`` Kayobe
+environment.
 
 The following GitHub secrets are defined in each GitHub environment:
 


### PR DESCRIPTION
Previously, the workflows would just use the AIO vault password.

Since the AIO password needs to persist (for the aios), it isn't as simple as just changing the variable in the github settings this time. The builder env needs a new secret variable.

This changes switches KAYOBE_VAULT_PASSWORD for KAYOBE_VAULT_PASSWORD_CI_BUILDER (newly defined variable) in builder workflows