### PR TITLE
Fix DOCA OFED build (Caracal)

### DIFF
--- a/etc/kayobe/environments/ci-doca-builder/stackhpc-ci.yml
+++ b/etc/kayobe/environments/ci-doca-builder/stackhpc-ci.yml
@@ -7,3 +7,6 @@ stackhpc_repos_enabled: true
 enable_docker_repo: false
 dnf_install_doca: true
 dnf_enable_doca_modules: false
+
+# Disable Pulp auth proxy (deployed too late for DOCA DNF repository setup).
+stackhpc_repo_mirror_auth_proxy_enabled: false


### PR DESCRIPTION
Disable Pulp auth proxy (deployed too late for DOCA DNF repository).

(cherry picked from commit 1b17a9534e45882d50f9d3d7ce0e4c78881e80c5)