### PR TITLE
Re-enable database TLS

### DIFF
--- a/doc/source/operations/upgrading-openstack.rst
+++ b/doc/source/operations/upgrading-openstack.rst
@@ -54,6 +54,34 @@ Errors like this will be logged::
 A proper fix is still WIP, in the meantime these errors can be resolved with this script:
 `<https://gist.github.com/MoteHue/00ba4b85b8e708c46060e025deee8a78>`__
 
+ProxySQL
+--------
+
+During OpenStack service upgrade from 2025.1 to 2026.1, database TLS with ProxySQL will be enabled.
+To make sure all certificate files that are required by ProxySQL are prepared, run the latest
+version of the playbook ``secret-store-generate-internal-tls.yml`` before running
+``kayobe overcloud service upgrade``.
+
+1. Ensure ``kolla_enable_proxysql`` is set to ``true`` in ``kolla.yml``.
+
+2. Run the playbook to generate ProxySQL certificates.
+
+   .. code-block:: console
+
+      kayobe playbook run $KAYOBE_CONFIG_PATH/ansible/secret-store/secret-store-generate-internal-tls.yml
+
+After running the playbook, check if the following files are generated.
+
+* ``$KAYOBE_CONFIG_PATH/kolla/certificates/proxysql-cert.pem``
+* ``$KAYOBE_CONFIG_PATH/kolla/certificates/proxysql-key.pem``
+* ``$KAYOBE_CONFIG_PATH/kolla/certificates/proxysql-ca.pem``
+
+If Kayobe environment is used, check these paths.
+
+* ``$KAYOBE_CONFIG_PATH/environments/$KAYOBE_ENVIRONMENT/kolla/certificates/proxysql-cert.pem``
+* ``$KAYOBE_CONFIG_PATH/environments/$KAYOBE_ENVIRONMENT/kolla/certificates/proxysql-key.pem``
+* ``$KAYOBE_CONFIG_PATH/environments/$KAYOBE_ENVIRONMENT/kolla/certificates/proxysql-ca.pem``
+
 Security baseline
 =================
 

--- a/etc/kayobe/ansible/secret-store/secret-store-generate-internal-tls.yml
+++ b/etc/kayobe/ansible/secret-store/secret-store-generate-internal-tls.yml
@@ -54,3 +54,37 @@
         dest: "{{ kayobe_env_config_path }}/kolla/certificates/ca/{{ stackhpc_ca_secret_store }}.crt"
         mode: "0600"
       delegate_to: localhost
+
+# NOTE(seunghun1ee): Kolla Ansible reuses internal TLS certificate when
+# creating certificate for proxysql
+# https://opendev.org/openstack/kolla-ansible/src/branch/stable/2026.1/ansible/roles/certificates/tasks/generate.yml#L169-L183
+    - name: Generate ProxySQL certificates
+      when: kolla_enable_proxysql | bool
+      block:
+        - name: Copy ProxySQL certificate
+          no_log: true
+          ansible.builtin.copy:
+            dest: "{{ kayobe_env_config_path }}/kolla/certificates/proxysql-cert.pem"
+            content: |
+              {{ internal_cert.data.certificate }}
+              {{ internal_cert.data.issuing_ca }}
+            mode: "0600"
+          delegate_to: localhost
+
+        - name: Copy ProxySQL certificate key
+          no_log: true
+          ansible.builtin.copy:
+            dest: "{{ kayobe_env_config_path }}/kolla/certificates/proxysql-key.pem"
+            content: |
+              {{ internal_cert.data.private_key }}
+            mode: "0600"
+          delegate_to: localhost
+
+# NOTE(seunghun1ee): When ProxySQL is used with database internal TLS, it expects the intermediate
+# certificate that signed the proxysql-cert.pem as a CA.
+        - name: Copy CA for ProxySQL
+          ansible.builtin.copy:
+            src: "{{ kayobe_env_config_path }}/{{ stackhpc_ca_secret_store }}/OS-TLS-INT.pem"
+            dest: "{{ kayobe_env_config_path }}/kolla/certificates/proxysql-ca.pem"
+            mode: "0600"
+          delegate_to: localhost

--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -67,8 +67,3 @@ prometheus_blackbox_exporter_endpoints_kayobe:
     enabled: "{{ seed_pulp_container_enabled | bool }}"
 
 prometheus_openstack_exporter_interval: "{{ stackhpc_prometheus_openstack_exporter_interval }}s"
-
-# NOTE(seunghun1ee) Disable database TLS until ProxySQL 2.7 gets bug fix for
-# https://github.com/sysown/proxysql/issues/4877 or K-A bumps ProxySQL to 3.x.
-database_enable_tls_internal: false
-database_enable_tls_backend: false


### PR DESCRIPTION
Upstream Kolla-Ansible 2026.1 brought ProxySQL 3.0.x.
It has a fix for the bug https://github.com/sysown/proxysql/issues/4877 which prevented using TLS between database and ProxySQL.
Re-enable Database TLS and add tasks for creating certificates for ProxySQL.

Note: Two variables ``database_enable_tls_internal`` and ``database_enable_tls_backend`` have default value ``true`` but these are still explicitly set to ``true`` to ensure existing systems can also get effect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic generation of ProxySQL internal TLS certificates and CA files when ProxySQL is enabled.
  * Added support for the RabbitMQ 4.1 container image.

* **Configuration**
  * Removed explicit database TLS override settings, allowing the deployment’s default behavior to apply.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->