### PR TITLE
fix: restore ability to dump all configuration

### DIFF
--- a/doc/source/configuration/walled-garden.rst
+++ b/doc/source/configuration/walled-garden.rst
@@ -29,7 +29,7 @@ In ``etc/kayobe/inventory/group_vars/overcloud/time``:
    # Following deployment we include the OpenStack VIP
 
    chrony_ntp_servers:
-     - server: "http://{{ lookup('vars', admin_oc_net_name ~ '_ips')[groups.seed.0] }}:3128"
+     - server: "{{ lookup('vars', admin_oc_net_name ~ '_ips')[groups.seed.0] }}"
 
 Proxy
 =====

--- a/doc/source/configuration/walled-garden.rst
+++ b/doc/source/configuration/walled-garden.rst
@@ -29,7 +29,7 @@ In ``etc/kayobe/inventory/group_vars/overcloud/time``:
    # Following deployment we include the OpenStack VIP
 
    chrony_ntp_servers:
-     - server: "{{ admin_oc_net_name | net_ip(inventory_hostname=groups['seed'][0]) }}"
+     - server: "http://{{ lookup('vars', admin_oc_net_name ~ '_ips')[groups.seed.0] }}:3128"
 
 Proxy
 =====
@@ -62,7 +62,7 @@ proxy:
    ---
    # HTTP proxy URL (format: http(s)://[user:password@]proxy_name:port). By
    # default no proxy is used.
-   http_proxy: "http://{{ admin_oc_net_name | net_ip(inventory_hostname=groups['seed'][0]) }}:3128"
+   http_proxy: "http://{{ lookup('vars', admin_oc_net_name ~ '_ips')[groups.seed.0] }}:3128"
 
    # HTTPS proxy URL (format: http(s)://[user:password@]proxy_name:port). By
    # default no proxy is used.

--- a/etc/kayobe/inventory/group_vars/all/openbao.yml
+++ b/etc/kayobe/inventory/group_vars/all/openbao.yml
@@ -77,7 +77,7 @@ seed_openbao_pki_certificate_subject:
   - common_name: "{% if kolla_internal_fqdn != kolla_internal_vip_address %}{{ kolla_internal_fqdn }}{% else %}overcloud{% endif %}"
     role: "{{ seed_openbao_pki_role_name }}"
     extra_params:
-      ip_sans: "{% for host in groups['controllers'] %}{{ internal_net_name | net_ip(host) }}{% if not loop.last %},{% endif %}{% endfor %},{{ kolla_internal_vip_address }}"
+      ip_sans: "{% for host in groups['controllers'] %}{{ lookup('vars', internal_net_name ~ '_ips')[host] }}{% if not loop.last %},{% endif %}{% endfor %},{{ kolla_internal_vip_address }}"
 
 # Enable OpenBao UI
 openbao_enable_ui: true

--- a/etc/kayobe/inventory/group_vars/all/vault
+++ b/etc/kayobe/inventory/group_vars/all/vault
@@ -88,4 +88,4 @@ seed_vault_pki_certificate_subject:
   - common_name: "{% if kolla_internal_fqdn != kolla_internal_vip_address %}{{ kolla_internal_fqdn }}{% else %}overcloud{% endif %}"
     role: "{{ seed_vault_pki_role_name }}"
     extra_params:
-      ip_sans: "{% for host in groups['controllers'] %}{{ internal_net_name | net_ip(host) }}{% if not loop.last %},{% endif %}{% endfor %},{{ kolla_internal_vip_address }}"
+      ip_sans: "{% for host in groups['controllers'] %}{{ lookup('vars', internal_net_name ~ '_ips')[host] }}{% if not loop.last %},{% endif %}{% endfor %},{{ kolla_internal_vip_address }}"

--- a/etc/kayobe/inventory/group_vars/wazuh-agent/wazuh-agent
+++ b/etc/kayobe/inventory/group_vars/wazuh-agent/wazuh-agent
@@ -5,7 +5,7 @@
 
 # Wazuh-Manager IP address
 # Convenience var not used by wazuh-agent role
-wazuh_manager_address: "{{ admin_oc_net_name | net_ip(groups['wazuh-manager'][0]) }}"
+wazuh_manager_address: "{{ lookup('vars', admin_oc_net_name ~ '_ips')[groups['wazuh-manager'][0]] }}"
 
 # Wazuh-Manager API config
 wazuh_managers:


### PR DESCRIPTION
When running `kayobe configuration dump` would fail with

```
...FAILED! => \n    msg: to_nice_yaml - 'hostvars'. 'hostvars'
```

This is due to the existence of variables that use `net_ip` filter. Therefore, this can be avoided by using `lookup` filter.

Some of these changes are done within config and would be picked automatically. However some changes are done within the documentation and would require a user to update their configuration to benefit from the changes suggested.

Note: This only works with you use `--limit` as the firewall configuration is within `all` group and gets evaluated by hosts that do not have network_interfaces such as switches. Due to the command producing a lot of output running the command without a `limit` it not advisable.