### PR TITLE
Ensure AIOs are only cleaned up after 6 hours

### DIFF
--- a/.github/workflows/stackhpc-ci-cleanup.yml
+++ b/.github/workflows/stackhpc-ci-cleanup.yml
@@ -40,10 +40,10 @@ jobs:
         run: |
           pip install python-openstackclient -c https://raw.githubusercontent.com/stackhpc/requirements/refs/heads/stackhpc/${{ steps.openstack_release.outputs.openstack_release }}/upper-constraints.txt
 
-      - name: Clean up aio instances over 3 hours old
+      - name: Clean up aio instances over 6 hours old
         run: |
           result=0
-          changes_before=$(date -Imin -d -3hours)
+          changes_before=$(date -Imin -d -6hours)
           for status in ACTIVE BUILD ERROR SHUTOFF; do
               for instance in $(openstack server list --tags skc-ci-aio --os-compute-api-version 2.66 --format value --column ID --changes-before $changes_before --status $status); do
                   echo "Cleaning up $status instance $instance"


### PR DESCRIPTION
AIO upgrade jobs on SMS regularly exceed 3 hours, so can be culled before they are finished. This commit ensures they are only removed after 6 hours.

Spinning this change out from https://github.com/stackhpc/stackhpc-kayobe-config/pull/2271 because the CI on that one keeps getting killed before it can finish.

This one won't trigger the same checks because it doesn't change the files that are associated with AIOs