### PR TITLE
Rebuild Magnum images

### DIFF
--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -23,6 +23,9 @@ kolla_image_tags:
   keystone:
     rocky-9: 2025.1-rocky-9-20260331T124655
     ubuntu-noble: 2025.1-ubuntu-noble-20260331T124655
+  magnum:
+    rocky-9: 2025.1-rocky-9-20260413T112937
+    ubuntu-noble: 2025.1-ubuntu-noble-20260413T112937
   neutron:
     rocky-9: 2025.1-rocky-9-20260403T083425
     ubuntu-noble: 2025.1-ubuntu-noble-20260403T083425

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -140,6 +140,11 @@ kolla_sources:
     type: git
     location: https://github.com/stackhpc/stackhpc-inspector-plugins.git
     reference: 1.3.0
+  magnum-conductor-plugin-helm:
+    version: "v4.1.4"
+    sha256:
+      amd64: 70b2c30a19da4db264dfd68c8a3664e05093a361cefd89572ffb36f8abfa3d09
+      arm64: 13d03672be289045d2ff00e4e345d61de1c6f21c1257a45955a30e8ae036d8f1
   neutron-base-plugin-networking-generic-switch:
     type: git
     location: https://github.com/stackhpc/networking-generic-switch.git

--- a/etc/kayobe/kolla/kolla-build.conf
+++ b/etc/kayobe/kolla/kolla-build.conf
@@ -27,8 +27,8 @@ version = v4.23.1
 sha256 = amd64:1fd60b1fd59c239bed22719a5de402cb745d1f933540cb1ec196e2c03e6e8882,arm64:1114745108343286d4bff189b4bdee3cba9d07ebcacc673860d91ab951d31e0d
 
 [magnum-conductor-plugin-helm]
-version = v3.18.2
-sha256 = amd64:c5deada86fe609deefdf40e9cbbe3da2f8cf3f6a4551a0ebe7886dc8fcf98bce,arm64:03181a494a0916b370a100a5b2536104963b095be53fb23d1e29b2afb1c7de8d
+version = v4.1.4
+sha256 = amd64:70b2c30a19da4db264dfd68c8a3664e05093a361cefd89572ffb36f8abfa3d09,arm64:13d03672be289045d2ff00e4e345d61de1c6f21c1257a45955a30e8ae036d8f1
 
 # TODO: move to kolla_sources in kolla.yml once https://review.opendev.org/c/openstack/kayobe/+/970268 is available
 [prometheus-cadvisor]

--- a/releasenotes/notes/update-magnum-containers-13042026-825829b55b12ff70.yaml
+++ b/releasenotes/notes/update-magnum-containers-13042026-825829b55b12ff70.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Updates Magnum to a newer Epoxy release version following critical bugs
+    merged & backported. Also, updates Helm version to latest (4.1.4).


### PR DESCRIPTION
Bump Helm version to patch a CVE and pull in latest backported code for API speed improvements