### PR TITLE
Build Rocky Linux 10 host images

### DIFF
--- a/.github/workflows/overcloud-host-image-build.yml
+++ b/.github/workflows/overcloud-host-image-build.yml
@@ -7,6 +7,10 @@ on:
         description: Build Rocky Linux 9
         type: boolean
         default: true
+      rocky10:
+        description: Build Rocky Linux 10
+        type: boolean
+        default: true
       ubuntu-noble:
         description: Build Ubuntu 24.04 Noble
         type: boolean
@@ -53,7 +57,7 @@ jobs:
     steps:
       - name: Validate inputs
         run: |
-          if [[ ${{ inputs.rocky9 }} == 'false' && ${{ inputs.ubuntu-noble }} == 'false' ]]; then
+          if [[ ${{ inputs.rocky9 }} == 'false' && ${{ inputs.rocky10 }} == 'false' && ${{ inputs.ubuntu-noble }} == 'false' ]]; then
             echo "At least one distribution must be selected"
             exit 1
           fi
@@ -292,6 +296,74 @@ jobs:
           KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
         if: inputs.rocky9 && steps.build_rocky_9.outcome == 'success'
 
+      - name: Build a Rocky Linux 10 overcloud host image
+        id: build_rocky_10
+        continue-on-error: true
+        run: |
+          source venvs/kayobe/bin/activate &&
+          source src/kayobe-config/kayobe-env --environment ci-builder &&
+          kayobe overcloud host image build --force-rebuild \
+          -e os_distribution="rocky" \
+          -e os_release="10" \
+          -e stackhpc_overcloud_dib_name=overcloud-rocky-10
+        env:
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
+        if: inputs.rocky10
+
+      - name: Show last error logs
+        continue-on-error: true
+        run: |
+          source venvs/kayobe/bin/activate &&
+          source src/kayobe-config/kayobe-env --environment ci-builder &&
+          kayobe seed host command run --command "tail -200 /opt/kayobe/images/overcloud-rocky-10/overcloud-rocky-10.stdout" --show-output
+        env:
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
+        if: steps.build_rocky_10.outcome == 'failure'
+
+      - name: Upload Rocky Linux 10 overcloud host image to current Dev Cloud (SMS/Leafcloud)
+        run: |
+          source venvs/kayobe/bin/activate &&
+          source src/kayobe-config/kayobe-env --environment ci-builder &&
+          kayobe playbook run \
+          src/kayobe-config/etc/kayobe/ansible/tools/openstack-host-image-upload.yml \
+          -e local_image_path="/opt/kayobe/images/overcloud-rocky-10/overcloud-rocky-10.qcow2" \
+          -e image_name=overcloud-rocky-10-${{ steps.host_image_tag.outputs.host_image_tag }}
+        env:
+          CLOUDS_YAML: ${{ secrets.CLOUDS_YAML }}
+          OS_APPLICATION_CREDENTIAL_ID: ${{ secrets.OS_APPLICATION_CREDENTIAL_ID }}
+          OS_APPLICATION_CREDENTIAL_SECRET: ${{ secrets.OS_APPLICATION_CREDENTIAL_SECRET }}
+        if: inputs.rocky10 && steps.build_rocky_10.outcome == 'success'
+
+      - name: Upload Rocky Linux 10 overcloud host image to other Dev Cloud (Leafcloud/SMS)
+        run: |
+          source venvs/kayobe/bin/activate &&
+          source src/kayobe-config/kayobe-env --environment ci-builder &&
+          kayobe playbook run \
+          src/kayobe-config/etc/kayobe/ansible/tools/openstack-host-image-upload.yml \
+          -e local_image_path="/opt/kayobe/images/overcloud-rocky-10/overcloud-rocky-10.qcow2" \
+          -e image_name=overcloud-rocky-10-${{ steps.host_image_tag.outputs.host_image_tag }}
+        env:
+          CLOUDS_YAML: ${{ secrets.CLOUDS_YAML_OTHER_CLOUD }}
+          OS_APPLICATION_CREDENTIAL_ID: ${{ secrets.OS_APPLICATION_CREDENTIAL_ID_OTHER_CLOUD }}
+          OS_APPLICATION_CREDENTIAL_SECRET: ${{ secrets.OS_APPLICATION_CREDENTIAL_SECRET_OTHER_CLOUD }}
+        if: inputs.rocky10 && steps.build_rocky_10.outcome == 'success'
+
+      - name: Upload Rocky Linux 10 overcloud host image to Ark
+        run: |
+          source venvs/kayobe/bin/activate &&
+          source src/kayobe-config/kayobe-env --environment ci-builder &&
+          kayobe playbook run \
+          src/kayobe-config/etc/kayobe/ansible/pulp/pulp-artifact-upload.yml \
+          -e artifact_path=/opt/kayobe/images/overcloud-rocky-10 \
+          -e artifact_tag=${{ steps.host_image_tag.outputs.host_image_tag }} \
+          -e artifact_type="kayobe-images" \
+          -e file_regex="*.qcow2" \
+          -e os_distribution="rocky" \
+          -e os_release="10"
+        env:
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
+        if: inputs.rocky10 && steps.build_rocky_10.outcome == 'success'
+
       - name: Build an Ubuntu Noble 24.04 overcloud host image
         id: build_ubuntu_noble
         continue-on-error: true
@@ -373,6 +445,7 @@ jobs:
           echo "Builds failed. See workflow artifacts for details." &&
           exit 1
         if: steps.build_rocky_9.outcome == 'failure' ||
+            steps.build_rocky_10.outcome == 'failure' ||
             steps.build_ubuntu_noble.outcome == 'failure'
 
       - name: Upload logs artifact
@@ -398,6 +471,7 @@ jobs:
           --repo stackhpc/stackhpc-kayobe-config \
           --ref $BRANCH_NAME \
           $(if [[ "${{ inputs.rocky9 }}" == "true" ]]; then echo "-f rocky9_tag=${{ steps.host_image_tag.outputs.host_image_tag }}"; fi) \
+          $(if [[ "${{ inputs.rocky10 }}" == "true" ]]; then echo "-f rocky10_tag=${{ steps.host_image_tag.outputs.host_image_tag }}"; fi) \
           $(if [[ "${{ inputs.ubuntu-noble }}" == "true" ]]; then echo "-f ubuntu_noble_tag=${{ steps.host_image_tag.outputs.host_image_tag }}"; fi)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/overcloud-host-image-promote.yml
+++ b/.github/workflows/overcloud-host-image-promote.yml
@@ -7,6 +7,10 @@ on:
         description: Promote Rocky Linux 9
         type: boolean
         default: true
+      rocky10:
+        description: Promote Rocky Linux 10
+        type: boolean
+        default: true
       ubuntu-noble:
         description: Promote Ubuntu 24.04 Noble
         type: boolean
@@ -21,7 +25,7 @@ jobs:
     steps:
       - name: Validate inputs
         run: |
-          if [[ ${{ inputs.rocky9 }} == 'false' && ${{ inputs.ubuntu-noble }} == 'false' ]]; then
+          if [[ ${{ inputs.rocky9 }} == 'false' && ${{ inputs.rocky10 }} == 'false' && ${{ inputs.ubuntu-noble }} == 'false' ]]; then
             echo "At least one distribution must be selected"
             exit 1
           fi
@@ -74,6 +78,13 @@ jobs:
         working-directory: src/kayobe-config
         if: inputs.rocky9
 
+      - name: Gather Rocky Linux 10 overcloud host image tag
+        id: rocky10_image_tag
+        run: |
+          echo image_tag=$(grep stackhpc_rocky_10_overcloud_host_image_version: etc/kayobe/pulp-host-image-versions.yml | awk '{print $2}') >> $GITHUB_OUTPUT
+        working-directory: src/kayobe-config
+        if: inputs.rocky10
+
       - name: Gather Ubuntu Noble overcloud host image tag
         id: ubuntu_noble_image_tag
         run: |
@@ -94,6 +105,20 @@ jobs:
         env:
           KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
         if: inputs.rocky9
+
+      - name: Promote Rocky Linux 10 overcloud host image artifact
+        run: |
+          source venvs/kayobe/bin/activate &&
+          source src/kayobe-config/kayobe-env --environment ci-builder &&
+          kayobe playbook run \
+          src/kayobe-config/etc/kayobe/ansible/pulp/pulp-artifact-promote.yml \
+          -e artifact_type="kayobe-images" \
+          -e os_distribution='rocky' \
+          -e os_release='10' \
+          -e promotion_tag=${{ steps.rocky10_image_tag.outputs.image_tag }}
+        env:
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
+        if: inputs.rocky10
 
       - name: Promote Ubuntu Noble 24.04 overcloud host image artifact
         run: |

--- a/.github/workflows/overcloud-host-image-upload.yml
+++ b/.github/workflows/overcloud-host-image-upload.yml
@@ -7,6 +7,10 @@ on:
         description: Upload Rocky Linux 9
         type: boolean
         default: true
+      rocky10:
+        description: Upload Rocky Linux 10
+        type: boolean
+        default: true
       ubuntu-noble:
         description: Upload Ubuntu 24.04 Noble
         type: boolean
@@ -50,7 +54,7 @@ jobs:
     steps:
       - name: Validate inputs
         run: |
-          if [[ ${{ inputs.rocky9 }} == 'false' && ${{ inputs.ubuntu-noble }} == 'false' ]]; then
+          if [[ ${{ inputs.rocky9 }} == 'false' && ${{ inputs.rocky10 }} == 'false' && ${{ inputs.ubuntu-noble }} == 'false' ]]; then
             echo "At least one distribution must be selected"
             exit 1
           fi
@@ -140,6 +144,51 @@ jobs:
           OS_APPLICATION_CREDENTIAL_ID: ${{ secrets.OS_APPLICATION_CREDENTIAL_ID }}
           OS_APPLICATION_CREDENTIAL_SECRET: ${{ secrets.OS_APPLICATION_CREDENTIAL_SECRET }}
         if: inputs.rocky9 && steps.rocky_9_image_exists.outcome == 'failure'
+
+      - name: Output Rocky Linux 10 image tag
+        id: rocky_10_image_tag
+        run: |
+          echo image_tag=$(grep stackhpc_rocky_10_overcloud_host_image_version: src/kayobe-config/etc/kayobe/pulp-host-image-versions.yml | awk '{print $2}') >> $GITHUB_OUTPUT
+
+      - name: Check if image exists already
+        id: rocky_10_image_exists
+        run: |
+          source venvs/kayobe/bin/activate &&
+          openstack image show \
+          overcloud-rocky-10-${{ steps.rocky_10_image_tag.outputs.image_tag }}
+        env:
+          OS_CLOUD: openstack
+          OS_APPLICATION_CREDENTIAL_ID: ${{ secrets.OS_APPLICATION_CREDENTIAL_ID }}
+          OS_APPLICATION_CREDENTIAL_SECRET: ${{ secrets.OS_APPLICATION_CREDENTIAL_SECRET }}
+        continue-on-error: true
+
+      - name: Download Rocky Linux 10 overcloud host image from Ark
+        run: |
+          source venvs/kayobe/bin/activate &&
+          source src/kayobe-config/kayobe-env --environment ${{ inputs.kayobe-environment }} &&
+          kayobe playbook run \
+          src/kayobe-config/etc/kayobe/ansible/pulp/pulp-host-image-download.yml \
+          -e os_distribution="rocky" \
+          -e os_release="10"
+        env:
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
+        if: inputs.rocky10 && steps.rocky_10_image_exists.outcome == 'failure'
+
+      - name: Upload Rocky Linux 10 overcloud host image to Cloud
+        run: |
+          source venvs/kayobe/bin/activate &&
+          openstack image create \
+          overcloud-rocky-10-${{ steps.rocky_10_image_tag.outputs.image_tag }} \
+          --container-format bare \
+          --disk-format qcow2 \
+          --file /tmp/rocky-10.qcow2 \
+          --private \
+          --progress
+        env:
+          OS_CLOUD: openstack
+          OS_APPLICATION_CREDENTIAL_ID: ${{ secrets.OS_APPLICATION_CREDENTIAL_ID }}
+          OS_APPLICATION_CREDENTIAL_SECRET: ${{ secrets.OS_APPLICATION_CREDENTIAL_SECRET }}
+        if: inputs.rocky10 && steps.rocky_10_image_exists.outcome == 'failure'
 
       - name: Output Ubuntu Noble image tag
         id: ubuntu_noble_image_tag

--- a/.github/workflows/update-overcloud-host-image-tags.yml
+++ b/.github/workflows/update-overcloud-host-image-tags.yml
@@ -7,6 +7,9 @@ on:
       rocky9_tag:
         description: Overcloud host image tag for Rocky 9
         type: string
+      rocky10_tag:
+        description: Overcloud host image tag for Rocky 10
+        type: string
       ubuntu_noble_tag:
         description: Overcloud host image tag for Ubuntu
         type: string
@@ -31,6 +34,11 @@ jobs:
           sed -i "/stackhpc_rocky_9_overcloud_host_image_version/s/.*/stackhpc_rocky_9_overcloud_host_image_version: ${{ inputs.rocky9_tag }}/" ${{ github.workspace }}/src/kayobe-config/etc/kayobe/pulp-host-image-versions.yml
         if: "${{ inputs.rocky9_tag != '' }}"
 
+      - name: Update Rocky 10 overcloud host image tag
+        run: |
+          sed -i "/stackhpc_rocky_10_overcloud_host_image_version/s/.*/stackhpc_rocky_10_overcloud_host_image_version: ${{ inputs.rocky10_tag }}/" ${{ github.workspace }}/src/kayobe-config/etc/kayobe/pulp-host-image-versions.yml
+        if: "${{ inputs.rocky10_tag != '' }}"
+
       - name: Update Ubuntu Noble overcloud host image tag
         run: |
           sed -i "/stackhpc_ubuntu_noble_overcloud_host_image_version/s/.*/stackhpc_ubuntu_noble_overcloud_host_image_version: ${{ inputs.ubuntu_noble_tag }}/" ${{ github.workspace }}/src/kayobe-config/etc/kayobe/pulp-host-image-versions.yml
@@ -43,7 +51,7 @@ jobs:
           commit-message: >-
             Bump overcloud host image tags
           author: stackhpc-ci <22933334+stackhpc-ci@users.noreply.github.com>
-          branch: bump-overcloud-host-images-${{ inputs.rocky9_tag }}-${{ inputs.ubuntu_noble_tag }}
+          branch: bump-overcloud-host-images-${{ inputs.rocky9_tag }}-${{ inputs.rocky10_tag }}-${{ inputs.ubuntu_noble_tag }}
           delete-branch: true
           title: >-
             Bump overcloud host image tags 
@@ -51,6 +59,7 @@ jobs:
             This PR was created automatically to update the overcloud host image
             tags.
             Rocky 9: ${{ inputs.rocky9_tag }}
+            Rocky 10: ${{ inputs.rocky10_tag }}
             Ubuntu Noble: ${{ inputs.ubuntu_noble_tag }}
           labels: |
             automated

--- a/etc/kayobe/environments/ci-builder/stackhpc-ci.yml
+++ b/etc/kayobe/environments/ci-builder/stackhpc-ci.yml
@@ -80,6 +80,9 @@ stackhpc_repo_rocky_9_highavailability_version: "{{ stackhpc_pulp_repo_rocky_9_h
 stackhpc_repo_rocky_9_sig_security_common_version: "{{ stackhpc_pulp_repo_multiarch_rocky_9_sig_security_common_version }}"
 stackhpc_repo_rhel9_doca_version: "{{ stackhpc_pulp_repo_rhel9_doca_version }}"
 
+stackhpc_repo_rocky_10_baseos_version: "{{ stackhpc_pulp_repo_rocky_10_baseos_version }}"
+stackhpc_repo_rocky_10_appstream_version: "{{ stackhpc_pulp_repo_rocky_10_appstream_version }}"
+
 # Rocky-and-CI-specific Pulp urls
 stackhpc_include_os_minor_version_in_repo_url: true
 

--- a/etc/kayobe/pulp-host-image-versions.yml
+++ b/etc/kayobe/pulp-host-image-versions.yml
@@ -2,4 +2,5 @@
 # Overcloud host image versioning tags
 # These images must be in SMS, since they are used by our AIO CI runners
 stackhpc_rocky_9_overcloud_host_image_version: 2025.1-20260306T094256
+stackhpc_rocky_10_overcloud_host_image_version: 2025.1-20260318T110608
 stackhpc_ubuntu_noble_overcloud_host_image_version: 2025.1-20260206T132408

--- a/etc/kayobe/stackhpc-overcloud-dib.yml
+++ b/etc/kayobe/stackhpc-overcloud-dib.yml
@@ -39,7 +39,11 @@ stackhpc_overcloud_dib_env_vars: "{{ stackhpc_overcloud_dib_env_vars_default | c
 
 # By default the :9 tag is used as base image. Here we want a specific minor version.
 stackhpc_overcloud_dib_container_opts_default: >-
-    --build-arg=ROCKY_VERSION=9.{{ stackhpc_pulp_repo_rocky_9_minor_version }}
+    {% if os_distribution == 'rocky' and os_release == '9' %}
+      --build-arg=ROCKY_VERSION=9.{{ stackhpc_pulp_repo_rocky_9_minor_version }}
+    {% elif os_distribution == 'rocky' and os_release == '10' %}
+      --build-arg=ROCKY_VERSION=10.{{ stackhpc_pulp_repo_rocky_10_minor_version }}
+    {% endif %}
 
 stackhpc_overcloud_dib_env_vars_default:
   DIB_BLOCK_DEVICE_CONFIG: "{{ stackhpc_overcloud_dib_block_device_config_uefi_lvm }}"
@@ -51,7 +55,7 @@ stackhpc_overcloud_dib_env_vars_default:
     {{ stackhpc_overcloud_dib_container_opts_default }}
   DIB_CONTAINERFILE_RUNTIME: "docker"
   DIB_CONTAINERFILE_NETWORK_DRIVER: "host"
-  DIB_CONTAINERFILE_DOCKERFILE: "/opt/kayobe/src/stackhpc-image-elements/elements/rocky-container-stackhpc/containerfiles/9-stackhpc"
+  DIB_CONTAINERFILE_DOCKERFILE: "/opt/kayobe/src/stackhpc-image-elements/elements/rocky-container-stackhpc/containerfiles/{{ os_release }}-stackhpc"
   DIB_DRACUT_ENABLED_MODULES_DEFAULT_CONFIG: "{{ stackhpc_overcloud_dib_dracut_enabled_modules_default_config }}"
   DIB_RELEASE: "{{ overcloud_dib_os_release }}"
   DIB_SUDOERS_FILENAME: "no-fqdn"
@@ -67,7 +71,11 @@ stackhpc_overcloud_dib_env_vars_default:
 stackhpc_overcloud_dib_env_vars_ark:
   DIB_CONTAINERFILE_BUILDOPTS: >-
     --build-arg=ROCKY_USE_CUSTOM_DNF_MIRRORS=true
-    --build-arg=ROCKY_CUSTOM_DNF_MIRROR_URLS={{ [stackhpc_repo_rocky_9_baseos_url, stackhpc_repo_rocky_9_appstream_url] | join(',') }}
+    {% if os_distribution == 'rocky' and os_release == '9' %}
+      --build-arg=ROCKY_CUSTOM_DNF_MIRROR_URLS={{ [stackhpc_repo_rocky_9_baseos_url, stackhpc_repo_rocky_9_appstream_url] | join(',') }}
+    {% elif os_distribution == 'rocky' and os_release == '10' %}
+      --build-arg=ROCKY_CUSTOM_DNF_MIRROR_URLS={{ [stackhpc_repo_rocky_10_baseos_url, stackhpc_repo_rocky_10_appstream_url] | join(',') }}
+    {% endif %}
     {{ stackhpc_overcloud_dib_container_opts_default }}
   DIB_DISTRIBUTION_MIRROR: "{{ stackhpc_repo_ubuntu_noble_url if os_distribution == 'ubuntu' else '' }}"
   # Ensure upstream repofiles are re-enabled after image build, otherwise `yum.repos.d` is left empty

--- a/etc/kayobe/stackhpc-overcloud-host-images.yml
+++ b/etc/kayobe/stackhpc-overcloud-host-images.yml
@@ -18,4 +18,5 @@ stackhpc_overcloud_host_image_url: "{{ stackhpc_release_pulp_content_url_with_au
 # Overcloud host image version tag selection
 stackhpc_overcloud_host_image_version: >-
   {{ stackhpc_rocky_9_overcloud_host_image_version if os_distribution == 'rocky' and os_release == '9' else
+  stackhpc_rocky_10_overcloud_host_image_version if os_distribution == 'rocky' and os_release == '10' else
   stackhpc_ubuntu_noble_overcloud_host_image_version if os_distribution == 'ubuntu' and os_release == 'noble' }}

--- a/etc/kayobe/stackhpc.yml
+++ b/etc/kayobe/stackhpc.yml
@@ -262,5 +262,5 @@ stackhpc_ca_secret_store: openbao
 stackhpc_dib_image_elements_repos:
   - repo: "https://github.com/stackhpc/stackhpc-image-elements"
     local: "{{ source_checkout_path }}/stackhpc-image-elements"
-    version: "v1.6.5"
+    version: "v1.6.6"
     elements_path: "elements"

--- a/releasenotes/notes/rocky-10-host-image-047aa557db60fa50.yaml
+++ b/releasenotes/notes/rocky-10-host-image-047aa557db60fa50.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Host images for Rocky Linux 10 can now be built in the 2025.1 release
+upgrade:
+  - |
+    Updates stackhpc-image-elements to v1.6.6


### PR DESCRIPTION
- updates workflow for building host images, as well as workflows to update host image tags and upload/promote the host image, to include RL10
- adds RL10 BaseOS and AppStream repos into ci-builder environment
- updates overcloud dib build args and dnf mirror urls for RL10 builds