### PR TITLE
Initialise workflow to build Rocky 10 packages

### DIFF
--- a/.github/workflows/build-rocky-packages.yml
+++ b/.github/workflows/build-rocky-packages.yml
@@ -1,0 +1,17 @@
+---
+# This workflow builds required versions of OVN and OVS for
+# Rocky Linux 10 then pushes them to a registry.
+
+# This will only be needed until we move to newer OVN/OVS
+# packages, which already exist in the NFV SIG repository for
+# CentOS Stream 10.
+
+name: Build Rocky 10 OVN/OVS Packages
+on: workflow_dispatch
+
+jobs:
+  run-away:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Print message and run away
+        run: echo "This workflow is not operational yet"


### PR DESCRIPTION
Currently working on a workflow to build the LTS versions of OVN/OVS for Rocky 10 in rl10/build-lts-packages branch - a skeleton version of the workflow needs to exist in the base branch to be able to test this via workflow dispatch.