### PR TITLE
Pin GitHub Actions to commits instead of tags

### DIFF
--- a/.github/workflows/amphora-image-build.yml
+++ b/.github/workflows/amphora-image-build.yml
@@ -80,7 +80,7 @@ jobs:
           pip install -r ../src/kayobe-config/requirements.txt
 
       - name: Install terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
 
       - name: Initialise terraform
         run: terraform init

--- a/.github/workflows/amphora-image-build.yml
+++ b/.github/workflows/amphora-image-build.yml
@@ -49,7 +49,7 @@ jobs:
           sudo /etc/init.d/ssh start
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: src/kayobe-config
 

--- a/.github/workflows/amphora-image-build.yml
+++ b/.github/workflows/amphora-image-build.yml
@@ -39,10 +39,10 @@ jobs:
     permissions: {}
     steps:
 
-      - name: Install Package
-        uses: ConorMacBride/install-package@main
-        with:
-          apt: git unzip nodejs python3-pip python3-venv openssh-server openssh-client jq
+      - name: Install Package dependencies
+        run: |
+          sudo apt update &&
+          sudo apt install -y git unzip nodejs python3-pip python3-venv openssh-server openssh-client jq
 
       - name: Start the SSH service
         run: |

--- a/.github/workflows/amphora-image-build.yml
+++ b/.github/workflows/amphora-image-build.yml
@@ -255,7 +255,7 @@ jobs:
         if: steps.build_amphora.outcome == 'failure'
 
       - name: Upload logs & image artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: amphora-image-build-log
           path: ./artifact

--- a/.github/workflows/amphora-image-promote.yml
+++ b/.github/workflows/amphora-image-promote.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.repository == 'stackhpc/stackhpc-kayobe-config'
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: src/kayobe-config
 

--- a/.github/workflows/ipa-image-build.yml
+++ b/.github/workflows/ipa-image-build.yml
@@ -329,7 +329,7 @@ jobs:
         if: always()
 
       - name: Upload logs artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: Build logs
           path: ./logs

--- a/.github/workflows/ipa-image-build.yml
+++ b/.github/workflows/ipa-image-build.yml
@@ -86,7 +86,7 @@ jobs:
           pip install -r ../src/kayobe-config/requirements.txt
 
       - name: Install terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
 
       - name: Initialise terraform
         run: terraform init

--- a/.github/workflows/ipa-image-build.yml
+++ b/.github/workflows/ipa-image-build.yml
@@ -47,10 +47,10 @@ jobs:
       - runner-selection
     permissions: {}
     steps:
-      - name: Install Package
-        uses: ConorMacBride/install-package@main
-        with:
-          apt: git unzip nodejs python3-pip python3-venv openssh-server openssh-client jq
+      - name: Install Package dependencies
+        run: |
+          sudo apt update &&
+          sudo apt install -y git unzip nodejs python3-pip python3-venv openssh-server openssh-client jq
 
       - name: Start the SSH service
         run: |

--- a/.github/workflows/ipa-image-build.yml
+++ b/.github/workflows/ipa-image-build.yml
@@ -57,7 +57,7 @@ jobs:
           sudo /etc/init.d/ssh start
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: src/kayobe-config
 

--- a/.github/workflows/ipa-image-promote.yml
+++ b/.github/workflows/ipa-image-promote.yml
@@ -30,7 +30,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: src/kayobe-config
 

--- a/.github/workflows/overcloud-host-image-build.yml
+++ b/.github/workflows/overcloud-host-image-build.yml
@@ -502,7 +502,7 @@ jobs:
         if: inputs.create_skc_pr
 
       - name: Send message to Slack via Workflow Builder
-        uses: slackapi/slack-github-action@v1.26.0
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
           payload: |
             {

--- a/.github/workflows/overcloud-host-image-build.yml
+++ b/.github/workflows/overcloud-host-image-build.yml
@@ -504,6 +504,7 @@ jobs:
       - name: Send message to Slack via Workflow Builder
         uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
+          webhook-type: "incoming-webhook"
           payload: |
             {
               "channel-id": "${{ env.SLACK_CHANNEL_ID }}",

--- a/.github/workflows/overcloud-host-image-build.yml
+++ b/.github/workflows/overcloud-host-image-build.yml
@@ -467,7 +467,7 @@ jobs:
             steps.build_ubuntu_noble.outcome == 'failure'
 
       - name: Upload logs artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: Build logs
           path: ./logs

--- a/.github/workflows/overcloud-host-image-build.yml
+++ b/.github/workflows/overcloud-host-image-build.yml
@@ -58,7 +58,7 @@ jobs:
       host_image_tag: ${{ steps.host_image_tag.outputs.host_image_tag }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: src/kayobe-config
 
@@ -97,7 +97,7 @@ jobs:
           echo "${{ needs.create-tag.outputs.host_image_tag }}"
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: src/kayobe-config
 

--- a/.github/workflows/overcloud-host-image-build.yml
+++ b/.github/workflows/overcloud-host-image-build.yml
@@ -101,10 +101,10 @@ jobs:
         with:
           path: src/kayobe-config
 
-      - name: Install Package
-        uses: ConorMacBride/install-package@main
-        with:
-          apt: git unzip nodejs python3-pip python3-venv openssh-server openssh-client jq gh
+      - name: Install Package dependencies
+        run: |
+          sudo apt update &&
+          sudo apt install -y git unzip nodejs python3-pip python3-venv openssh-server openssh-client jq gh
 
       - name: Start the SSH service
         run: |

--- a/.github/workflows/overcloud-host-image-build.yml
+++ b/.github/workflows/overcloud-host-image-build.yml
@@ -120,7 +120,7 @@ jobs:
           pip install -r ../src/kayobe-config/requirements.txt
 
       - name: Install terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
 
       - name: Initialise terraform
         run: terraform init

--- a/.github/workflows/overcloud-host-image-promote.yml
+++ b/.github/workflows/overcloud-host-image-promote.yml
@@ -30,7 +30,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: src/kayobe-config
 

--- a/.github/workflows/overcloud-host-image-upload.yml
+++ b/.github/workflows/overcloud-host-image-upload.yml
@@ -64,7 +64,7 @@ jobs:
           sudo apt update
           sudo apt install -y build-essential git unzip nodejs python3-wheel python3-pip python3-venv
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: src/kayobe-config
 

--- a/.github/workflows/package-build-ofed.yml
+++ b/.github/workflows/package-build-ofed.yml
@@ -43,7 +43,7 @@ jobs:
           sudo /etc/init.d/ssh start
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: src/kayobe-config
 

--- a/.github/workflows/package-build-ofed.yml
+++ b/.github/workflows/package-build-ofed.yml
@@ -57,7 +57,7 @@ jobs:
           pip install -r ../src/kayobe-config/requirements.txt
 
       - name: Install terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
 
       - name: Initialise terraform
         run: terraform init

--- a/.github/workflows/package-build-ofed.yml
+++ b/.github/workflows/package-build-ofed.yml
@@ -33,10 +33,10 @@ jobs:
         run: |
           echo "ofed_tag=$(date +%Y%m%dT%H%M%S)" >> $GITHUB_OUTPUT
 
-      - name: Install Package
-        uses: ConorMacBride/install-package@main
-        with:
-          apt: git unzip nodejs python3-pip python3-venv openssh-server openssh-client jq
+      - name: Install Package dependencies
+        run: |
+          sudo apt update &&
+          sudo apt install -y git unzip nodejs python3-pip python3-venv openssh-server openssh-client jq
 
       - name: Start the SSH service
         run: |

--- a/.github/workflows/stackhpc-all-in-one.yml
+++ b/.github/workflows/stackhpc-all-in-one.yml
@@ -103,7 +103,7 @@ jobs:
 
       # If testing upgrade, checkout previous release, otherwise checkout current branch
       - name: Checkout ${{ inputs.upgrade && 'previous release' || 'current' }} config
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.upgrade && env.PREVIOUS_BRANCH || inputs.github_ref }}
@@ -396,7 +396,7 @@ jobs:
         if: inputs.upgrade
 
       - name: Checkout current release config
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.github_ref }}

--- a/.github/workflows/stackhpc-all-in-one.yml
+++ b/.github/workflows/stackhpc-all-in-one.yml
@@ -96,10 +96,10 @@ jobs:
       # NOTE(upgrade): Reference the PREVIOUS release branch here.
       PREVIOUS_BRANCH: stackhpc/2024.1
     steps:
-      - name: Install Package
-        uses: ConorMacBride/install-package@main
-        with:
-          apt: git unzip nodejs openssh-client
+      - name: Install Package dependencies
+        run: |
+          sudo apt update &&
+          sudo apt install -y git unzip nodejs openssh-client
 
       # If testing upgrade, checkout previous release, otherwise checkout current branch
       - name: Checkout ${{ inputs.upgrade && 'previous release' || 'current' }} config

--- a/.github/workflows/stackhpc-all-in-one.yml
+++ b/.github/workflows/stackhpc-all-in-one.yml
@@ -139,7 +139,7 @@ jobs:
           fi
 
       - name: Install terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
 
       - name: Initialise terraform
         run: terraform init

--- a/.github/workflows/stackhpc-all-in-one.yml
+++ b/.github/workflows/stackhpc-all-in-one.yml
@@ -490,7 +490,7 @@ jobs:
         if: ${{ !cancelled() && steps.tf_apply.outcome == 'success' }}
 
       - name: Upload test result artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: test-results-${{ inputs.os_distribution }}-${{ inputs.os_release }}-${{ inputs.neutron_plugin }}${{ inputs.upgrade && '-upgrade' || '' }}
           path: |

--- a/.github/workflows/stackhpc-build-kayobe-image.yml
+++ b/.github/workflows/stackhpc-build-kayobe-image.yml
@@ -51,7 +51,7 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout kayobe config
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
 

--- a/.github/workflows/stackhpc-build-kayobe-image.yml
+++ b/.github/workflows/stackhpc-build-kayobe-image.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 

--- a/.github/workflows/stackhpc-build-kayobe-image.yml
+++ b/.github/workflows/stackhpc-build-kayobe-image.yml
@@ -69,7 +69,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
         with:
           driver-opts: |
             image=moby/buildkit:master

--- a/.github/workflows/stackhpc-build-kayobe-image.yml
+++ b/.github/workflows/stackhpc-build-kayobe-image.yml
@@ -101,7 +101,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Send message to Slack via Workflow Builder
-        uses: slackapi/slack-github-action@v1.26.0
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
           payload: |
             {

--- a/.github/workflows/stackhpc-build-kayobe-image.yml
+++ b/.github/workflows/stackhpc-build-kayobe-image.yml
@@ -103,6 +103,7 @@ jobs:
       - name: Send message to Slack via Workflow Builder
         uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
+          webhook-type: "incoming-webhook"
           payload: |
             {
               "channel-id": "${{ env.SLACK_CHANNEL_ID }}",

--- a/.github/workflows/stackhpc-build-kayobe-image.yml
+++ b/.github/workflows/stackhpc-build-kayobe-image.yml
@@ -85,7 +85,7 @@ jobs:
       # Setting KAYOBE_USER_UID and KAYOBE_USER_GID to 1001 to match docker's defaults
       # so that docker can run as a privileged user within the Kayobe image.
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           file: ./.automation/docker/kayobe/Dockerfile
           context: .

--- a/.github/workflows/stackhpc-build-kayobe-image.yml
+++ b/.github/workflows/stackhpc-build-kayobe-image.yml
@@ -56,7 +56,7 @@ jobs:
           submodules: true
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/stackhpc-check-tags.yml
+++ b/.github/workflows/stackhpc-check-tags.yml
@@ -37,7 +37,7 @@ jobs:
           sudo apt install -y git unzip nodejs
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
 

--- a/.github/workflows/stackhpc-ci-cleanup.yml
+++ b/.github/workflows/stackhpc-ci-cleanup.yml
@@ -22,7 +22,7 @@ jobs:
           path: src/kayobe-config
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
 
       - name: Generate clouds.yaml
         run: |

--- a/.github/workflows/stackhpc-ci-cleanup.yml
+++ b/.github/workflows/stackhpc-ci-cleanup.yml
@@ -121,7 +121,7 @@ jobs:
           OS_APPLICATION_CREDENTIAL_SECRET: ${{ secrets.OS_APPLICATION_CREDENTIAL_SECRET }}
 
       - name: Send message to Slack via Workflow Builder
-        uses: slackapi/slack-github-action@v1.26.0
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
           payload: |
             {

--- a/.github/workflows/stackhpc-ci-cleanup.yml
+++ b/.github/workflows/stackhpc-ci-cleanup.yml
@@ -17,7 +17,7 @@ jobs:
     environment: ${{ matrix.environment }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: src/kayobe-config
 

--- a/.github/workflows/stackhpc-ci-cleanup.yml
+++ b/.github/workflows/stackhpc-ci-cleanup.yml
@@ -123,6 +123,7 @@ jobs:
       - name: Send message to Slack via Workflow Builder
         uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
+          webhook-type: "incoming-webhook"
           payload: |
             {
               "channel-id": "${{ env.SLACK_CHANNEL_ID }}",

--- a/.github/workflows/stackhpc-container-image-build.yml
+++ b/.github/workflows/stackhpc-container-image-build.yml
@@ -354,7 +354,7 @@ jobs:
       - runner-selection
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
 
       - name: Combine pushed images lists
         run: |

--- a/.github/workflows/stackhpc-container-image-build.yml
+++ b/.github/workflows/stackhpc-container-image-build.yml
@@ -310,7 +310,7 @@ jobs:
         if: inputs.push
 
       - name: Upload output artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: ${{ matrix.distro.name }}-${{ matrix.distro.release }}-${{ matrix.distro.arch }}-logs
           path: image-build-logs
@@ -376,7 +376,7 @@ jobs:
         run: src/kayobe-config/tools/multiarch-manifests.sh
 
       - name: Upload manifest logs
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: manifest-logs
           path: |

--- a/.github/workflows/stackhpc-container-image-build.yml
+++ b/.github/workflows/stackhpc-container-image-build.yml
@@ -76,7 +76,7 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Determine OpenStack release
         id: openstack_release
@@ -145,7 +145,7 @@ jobs:
           sudo apt install -y build-essential git unzip nodejs python3-wheel python3-pip python3-venv curl jq wget
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: src/kayobe-config
 
@@ -368,7 +368,7 @@ jobs:
           password: ${{ secrets.RLS_TRAIN_CI_ARK_REGISTRY_PASS }}
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: src/kayobe-config
 

--- a/.github/workflows/stackhpc-container-image-build.yml
+++ b/.github/workflows/stackhpc-container-image-build.yml
@@ -361,7 +361,7 @@ jobs:
           find . -name 'push-attempt-images.txt' -exec cat {} + > all-pushed-images.txt
 
       - name: Log in to container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ark.stackhpc.com
           username: ${{ secrets.RLS_TRAIN_CI_ARK_REGISTRY_USER }}

--- a/.github/workflows/stackhpc-multinode-periodic.yml
+++ b/.github/workflows/stackhpc-multinode-periodic.yml
@@ -23,7 +23,7 @@ jobs:
       terraform_kayobe_multinode_previous_version: ${{ steps.generate-inputs.outputs.terraform_kayobe_multinode_previous_version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Generate inputs for multinode workflow
         id: generate-inputs

--- a/.github/workflows/stackhpc-promote.yml
+++ b/.github/workflows/stackhpc-promote.yml
@@ -62,6 +62,7 @@ jobs:
       - name: Send message to Slack via Workflow Builder
         uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
+          webhook-type: "incoming-webhook"
           payload: |
             {
               "channel-id": "${{ env.SLACK_CHANNEL_ID }}",

--- a/.github/workflows/stackhpc-promote.yml
+++ b/.github/workflows/stackhpc-promote.yml
@@ -60,7 +60,7 @@ jobs:
           echo "::notice Overcloud host image promote workflow: https://github.com/stackhpc/stackhpc-kayobe-config/actions/workflows/overcloud-host-image-promote.yml"
 
       - name: Send message to Slack via Workflow Builder
-        uses: slackapi/slack-github-action@v1.26.0
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
           payload: |
             {

--- a/.github/workflows/stackhpc-pull-request.yml
+++ b/.github/workflows/stackhpc-pull-request.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Check changed files
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: changes
         with:
           # Filters are defined in this file.

--- a/.github/workflows/stackhpc-pull-request.yml
+++ b/.github/workflows/stackhpc-pull-request.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup Python ${{ matrix.python-version }} 🐍
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Tox 📦
@@ -83,7 +83,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Python ${{ matrix.python-version }} 🐍
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python }}
 

--- a/.github/workflows/stackhpc-pull-request.yml
+++ b/.github/workflows/stackhpc-pull-request.yml
@@ -27,7 +27,7 @@ jobs:
       check-tags: ${{ steps.changes.outputs.check-tags }}
     steps:
       - name: GitHub Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Check changed files
         uses: dorny/paths-filter@v3
@@ -52,7 +52,7 @@ jobs:
     if: github.repository == 'stackhpc/stackhpc-kayobe-config'
     steps:
       - name: GitHub Checkout 🛎
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Setup Python ${{ matrix.python-version }} 🐍
@@ -80,7 +80,7 @@ jobs:
     if: github.repository == 'stackhpc/stackhpc-kayobe-config'
     steps:
       - name: GitHub Checkout 🛎
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Python ${{ matrix.python-version }} 🐍
         uses: actions/setup-python@v6

--- a/.github/workflows/trigger-overcloud-host-image-build.yml
+++ b/.github/workflows/trigger-overcloud-host-image-build.yml
@@ -14,7 +14,7 @@ jobs:
       pulp-repo-versions: ${{ steps.changes.outputs.pulp-repo-versions }}
     steps:
       - name: GitHub Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Check changed files
         uses: dorny/paths-filter@v3

--- a/.github/workflows/trigger-overcloud-host-image-build.yml
+++ b/.github/workflows/trigger-overcloud-host-image-build.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Check changed files
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: changes
         with:
           filters: .github/overcloud-host-image-build-path-filters.yml

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -36,7 +36,7 @@ jobs:
       kayobe-tag: ${{ steps.latest_kayobe_tag.outputs.latest_tag || steps.current_kayobe_version.outputs.version }}
     steps:
       - name: Checkout Kayobe-config
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.branch }}
           path: src/kayobe-config
@@ -61,7 +61,7 @@ jobs:
           echo "### Changes" >> pr_body.md
 
       - name: Checkout Kolla repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: stackhpc/kolla
           ref: ${{ inputs.branch }}
@@ -92,7 +92,7 @@ jobs:
         working-directory: src/kayobe-config
 
       - name: Checkout Kolla Ansible repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: stackhpc/kolla-ansible
           ref: ${{ inputs.branch }}
@@ -123,7 +123,7 @@ jobs:
         working-directory: src/kayobe-config
 
       - name: Checkout Kayobe repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: stackhpc/kayobe
           ref: ${{ inputs.branch }}

--- a/.github/workflows/update-overcloud-host-image-tags.yml
+++ b/.github/workflows/update-overcloud-host-image-tags.yml
@@ -24,7 +24,7 @@ jobs:
     name: Update overcloud host image tags
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: stackhpc/2025.1
           path: ${{ github.workspace }}/src/kayobe-config

--- a/.github/workflows/update-overcloud-host-image-tags.yml
+++ b/.github/workflows/update-overcloud-host-image-tags.yml
@@ -45,7 +45,7 @@ jobs:
         if: "${{ inputs.ubuntu_noble_tag != '' }}"
 
       - name: Propose changes via PR if required
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
           path: ${{ github.workspace }}/src/kayobe-config
           commit-message: >-


### PR DESCRIPTION
Updates all actions that were previously pinned to a tag, to be pinned to the latest commit hash

This is to mitigate the risk of supply chain attacks that target upstream GitHub actions, and avoid [node 20 deprecation](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) warnings at the same time.