### PR TITLE
Fix typo in a sample file

### DIFF
--- a/etc/kayobe/kolla/config/prometheus/prometheus-alertmanager.msteamsv2.yml.example
+++ b/etc/kayobe/kolla/config/prometheus/prometheus-alertmanager.msteamsv2.yml.example
@@ -13,7 +13,7 @@ route:
   routes:
     - matchers:
         - severity=~"critical|alert"
-      receiver: 'msteamvs2-critical-notifications'
+      receiver: 'msteamsv2-critical-notifications'
 
 receivers:
   - name: 'msteamsv2-notifications'


### PR DESCRIPTION
Without this, the example does not work out of the box.