### PR TITLE
Bump trivy to 0.69.2

### DIFF
--- a/.github/workflows/stackhpc-container-image-build.yml
+++ b/.github/workflows/stackhpc-container-image-build.yml
@@ -155,7 +155,7 @@ jobs:
 
       - name: Install Trivy
         run: |
-          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin v0.69.1
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin v0.69.2
 
       - name: Install yq
         run: |

--- a/tools/scan-images.sh
+++ b/tools/scan-images.sh
@@ -27,7 +27,7 @@ usage() {
 # Check dependencies are installed, print installation instructions otherwise
 check_deps_installed() {
   if ! trivy --version > /dev/null; then
-    echo 'Please install trivy: curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin v0.69.1'
+    echo 'Please install trivy: curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin v0.69.2'
     exit 1
   fi
   if ! yq --version > /dev/null; then


### PR DESCRIPTION
Trivy had security incident on 1st March 2026 [1], resulting losing all
GitHub Releases between 0.27.0-0.69.1.
They then restored the latest as 0.69.2

[1] https://github.com/aquasecurity/trivy/discussions/10265