### PR TITLE
Support skipping Rocky Linux version check

### DIFF
--- a/etc/kayobe/ansible/install-doca.yml
+++ b/etc/kayobe/ansible/install-doca.yml
@@ -6,7 +6,7 @@
   vars:
     # we don't build kernel modules for each version, eg 5.14.0-611.13.1 has been built,
     # but not 5.14.0-611.20.1
-    doca_kernel_version: "{{ stackhpc_doca_kernel_version_matrix[stackhpc_pulp_repo_rocky_9_minor_version] }}"
+    doca_kernel_version: "{{ stackhpc_doca_kernel_version_matrix[stackhpc_pulp_repo_rocky_9_minor_version | string] }}"
   tasks:
     - name: Install kernel repo
       ansible.builtin.dnf:

--- a/etc/kayobe/ansible/rocky-97-ofed-upgrade.yml
+++ b/etc/kayobe/ansible/rocky-97-ofed-upgrade.yml
@@ -17,7 +17,7 @@
   vars:
     # we don't build kernel modules for each version, eg 5.14.0-611.13.1 has been built,
     # but not 5.14.0-611.20.1.
-    doca_kernel_version: "{{ stackhpc_doca_kernel_version_matrix[stackhpc_pulp_repo_rocky_9_minor_version] }}"
+    doca_kernel_version: "{{ stackhpc_doca_kernel_version_matrix[stackhpc_pulp_repo_rocky_9_minor_version | string] }}"
   tasks:
     - name: Assert that hosts are running Rocky Linux 9.6
       ansible.builtin.assert:

--- a/etc/kayobe/ansible/rocky-97-ofed-upgrade.yml
+++ b/etc/kayobe/ansible/rocky-97-ofed-upgrade.yml
@@ -28,7 +28,9 @@
         fail_msg: >-
           This playbook is only designed for Rocky Linux 9.6 hosts. Ensure
           that you are limiting it to only run on Rocky Linux 9.6 hosts and
-          os_distribution is set to rocky.
+          os_distribution is set to rocky. This can be bypassed by setting the
+          skip_rocky_96_version_check variable to true.
+      when: not skip_rocky_96_version_check | default(false) | bool
 
     - name: Ensure doca kernel repo is up to date
       ansible.builtin.dnf:

--- a/etc/kayobe/ofed.yml
+++ b/etc/kayobe/ofed.yml
@@ -6,7 +6,7 @@
 stackhpc_pulp_doca_version_matrix:
     "6": 2.9.3
     "7": 3.2.1
-stackhpc_pulp_doca_version: "{{ stackhpc_pulp_doca_version_matrix[stackhpc_pulp_repo_rocky_9_minor_version] | default('2.9.1') }}"
+stackhpc_pulp_doca_version: "{{ stackhpc_pulp_doca_version_matrix[stackhpc_pulp_repo_rocky_9_minor_version | string] | default('2.9.1') }}"
 
 # Available and tested versions of the pre-compiled doca-ofed kernel modules
 stackhpc_doca_kernel_version_matrix:


### PR DESCRIPTION
This can be useful if the playbook has been interrupted before finishing, but the rocky-release package is already updated to 9.7.

(cherry picked from commit 0640fd18764526f68ed3f07cc173662efe54eab2)