### PR TITLE
Increase upgrade AIO volume size

### DIFF
--- a/.github/workflows/stackhpc-all-in-one.yml
+++ b/.github/workflows/stackhpc-all-in-one.yml
@@ -176,7 +176,7 @@ jobs:
           VM_NAME: "skc-ci-aio-${{ inputs.neutron_plugin }}-${{ github.run_id }}"
           VM_IMAGE: ${{ steps.image_name.outputs.image_name }}
           VM_INTERFACE: ${{ inputs.vm_interface }}
-          VM_VOLUME_SIZE: ${{ inputs.upgrade && '75' || '50' }}
+          VM_VOLUME_SIZE: ${{ inputs.upgrade && '100' || '50' }}
           VM_TAGS: '["skc-ci-aio", "PR=${{ github.event.number }}"]'
 
       - name: Terraform Plan

--- a/etc/kayobe/environments/ci-aio/inventory/group_vars/controllers/lvm.yml
+++ b/etc/kayobe/environments/ci-aio/inventory/group_vars/controllers/lvm.yml
@@ -16,7 +16,7 @@ stackhpc_lvm_lv_root_size: 2g
 stackhpc_lvm_lv_tmp_size: 2g
 
 # StackHPC LVM lv_var LV size.
-stackhpc_lvm_lv_var_size: 2g
+stackhpc_lvm_lv_var_size: 5g
 
 # StackHPC LVM lv_var_tmp LV size.
 stackhpc_lvm_lv_var_tmp_size: 2g


### PR DESCRIPTION
Ubuntu Jammy -> Noble AIO upgrade jobs are currently failing (when they manage to run to completion) due to the Docker LV being >90% full:
```
E       AssertionError: assert 1 == 0
E        +  where 1 = len([{'labels': {'alertname': 'ElasticsearchDiskOutOfSpace', 'cluster': 'kolla_logging', 'es_client_node': 'true', 'es_data_node': 'true', 'es_ingest_node': 'true', 'es_master_node': 'true', 'host': '192.168.33.3', 'instance': 'controller0', 'job': 'elasticsearch_exporter', 'mount': '/var/lib/opensearch/data (/dev/mapper/rootvg-lv_docker)', 'name': '192.168.33.3', 'path': '/var/lib/opensearch/data/nodes/0', 'severity': 'critical'}, 'annotations': {'description': 'The disk usage is over 90%', 'summary': 'Elasticsearch disk out of space (instance controller0)'}, 'state': 'firing', 'activeAt': '2026-04-09T11:41:46.772260708Z', 'value': '8.145042223191474e+00'}])
```

This change increases the overall volume size available to the instance, as well as increasing the LV size for the `/var` volume as that was also >90% utilised.

Volume usage before the change:
```
Filesystem                     Size  Used Avail Use% Mounted on
tmpfs                          1.6G  4.7M  1.6G   1% /run
/dev/mapper/rootvg-lv_root     4.6G  3.5G  777M  83% /
tmpfs                          7.9G   44K  7.9G   1% /dev/shm
tmpfs                          5.0M     0  5.0M   0% /run/lock
/dev/mapper/rootvg-lv_home     1.9G  111M  1.7G   7% /home
/dev/mapper/rootvg-lv_var      2.0G  1.7G  190M  91% /var
/dev/vda1                      500M  360K  500M   1% /boot/efi
/dev/mapper/rootvg-lv_tmp      2.0G  529M  1.4G  28% /tmp
/dev/mapper/rootvg-lv_docker    55G   48G  4.5G  92% /var/lib/docker
/dev/mapper/rootvg-lv_log      2.0G  188M  1.7G  10% /var/log
/dev/mapper/rootvg-lv_var_tmp  2.0G   56K  1.9G   1% /var/tmp
/dev/mapper/rootvg-lv_audit    466M  248M  193M  57% /var/log/audit
```

After the change:
```
Filesystem                     Size  Used Avail Use% Mounted on
tmpfs                          1.6G  4.7M  1.6G   1% /run
/dev/mapper/rootvg-lv_root     4.6G  3.5G  777M  83% /
tmpfs                          7.9G   44K  7.9G   1% /dev/shm
tmpfs                          5.0M     0  5.0M   0% /run/lock
/dev/vda1                      500M  360K  500M   1% /boot/efi
/dev/mapper/rootvg-lv_home     1.9G  112M  1.7G   7% /home
/dev/mapper/rootvg-lv_tmp      2.0G  543M  1.4G  29% /tmp
/dev/mapper/rootvg-lv_var      5.0G  1.7G  3.1G  36% /var
/dev/mapper/rootvg-lv_docker    79G   48G   27G  65% /var/lib/docker
/dev/mapper/rootvg-lv_log      2.0G  197M  1.7G  11% /var/log
/dev/mapper/rootvg-lv_var_tmp  2.0G   64K  1.9G   1% /var/tmp
/dev/mapper/rootvg-lv_audit    466M  248M  193M  57% /var/log/audit
```

With three AIO upgrade jobs this will result in an extra 75GB being used by every pull request workflow run.

Clean CI run (without the instance being deleted in the background) [here](https://github.com/stackhpc/stackhpc-kayobe-config/actions/runs/24458095027).