### PR TITLE
Ensure AIOs use correct flavor

### DIFF
--- a/.github/workflows/stackhpc-all-in-one.yml
+++ b/.github/workflows/stackhpc-all-in-one.yml
@@ -164,9 +164,9 @@ jobs:
           aio_vm_interface = "${{ env.VM_INTERFACE }}"
           aio_vm_name = "${{ env.VM_NAME }}"
           aio_vm_image = "${{ env.VM_IMAGE }}"
-          aio_vm_flavor = "${{ vars.HOST_IMAGE_BUILD_FLAVOR }}"
-          aio_vm_network = "${{ vars.HOST_IMAGE_BUILD_NETWORK }}"
-          aio_vm_subnet = "${{ vars.HOST_IMAGE_BUILD_SUBNET }}"
+          aio_vm_flavor = "${{ vars.AIO_FLAVOR }}"
+          aio_vm_network = "${{ vars.AIO_NETWORK }}"
+          aio_vm_subnet = "${{ vars.AIO_SUBNET }}"
           aio_vm_volume_size = "${{ env.VM_VOLUME_SIZE }}"
           aio_vm_tags = ${{ env.VM_TAGS }}
           EOF

--- a/.github/workflows/stackhpc-all-in-one.yml
+++ b/.github/workflows/stackhpc-all-in-one.yml
@@ -176,7 +176,7 @@ jobs:
           VM_NAME: "skc-ci-aio-${{ inputs.neutron_plugin }}-${{ github.run_id }}"
           VM_IMAGE: ${{ steps.image_name.outputs.image_name }}
           VM_INTERFACE: ${{ inputs.vm_interface }}
-          VM_VOLUME_SIZE: ${{ inputs.upgrade && '75' || '50' }}
+          VM_VOLUME_SIZE: ${{ inputs.upgrade && '100' || '50' }}
           VM_TAGS: '["skc-ci-aio", "PR=${{ github.event.number }}"]'
 
       - name: Terraform Plan

--- a/.github/workflows/stackhpc-ci-cleanup.yml
+++ b/.github/workflows/stackhpc-ci-cleanup.yml
@@ -40,10 +40,10 @@ jobs:
         run: |
           pip install python-openstackclient -c https://raw.githubusercontent.com/stackhpc/requirements/refs/heads/stackhpc/${{ steps.openstack_release.outputs.openstack_release }}/upper-constraints.txt
 
-      - name: Clean up aio instances over 3 hours old
+      - name: Clean up aio instances over 6 hours old
         run: |
           result=0
-          changes_before=$(date -Imin -d -3hours)
+          changes_before=$(date -Imin -d -6hours)
           for status in ACTIVE BUILD ERROR SHUTOFF; do
               for instance in $(openstack server list --tags skc-ci-aio --os-compute-api-version 2.66 --format value --column ID --changes-before $changes_before --status $status); do
                   echo "Cleaning up $status instance $instance"

--- a/etc/kayobe/environments/ci-aio/inventory/group_vars/controllers/lvm.yml
+++ b/etc/kayobe/environments/ci-aio/inventory/group_vars/controllers/lvm.yml
@@ -16,7 +16,7 @@ stackhpc_lvm_lv_root_size: 2g
 stackhpc_lvm_lv_tmp_size: 2g
 
 # StackHPC LVM lv_var LV size.
-stackhpc_lvm_lv_var_size: 2g
+stackhpc_lvm_lv_var_size: 5g
 
 # StackHPC LVM lv_var_tmp LV size.
 stackhpc_lvm_lv_var_tmp_size: 2g


### PR DESCRIPTION
This fixes ~two~ many issues
1. It ensures AIOs select their flavor/network combo using the right github env var
2. It changes the AIO flavor on SMS to a custom flavor that should stop it from landing on the slow hypervisors
3. It changes the AIO instance cleanup action to let jobs run for up to 6 hours
4. It increases the size of the AIO disk so upgrade jobs don't run out of space (mainly in the docker LV)