### PR TITLE
Reduce max Pulp workers to 12

### DIFF
--- a/etc/kayobe/seed.yml
+++ b/etc/kayobe/seed.yml
@@ -111,8 +111,8 @@ seed_pulp_container:
     # s6-overlay-suexec starts as pid 1
     init: false
     env:
-      PULP_CONTENT_WORKERS: "{{ [ansible_facts.processor_vcpus * 2 + 1, 32] | min }}"
-      PULP_API_WORKERS: "{{ [ansible_facts.processor_vcpus * 2 + 1, 32] | min }}"
+      PULP_CONTENT_WORKERS: "{{ [ansible_facts.processor_vcpus * 2 + 1, 12] | min }}"
+      PULP_API_WORKERS: "{{ [ansible_facts.processor_vcpus * 2 + 1, 12] | min }}"
       PULP_HTTPS: "{{ 'true' if pulp_enable_tls | bool else 'false' }}"
     volumes:
       - /opt/kayobe/containers/pulp:/etc/pulp

--- a/releasenotes/notes/reduce-seed-pulp-workers-b085c86bfe7ab5b6.yaml
+++ b/releasenotes/notes/reduce-seed-pulp-workers-b085c86bfe7ab5b6.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Reduce the maximum number of PULP_CONTENT_WORKERS and PULP_API_WORKERS
+    to 12 to prevent connection starvation on seed hosts with more than 12
+    cpu threads.


### PR DESCRIPTION
On seed hosts with more than 32 CPU threads, `PULP_CONTENT_WORKERS` and `PULP_API_WORKERS` were set to 32, which was causing the number of connections to the bundled Postgres instance to exceed the default max_connections.

Reducing the maximum number of `PULP_CONTENT_WORKERS` and `PULP_API_WORKERS` will prevent Postgres from running out of connection slots.