### PR TITLE
Bump Octavia Amphora image

### DIFF
--- a/etc/kayobe/stackhpc.yml
+++ b/etc/kayobe/stackhpc.yml
@@ -247,7 +247,7 @@ stackhpc_enable_kolla_ansible_check: true
 download_amphora_from_ark: true
 
 # Octavia Amphora image version
-stackhpc_amphora_image_version: "2025.1-20250619T113933"
+stackhpc_amphora_image_version: "2025.1-20260319T131237"
 
 ################################################################################
 # Certificate Authority

--- a/releasenotes/notes/bump-amphora-image-noble-ea7a163beff43242.yaml
+++ b/releasenotes/notes/bump-amphora-image-noble-ea7a163beff43242.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    The Octavia Amphora image was rebuilt and now uses Ubuntu 24.04 LTS instead
+    of Ubuntu 22.04 LTS.


### PR DESCRIPTION
The Amphora image is now built using Ubuntu 24.04 LTS.