### PR TITLE
Use Docker 29 on 2024.1 Caracal

### DIFF
--- a/etc/kayobe/ansible/stackhpc-cloud-tests.yml
+++ b/etc/kayobe/ansible/stackhpc-cloud-tests.yml
@@ -142,7 +142,7 @@
             # Inclusive min
             sct_docker_version_min: "24.0.0"
             # Exclusive max
-            sct_docker_version_max: "29.0.0"
+            sct_docker_version_max: "30.0.0"
             sct_selinux_state: "{{ selinux_state }}"
           failed_when: host_results.rc not in [0, 1]
           register: host_results

--- a/etc/kayobe/docker.yml
+++ b/etc/kayobe/docker.yml
@@ -38,15 +38,6 @@ docker_registry_insecure: "{{ 'https' not in stackhpc_repo_mirror_url }}"
 # Enable live-restore on docker daemon
 docker_daemon_live_restore: true
 
-# Avoid docker 29 for the moment in Caracal
-docker_packages_version: "{{ '-28.*' if os_distribution == 'rocky' else ('=5:28*' if os_release == 'noble' else '=5:27*') }}"
-# variable from https://github.com/stackhpc/ansible-role-docker/blob/master/defaults/main.yml
-docker_packages:
-  - "docker-ce{{ docker_packages_version }}"
-  - "docker-ce-cli{{ docker_packages_version }}"
-  - "docker-ce-rootless-extras{{ docker_packages_version }}"
-  - "containerd.io"
-
 ###############################################################################
 # Dummy variable to allow Ansible to accept this file.
 workaround_ansible_issue_8743: yes


### PR DESCRIPTION
Docker can be updated to version 29 using a package update. We risk downgrading to 28 when running `kayobe overcloud host configure`, which might be worse than the upgrade from 28 to 29.

Revert "limit docker-ce to 28 on Caracal"

This reverts commit 18027cac09dc03eae5cb623ad722832f04266b62.

Revert "Fix Docker version check"

This reverts commit 01de41aad7e239b6409de67ed1374448b38756b0.