### PR TITLE
CI: Use rockylinux/rockylinux:9 image

### DIFF
--- a/.github/workflows/stackhpc-build-kayobe-image.yml
+++ b/.github/workflows/stackhpc-build-kayobe-image.yml
@@ -24,7 +24,7 @@ on:
       base_image:
         type: string
         required: false
-        default: "rockylinux:9"
+        default: "rockylinux/rockylinux:9"
       if:
         description: Whether to run the workflow (workaround for required status checks issue)
         type: boolean
@@ -92,7 +92,7 @@ jobs:
           build-args: |
              http_proxy=${{ inputs.http_proxy }}
              https_proxy=${{ inputs.https_proxy }}
-             BASE_IMAGE=${{ inputs.base_image || 'rockylinux:9' }}
+             BASE_IMAGE=${{ inputs.base_image || 'rockylinux/rockylinux:9' }}
              USE_PYTHON_312=true
              KAYOBE_USER_UID=1001
              KAYOBE_USER_GID=1001

--- a/doc/source/operations/tempest.rst
+++ b/doc/source/operations/tempest.rst
@@ -103,7 +103,7 @@ Build a Kayobe automation image:
     git submodule update
     # If running on Ubuntu, the fact cache can confuse Kayobe in the Rocky-based container
     mv etc/kayobe/facts{,-old}
-    sudo DOCKER_BUILDKIT=1 docker build --network host --build-arg BASE_IMAGE=rockylinux:9 --file .automation/docker/kayobe/Dockerfile --tag kayobe:latest .
+    sudo DOCKER_BUILDKIT=1 docker build --network host --build-arg BASE_IMAGE=rockylinux/rockylinux:9 --file .automation/docker/kayobe/Dockerfile --tag kayobe:latest .
 
 Configuration
 =============

--- a/etc/kayobe/environments/ci-aio/automated-setup.sh
+++ b/etc/kayobe/environments/ci-aio/automated-setup.sh
@@ -203,7 +203,7 @@ run_tempest() {
     if ! sudo docker image inspect kayobe:latest > /dev/null 2>&1; then
         echo "Building Kayobe Automation image"
         sudo DOCKER_BUILDKIT=1 docker build \
-        --build-arg BASE_IMAGE=rockylinux:9 \
+        --build-arg BASE_IMAGE=rockylinux/rockylinux:9 \
         --build-arg USE_PYTHON_312=true \
         --file .automation/docker/kayobe/Dockerfile \
         --tag kayobe:latest \


### PR DESCRIPTION
The "official" rockylinux images (aka library/rockylinux) are not updated anymore [1]. It is recommended to use rockylinux/rockylinux images instead [2].

This could speed up the Kayobe image build step because fewer packages will be updated.

[1] https://hub.docker.com/_/rockylinux
[2] https://hub.docker.com/r/rockylinux/rockylinux