### PR TITLE
fix: sort `redfish_exporter_targets` to avoid config changes

### DIFF
--- a/etc/kayobe/kolla/config/prometheus/prometheus.yml.d/60-redfish.yml
+++ b/etc/kayobe/kolla/config/prometheus/prometheus.yml.d/60-redfish.yml
@@ -16,7 +16,7 @@ scrape_configs:
      - target_label: __address__
        replacement: "{{ lookup('vars', admin_oc_net_name ~ '_ips')[groups.seed.0] }}:9610"
     static_configs:
-{% for host in groups.get('redfish_exporter_targets', []) %}
+{% for host in (groups.get('redfish_exporter_targets', []) | sort) %}
       - targets:
           - '{{ hostvars[host]["redfish_exporter_target_address"] }}'
         labels:


### PR DESCRIPTION
When templating `redfish_exporter_targets` in `60-redfish.yml` the groups are written randomly and as a result can cause unnecessary updates to the templated file which can lead to reboots of prometheus as well as polluting configuration diff.