### PR TITLE
CI: Fix container image build workflow (Zed)

### DIFF
--- a/.github/workflows/stackhpc-container-image-build.yml
+++ b/.github/workflows/stackhpc-container-image-build.yml
@@ -148,7 +148,12 @@ jobs:
       # Normally installed during host configure.
       - name: Install Docker Python SDK
         run: |
-          sudo pip install docker
+          . /etc/os-release
+          if [[ $VERSION_ID == 22.04 ]]; then
+              sudo pip install docker
+          else
+              sudo pip install docker --break-system-packages
+          fi
 
       - name: Get Kolla tag
         id: write-kolla-tag


### PR DESCRIPTION
Ubuntu Noble runners now need the `--break-system-packages` option to install system-wide Python packages. However this option is absent from pip on our Ubuntu Jammy arm64 runners.

Detect the distribution version and run the appropriate command.

(cherry picked from commit 82075675fe59fbeafd959f2dd80cc2b892e8aa02)