### PR TITLE
Fix Docker version check

### DIFF
--- a/etc/kayobe/ansible/stackhpc-cloud-tests.yml
+++ b/etc/kayobe/ansible/stackhpc-cloud-tests.yml
@@ -142,7 +142,7 @@
             # Inclusive min
             sct_docker_version_min: "24.0.0"
             # Exclusive max
-            sct_docker_version_max: "30.0.0"
+            sct_docker_version_max: "29.0.0"
             sct_selinux_state: "{{ selinux_state }}"
           failed_when: host_results.rc not in [0, 1]
           register: host_results


### PR DESCRIPTION
We decided to keep 2024.1 at Docker Engine v28.