### PR TITLE
CI: Fix container image build workflow (Antelope)

### DIFF
--- a/.github/workflows/stackhpc-container-image-build.yml
+++ b/.github/workflows/stackhpc-container-image-build.yml
@@ -163,8 +163,13 @@ jobs:
       # Normally installed during host configure.
       - name: Install Docker Python SDK
         run: |
-          sudo pip install docker 'requests<2.32.0'
-      
+          . /etc/os-release
+          if [[ $VERSION_ID == 22.04 ]]; then
+              sudo pip install docker 'requests<2.32.0'
+          else
+              sudo pip install docker 'requests<2.32.0' --break-system-packages
+          fi
+
       - name: Get Kolla tag
         id: write-kolla-tag
         run: echo "kolla-tag=${{ needs.generate-tag.outputs.openstack_release }}-${{ matrix.distro }}-${{ matrix.distro == 'rocky' && '9' || 'jammy' }}-${{ needs.generate-tag.outputs.datetime_tag }}"  >> $GITHUB_OUTPUT


### PR DESCRIPTION
Ubuntu Noble runners now need the `--break-system-packages` option to install system-wide Python packages. However this option is absent from pip on our Ubuntu Jammy arm64 runners.

Detect the distribution version and run the appropriate command.

(cherry picked from commit 82075675fe59fbeafd959f2dd80cc2b892e8aa02)