### PR TITLE
Update Pull Request workflow job permissions

### DIFF
--- a/.github/workflows/stackhpc-pull-request.yml
+++ b/.github/workflows/stackhpc-pull-request.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       pull-requests: read
+      packages: none
     name: Check changed files
     if: github.repository == 'stackhpc/stackhpc-kayobe-config'
     needs:
@@ -113,6 +114,9 @@ jobs:
 
   build-kayobe-image:
     name: Build Kayobe Image
+    permissions:
+      contents: read
+      packages: write # required by docker/build-push-action
     needs:
       - check-changes
     uses: ./.github/workflows/stackhpc-build-kayobe-image.yml
@@ -122,6 +126,7 @@ jobs:
 
   check-tags:
     name: Check container image tags
+    permissions: {}
     needs:
       - check-changes
       - build-kayobe-image
@@ -134,6 +139,7 @@ jobs:
 
   all-in-one-ubuntu-noble-ovn:
     name: aio (Ubuntu Noble OVN)
+    permissions: {}
     needs:
       - check-changes
       - build-kayobe-image
@@ -151,6 +157,7 @@ jobs:
 
   all-in-one-rocky-9-ovs:
     name: aio (Rocky 9 OVS)
+    permissions: {}
     needs:
       - check-changes
       - build-kayobe-image
@@ -168,6 +175,7 @@ jobs:
 
   all-in-one-rocky-9-ovn:
     name: aio (Rocky 9 OVN)
+    permissions: {}
     needs:
       - check-changes
       - build-kayobe-image
@@ -187,6 +195,7 @@ jobs:
 
   all-in-one-upgrade-ubuntu-jammy-to-noble-ovn:
     name: aio upgrade (Ubuntu Jammy to Noble OVN)
+    permissions: {}
     needs:
       - check-changes
       - build-kayobe-image
@@ -205,6 +214,7 @@ jobs:
 
   all-in-one-upgrade-rocky-9-ovn:
     name: aio upgrade (Rocky 9 OVN)
+    permissions: {}
     needs:
       - check-changes
       - build-kayobe-image
@@ -223,6 +233,7 @@ jobs:
 
   all-in-one-upgrade-rocky-9-ovs:
     name: aio upgrade (Rocky 9 OVS)
+    permissions: {}
     needs:
       - check-changes
       - build-kayobe-image


### PR DESCRIPTION
Adds the `packages:write` permission to the Build Kayobe Image job in the workflow (required for `docker/build-push-action`) and ensures all other jobs don't have this permission.