### PR TITLE
Bump Trivy to 0.69.2 Yoga

### DIFF
--- a/.github/workflows/stackhpc-container-image-build.yml
+++ b/.github/workflows/stackhpc-container-image-build.yml
@@ -142,7 +142,7 @@ jobs:
 
       - name: Install Trivy
         run: |
-          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin v0.49.0
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin v0.69.2
 
       - name: Install Kayobe
         run: |

--- a/tools/scan-images.sh
+++ b/tools/scan-images.sh
@@ -11,7 +11,7 @@ set -u
 
 # Check that trivy is installed
 if ! trivy --version; then
-  echo 'Please install trivy: curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.49.1'
+  echo 'Please install trivy: curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.69.2'
 fi
 
 # Clear any previous outputs


### PR DESCRIPTION
Trivy had security incident on 1st March 2026 [1], resulting losing all GitHub Releases between 0.27.0-0.69.1.
They then restored the latest as 0.69.2

[1] https://github.com/aquasecurity/trivy/discussions/10265

(cherry picked from commit 9144c9f7e2ad95b72bceb8aeb96d5eacb3c8b8ec)