### PR TITLE
Improve Amphora image registration logic

### DIFF
--- a/etc/kayobe/ansible/maintenance/octavia-amphora-image-register.yml
+++ b/etc/kayobe/ansible/maintenance/octavia-amphora-image-register.yml
@@ -85,38 +85,37 @@
       register: image_info
       delegate_to: "{{ groups['controllers'][0] }}"
 
-    - name: Ensure old Octavia Amphora image is renamed
-      vars:
-        ansible_python_interpreter: "{{ venv }}/bin/python"
-        ansible_host: "{{ hostvars[groups['controllers'][0]].ansible_host }}"
-      ansible.builtin.command:
-        cmd: >-
-          {{ venv }}/bin/openstack image set amphora-x64-haproxy --name amphora-x64-haproxy-{{ ansible_facts.date_time.iso8601_basic_short }}
-      when:
-        - image_info.images | length != 0
-        - image_info.images[0].checksum != image_checksum.stat.checksum
-      changed_when: true
-      environment: "{{ openstack_auth_env }}"
-      delegate_to: "{{ groups['controllers'][0] }}"
+    - when: image_info.images | selectattr("name", "equalto", "amphora-x64-haproxy") | selectattr("checksum", "equalto", image_checksum.stat.checksum) | list | length == 0
+      block:
+        - name: Ensure old Octavia Amphora image is renamed
+          vars:
+            ansible_python_interpreter: "{{ venv }}/bin/python"
+            ansible_host: "{{ hostvars[groups['controllers'][0]].ansible_host }}"
+          ansible.builtin.command:
+            cmd: >-
+              {{ venv }}/bin/openstack image set amphora-x64-haproxy --name amphora-x64-haproxy-{{ ansible_facts.date_time.iso8601_basic_short }}
+          changed_when: true
+          environment: "{{ openstack_auth_env }}"
+          delegate_to: "{{ groups['controllers'][0] }}"
+          when: image_info.images | selectattr("name", "equalto", "amphora-x64-haproxy") | list | length == 1
 
-    - name: Ensure new Octavia Amphora image is registered
-      vars:
-        ansible_python_interpreter: "{{ venv }}/bin/python"
-        ansible_host: "{{ hostvars[groups['controllers'][0]].ansible_host }}"
-      openstack.cloud.image:
-        auth_type: password
-        auth: "{{ openstack_auth }}"
-        ca_cert: "{{ openstack_cacert }}"
-        interface: "{{ openstack_interface }}"
-        name: amphora-x64-haproxy
-        tags: ["amphora"]
-        container_format: bare
-        disk_format: qcow2
-        is_public: false
-        filename: "{{ image_path }}"
-        properties:
-          hw_architecture: x86_64
-          hw_rng_model: virtio
-      when: image_info.images | length == 0 or (image_info.images | length != 0 and image_info.images[0].checksum != image_checksum.stat.checksum)
-      become: true
-      delegate_to: "{{ groups['controllers'][0] }}"
+        - name: Ensure new Octavia Amphora image is registered
+          vars:
+            ansible_python_interpreter: "{{ venv }}/bin/python"
+            ansible_host: "{{ hostvars[groups['controllers'][0]].ansible_host }}"
+          openstack.cloud.image:
+            auth_type: password
+            auth: "{{ openstack_auth }}"
+            ca_cert: "{{ openstack_cacert }}"
+            interface: "{{ openstack_interface }}"
+            name: amphora-x64-haproxy
+            tags: ["amphora"]
+            container_format: bare
+            disk_format: qcow2
+            is_public: false
+            filename: "{{ image_path }}"
+            properties:
+              hw_architecture: x86_64
+              hw_rng_model: virtio
+          become: true
+          delegate_to: "{{ groups['controllers'][0] }}"


### PR DESCRIPTION
Group the image rename and registration tasks in a block to ensure both are skipped if the correct image is already present.

Use a more robust check using selectattr and checksum to determine if the image needs to be updated: with the old check there was no guarantee that the latest image would be the first element in the list.