### PR TITLE
Fix Rocky minor version strict typing

### DIFF
--- a/etc/kayobe/ansible/maintenance/rocky-97-ofed-upgrade.yml
+++ b/etc/kayobe/ansible/maintenance/rocky-97-ofed-upgrade.yml
@@ -17,7 +17,7 @@
   vars:
     # we don't build kernel modules for each version, eg 5.14.0-611.13.1 has been built,
     # but not 5.14.0-611.20.1.
-    doca_kernel_version: "{{ stackhpc_doca_kernel_version_matrix[stackhpc_pulp_repo_rocky_9_minor_version] }}"
+    doca_kernel_version: "{{ stackhpc_doca_kernel_version_matrix[stackhpc_pulp_repo_rocky_9_minor_version | string] }}"
   tasks:
     - name: Assert that hosts are running Rocky Linux 9.6
       ansible.builtin.assert:

--- a/etc/kayobe/ansible/tools/install-doca.yml
+++ b/etc/kayobe/ansible/tools/install-doca.yml
@@ -6,7 +6,7 @@
   vars:
     # we don't build kernel modules for each version, eg 5.14.0-611.13.1 has been built,
     # but not 5.14.0-611.20.1
-    doca_kernel_version: "{{ stackhpc_doca_kernel_version_matrix[stackhpc_pulp_repo_rocky_9_minor_version] }}"
+    doca_kernel_version: "{{ stackhpc_doca_kernel_version_matrix[stackhpc_pulp_repo_rocky_9_minor_version | string] }}"
   tasks:
     - name: Install kernel repo
       ansible.builtin.dnf:

--- a/etc/kayobe/ofed.yml
+++ b/etc/kayobe/ofed.yml
@@ -6,7 +6,7 @@
 stackhpc_pulp_doca_version_matrix:
     "6": 2.9.3
     "7": 3.2.1
-stackhpc_pulp_doca_version: "{{ stackhpc_pulp_doca_version_matrix[stackhpc_pulp_repo_rocky_9_minor_version] | default('2.9.1') }}"
+stackhpc_pulp_doca_version: "{{ stackhpc_pulp_doca_version_matrix[stackhpc_pulp_repo_rocky_9_minor_version | string] | default('2.9.1') }}"
 
 # Available and tested versions of the pre-compiled doca-ofed kernel modules
 stackhpc_doca_kernel_version_matrix:


### PR DESCRIPTION
I ran the `pulp-repo-sync.yml` and got a very long error trace that ended like this:
```
No variable found with this name: stackhpc_pulp_repo_doca_2_9_1_rhel9_7_version 
```
After a bit of fishing, I found that the issue was I had set:
`stackhpc_pulp_repo_rocky_9_minor_version: 7`
and not
`stackhpc_pulp_repo_rocky_9_minor_version: '7'`
i.e. the minor version was an integer, not a string.
That meant this this lookup failed:
```
stackhpc_pulp_doca_version_matrix:
    "6": 2.9.3
    "7": 3.2.1
```
Fixed by a string filter on the lookup. Same fix applied to other instances where the minor version is used