### PR TITLE
add aarch64 ipa R9 build

### DIFF
--- a/.github/workflows/ipa-image-build.yml
+++ b/.github/workflows/ipa-image-build.yml
@@ -7,6 +7,10 @@ on:
         description: Build Rocky Linux 9
         type: boolean
         default: true
+      rocky9-aarch64:
+        description: Build Rocky Linux 9 aarch64
+        type: boolean
+        default: true
       ubuntu-noble:
         description: Build Ubuntu 24.04 Noble
         type: boolean
@@ -38,24 +42,18 @@ jobs:
     with:
       runner_env: ${{ inputs.runner_env }}
 
-  ipa-image-build:
-    name: Build IPA images
+  create-tag:
+    name: Create a tag to be added to resulting images
     if: github.repository == 'stackhpc/stackhpc-kayobe-config'
     environment: ${{ inputs.runner_env }}
     runs-on: ${{ needs.runner-selection.outputs.runner_name_image_build }}
     needs:
       - runner-selection
     permissions: {}
+    outputs:
+      openstack_release: ${{ steps.openstack_release.outputs.openstack_release }}
+      ipa_image_tag: ${{ steps.ipa_image_tag.outputs.ipa_image_tag }}
     steps:
-      - name: Install Package dependencies
-        run: |
-          sudo apt update &&
-          sudo apt install -y git unzip nodejs python3-pip python3-venv openssh-server openssh-client jq
-
-      - name: Start the SSH service
-        run: |
-          sudo /etc/init.d/ssh start
-
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -72,9 +70,33 @@ jobs:
         run: |
           echo "ipa_image_tag=$(date +${{ steps.openstack_release.outputs.openstack_release }}-%Y%m%dT%H%M%S)" >> $GITHUB_OUTPUT
 
+  ipa-image-build:
+    name: Build IPA images
+    if: github.repository == 'stackhpc/stackhpc-kayobe-config'
+    environment: ${{ inputs.runner_env }}
+    runs-on: ${{ needs.runner-selection.outputs.runner_name_image_build }}
+    needs:
+      - runner-selection
+      - create-tag
+    permissions: {}
+    steps:
+      - name: Install Package dependencies
+        run: |
+          sudo apt update &&
+          sudo apt install -y git unzip nodejs python3-pip python3-venv openssh-server openssh-client jq
+
+      - name: Start the SSH service
+        run: |
+          sudo /etc/init.d/ssh start
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: src/kayobe-config
+
       - name: Display IPA image tag
         run: |
-          echo "${{ steps.ipa_image_tag.outputs.ipa_image_tag }}"
+          echo "${{ needs.create-tag.outputs.ipa_image_tag }}"
 
       - name: Install Kayobe
         run: |
@@ -240,7 +262,7 @@ jobs:
           src/kayobe-config/etc/kayobe/ansible/pulp/pulp-artifact-upload.yml \
           -e artifact_path=/opt/kayobe/images/ipa \
           -e artifact_type=ipa-images \
-          -e artifact_tag=${{ steps.ipa_image_tag.outputs.ipa_image_tag }} \
+          -e artifact_tag=${{ needs.create-tag.outputs.ipa_image_tag }} \
           -e os_distribution="ubuntu" \
           -e os_release="noble" \
           -e file_regex='*.kernel'
@@ -256,7 +278,7 @@ jobs:
           src/kayobe-config/etc/kayobe/ansible/pulp/pulp-artifact-upload.yml \
           -e artifact_path=/opt/kayobe/images/ipa \
           -e artifact_type=ipa-images \
-          -e artifact_tag=${{ steps.ipa_image_tag.outputs.ipa_image_tag }} \
+          -e artifact_tag=${{ needs.create-tag.outputs.ipa_image_tag }} \
           -e os_distribution="ubuntu" \
           -e os_release="noble" \
           -e file_regex='*.initramfs'
@@ -297,7 +319,7 @@ jobs:
           src/kayobe-config/etc/kayobe/ansible/pulp/pulp-artifact-upload.yml \
           -e artifact_path=/opt/kayobe/images/ipa \
           -e artifact_type=ipa-images \
-          -e artifact_tag=${{ steps.ipa_image_tag.outputs.ipa_image_tag }} \
+          -e artifact_tag=${{ needs.create-tag.outputs.ipa_image_tag }} \
           -e os_distribution="rocky" \
           -e os_release="9" \
           -e file_regex='*.kernel'
@@ -313,7 +335,7 @@ jobs:
           src/kayobe-config/etc/kayobe/ansible/pulp/pulp-artifact-upload.yml \
           -e artifact_path=/opt/kayobe/images/ipa \
           -e artifact_type=ipa-images \
-          -e artifact_tag=${{ steps.ipa_image_tag.outputs.ipa_image_tag }} \
+          -e artifact_tag=${{ needs.create-tag.outputs.ipa_image_tag }} \
           -e os_distribution="rocky" \
           -e os_release="9" \
           -e file_regex='*.initramfs'
@@ -340,6 +362,254 @@ jobs:
           exit 1
         if: steps.build_rocky_9_ipa.outcome == 'failure' ||
             steps.build_ubuntu_noble_ipa.outcome == 'failure'
+
+      - name: Destroy
+        run: terraform destroy -auto-approve
+        working-directory: ${{ github.workspace }}/src/kayobe-config/terraform/aio
+        env:
+          OS_CLOUD: openstack
+          OS_APPLICATION_CREDENTIAL_ID: ${{ secrets.OS_APPLICATION_CREDENTIAL_ID }}
+          OS_APPLICATION_CREDENTIAL_SECRET: ${{ secrets.OS_APPLICATION_CREDENTIAL_SECRET }}
+        if: always()
+
+  ipa-image-build-aarch64:
+    name: Build Rocky 9 aarch64 IPA image
+    if: github.repository == 'stackhpc/stackhpc-kayobe-config' && inputs.rocky9-aarch64 && inputs.runner_env == 'SMS Lab'
+    environment: ${{ inputs.runner_env }}
+    runs-on: ${{ needs.runner-selection.outputs.runner_name_image_build }}
+    needs:
+      - runner-selection
+      - create-tag
+    permissions: {}
+    steps:
+      - name: Install Package dependencies
+        run: |
+          sudo apt update &&
+          sudo apt install -y git unzip nodejs python3-pip python3-venv openssh-server openssh-client jq
+
+      - name: Start the SSH service
+        run: |
+          sudo /etc/init.d/ssh start
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: src/kayobe-config
+
+      - name: Display IPA image tag
+        run: |
+          echo "${{ needs.create-tag.outputs.ipa_image_tag }}"
+
+      - name: Install Kayobe
+        run: |
+          mkdir -p venvs &&
+          pushd venvs &&
+          python3 -m venv kayobe &&
+          source kayobe/bin/activate &&
+          pip install -U pip &&
+          pip install -r ../src/kayobe-config/requirements.txt
+
+      - name: Install terraform
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
+
+      - name: Initialise terraform
+        run: terraform init
+        working-directory: ${{ github.workspace }}/src/kayobe-config/terraform/aio
+
+      - name: Generate SSH keypair
+        run: ssh-keygen -f id_rsa -N ''
+        working-directory: ${{ github.workspace }}/src/kayobe-config/terraform/aio
+
+      - name: Generate clouds.yaml
+        run: |
+          cat << EOF > clouds.yaml
+          ${{ secrets.CLOUDS_YAML }}
+          EOF
+        working-directory: ${{ github.workspace }}/src/kayobe-config/terraform/aio
+
+      - name: Generate terraform.tfvars
+        run: |
+          cat << EOF > terraform.tfvars
+          ssh_public_key = "id_rsa.pub"
+          ssh_username = "ubuntu"
+          aio_vm_name = "skc-ipa-image-builder-arm64"
+          aio_vm_image = "${{ vars.HOST_IMAGE_BUILD_IMAGE_ARM64 }}"
+          aio_vm_flavor = "${{ vars.HOST_IMAGE_BUILD_FLAVOR }}"
+          aio_vm_network = "${{ vars.HOST_IMAGE_BUILD_NETWORK }}"
+          aio_vm_subnet = "${{ vars.HOST_IMAGE_BUILD_SUBNET }}"
+          aio_vm_interface = "ens3"
+          aio_vm_volume_size = "${{ vars.HOST_IMAGE_BUILD_VOLUME }}"
+          EOF
+        working-directory: ${{ github.workspace }}/src/kayobe-config/terraform/aio
+
+      - name: Terraform Plan
+        run: terraform plan
+        working-directory: ${{ github.workspace }}/src/kayobe-config/terraform/aio
+        env:
+          OS_CLOUD: ${{ vars.OS_CLOUD }}
+          OS_APPLICATION_CREDENTIAL_ID: ${{ secrets.OS_APPLICATION_CREDENTIAL_ID }}
+          OS_APPLICATION_CREDENTIAL_SECRET: ${{ secrets.OS_APPLICATION_CREDENTIAL_SECRET }}
+
+      - name: Terraform Apply
+        run: |
+          for attempt in $(seq 5); do
+              if terraform apply -auto-approve; then
+                  echo "Created infrastructure on attempt $attempt"
+                  exit 0
+              fi
+              echo "Failed to create infrastructure on attempt $attempt"
+              sleep 10
+              terraform destroy -auto-approve
+              sleep 60
+          done
+          echo "Failed to create infrastructure after $attempt attempts"
+          exit 1
+        working-directory: ${{ github.workspace }}/src/kayobe-config/terraform/aio
+        env:
+          OS_CLOUD: ${{ vars.OS_CLOUD }}
+          OS_APPLICATION_CREDENTIAL_ID: ${{ secrets.OS_APPLICATION_CREDENTIAL_ID }}
+          OS_APPLICATION_CREDENTIAL_SECRET: ${{ secrets.OS_APPLICATION_CREDENTIAL_SECRET }}
+
+      - name: Get Terraform outputs
+        id: tf_outputs
+        run: |
+          terraform output -json
+        working-directory: ${{ github.workspace }}/src/kayobe-config/terraform/aio
+
+      - name: Write Terraform outputs
+        run: |
+          cat << EOF > src/kayobe-config/etc/kayobe/environments/ci-builder/tf-outputs.yml
+          ${{ steps.tf_outputs.outputs.stdout }}
+          EOF
+
+      - name: Write Terraform network config
+        run: |
+          cat << EOF > src/kayobe-config/etc/kayobe/environments/ci-builder/tf-network-allocation.yml
+          ---
+          aio_ips:
+            builder: "{{ access_ip_v4.value }}"
+          EOF
+
+      - name: Write Terraform network interface config
+        run: |
+          mkdir -p src/kayobe-config/etc/kayobe/environments/$KAYOBE_ENVIRONMENT/inventory/group_vars/seed
+          rm -f src/kayobe-config/etc/kayobe/environments/$KAYOBE_ENVIRONMENT/inventory/group_vars/seed/network-interfaces
+          cat << EOF > src/kayobe-config/etc/kayobe/environments/$KAYOBE_ENVIRONMENT/inventory/group_vars/seed/network-interfaces
+          admin_interface: "{{ access_interface.value }}"
+          aio_interface: "{{ access_interface.value }}"
+          EOF
+
+      - name: Manage SSH keys
+        run: |
+          mkdir -p ~/.ssh
+          touch ~/.ssh/authorized_keys
+          cat src/kayobe-config/terraform/aio/id_rsa.pub >> ~/.ssh/authorized_keys
+          cp src/kayobe-config/terraform/aio/id_rsa* ~/.ssh/
+
+      - name: Bootstrap the control host
+        run: |
+          source venvs/kayobe/bin/activate &&
+          source src/kayobe-config/kayobe-env --environment ci-builder &&
+          kayobe control host bootstrap
+
+      - name: Configure the seed host (Builder VM)
+        run: |
+          source venvs/kayobe/bin/activate &&
+          source src/kayobe-config/kayobe-env --environment ci-builder &&
+          kayobe seed host configure \
+          -e seed_bootstrap_user=ubuntu \
+          --skip-tags network,apt,docker,docker-registry
+        env:
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
+
+      - name: Install dependencies
+        run: |
+          source venvs/kayobe/bin/activate &&
+          source src/kayobe-config/kayobe-env --environment ci-builder &&
+          kayobe seed host command run \
+          --command "sudo apt update && sudo apt -y install gcc git libffi-dev python3-dev python-is-python3 python3-venv" --show-output
+        env:
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
+
+      - name: Build a Rocky 9 aarch64 IPA image
+        id: build_rocky_9_ipa_aarch64
+        continue-on-error: true
+        run: |
+          source venvs/kayobe/bin/activate &&
+          source src/kayobe-config/kayobe-env --environment ci-builder &&
+          kayobe overcloud deployment image build --force-rebuild \
+          -e os_distribution="rocky" \
+          -e os_release="9" \
+          -e ipa_ci_builder_distribution="rocky" \
+          -e ipa_ci_builder_release="9" \
+          -e ipa_ci_builder_arch="aarch64"
+        env:
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
+
+      - name: Show last error logs
+        continue-on-error: true
+        run: |
+          source venvs/kayobe/bin/activate &&
+          source src/kayobe-config/kayobe-env --environment ci-builder &&
+          kayobe seed host command run --command "tail -200 /opt/kayobe/images/ipa/ipa.stdout" --show-output
+        env:
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
+        if: steps.build_rocky_9_ipa_aarch64.outcome == 'failure'
+
+      - name: Upload Rocky 9 aarch64 IPA kernel image to Ark
+        run: |
+          source venvs/kayobe/bin/activate &&
+          source src/kayobe-config/kayobe-env --environment ci-builder &&
+          kayobe playbook run \
+          src/kayobe-config/etc/kayobe/ansible/pulp/pulp-artifact-upload.yml \
+          -e artifact_path=/opt/kayobe/images/ipa \
+          -e artifact_type=ipa-images \
+          -e artifact_tag=${{ needs.create-tag.outputs.ipa_image_tag }} \
+          -e repository_name="ipa-images-${{ needs.create-tag.outputs.openstack_release }}-rocky-9-aarch64" \
+          -e pulp_base_path="ipa-images/${{ needs.create-tag.outputs.openstack_release }}/rocky/9/aarch64" \
+          -e os_distribution="rocky" \
+          -e os_release="9" \
+          -e file_regex='ipa.kernel'
+        env:
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
+        if: steps.build_rocky_9_ipa_aarch64.outcome == 'success'
+
+      - name: Upload Rocky 9 aarch64 IPA ramdisk image to Ark
+        run: |
+          source venvs/kayobe/bin/activate &&
+          source src/kayobe-config/kayobe-env --environment ci-builder &&
+          kayobe playbook run \
+          src/kayobe-config/etc/kayobe/ansible/pulp/pulp-artifact-upload.yml \
+          -e artifact_path=/opt/kayobe/images/ipa \
+          -e artifact_type=ipa-images \
+          -e artifact_tag=${{ needs.create-tag.outputs.ipa_image_tag }} \
+          -e repository_name="ipa-images-${{ needs.create-tag.outputs.openstack_release }}-rocky-9-aarch64" \
+          -e pulp_base_path="ipa-images/${{ needs.create-tag.outputs.openstack_release }}/rocky/9/aarch64" \
+          -e os_distribution="rocky" \
+          -e os_release="9" \
+          -e file_regex='ipa.initramfs'
+        env:
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
+        if: steps.build_rocky_9_ipa_aarch64.outcome == 'success'
+
+      - name: Copy logs back
+        continue-on-error: true
+        run: |
+          mkdir logs
+          scp -r ubuntu@$(jq -r .access_ip_v4.value src/kayobe-config/etc/kayobe/environments/ci-builder/tf-outputs.yml):/opt/kayobe/images/*/*.std* ./logs/
+        if: always()
+
+      - name: Upload logs artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: Build logs aarch64
+          path: ./logs
+
+      - name: Fail if the aarch64 IPA image build failed
+        run: |
+          echo "Build failed. See workflow artifacts for details." &&
+          exit 1
+        if: steps.build_rocky_9_ipa_aarch64.outcome == 'failure'
 
       - name: Destroy
         run: terraform destroy -auto-approve

--- a/.github/workflows/ipa-image-promote.yml
+++ b/.github/workflows/ipa-image-promote.yml
@@ -7,6 +7,10 @@ on:
         description: Promote Rocky Linux 9
         type: boolean
         default: true
+      rocky9-aarch64:
+        description: Promote Rocky Linux 9 aarch64
+        type: boolean
+        default: true
       ubuntu-noble:
         description: Promote Ubuntu 24.04 Noble
         type: boolean
@@ -25,7 +29,7 @@ jobs:
     steps:
       - name: Validate inputs
         run: |
-          if [[ ${{ inputs.rocky9 }} == 'false' && ${{ inputs.ubuntu-noble }} == 'false' ]]; then
+          if [[ ${{ inputs.rocky9 }} == 'false' && ${{ inputs.rocky9-aarch64 }} == 'false' && ${{ inputs.ubuntu-noble }} == 'false' ]]; then
             echo "At least one distribution must be selected"
             exit 1
           fi
@@ -84,6 +88,19 @@ jobs:
           ARTIFACT_TAG: ${{ inputs.image_tag }}
           KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
         if: inputs.rocky9
+
+      - name: Promote Rocky Linux 9 aarch64 IPA image artifact
+        run: |
+          source venvs/kayobe/bin/activate &&
+          source src/kayobe-config/kayobe-env --environment ci-builder &&
+          kayobe playbook run \
+          src/kayobe-config/etc/kayobe/ansible/pulp/pulp-artifact-promote.yml \
+          -e repository_name="ipa-images-${{ steps.openstack_release.outputs.openstack_release }}-rocky-9-aarch64" \
+          -e pulp_base_path="ipa-images/${{ steps.openstack_release.outputs.openstack_release }}/rocky/9/aarch64"
+        env:
+          ARTIFACT_TAG: ${{ inputs.image_tag }}
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
+        if: inputs.rocky9-aarch64
 
       - name: Promote Ubuntu Noble 24.04 IPA image artifact
         run: |

--- a/doc/source/configuration/ipa.rst
+++ b/doc/source/configuration/ipa.rst
@@ -25,10 +25,19 @@ post configure`` for Overcloud Ironic. This behaviour can be disabled in
     stackhpc_ipa_image_bifrost_enabled: false
     stackhpc_ipa_image_overcloud_enabled: false
 
-You can also override the distribution version pulled in during deployment,
-to do this you can change ``stackhpc_ipa_image_version`` to be the opposite
-distribution. For example, the case of switching to Ubuntu 24.04 on a Rocky 9
-cloud:
+You can also select the architecture of the IPA images pulled in during
+deployment:
+
+.. code-block:: yaml
+
+    stackhpc_ipa_arch: aarch64
+
+The supported values are ``amd64`` and ``aarch64``. Rocky Linux 9 uses
+``stackhpc_rocky_9_ipa_image_version`` for ``amd64`` and
+``stackhpc_rocky_9_ipa_image_version_aarch64`` for ``aarch64``.
+
+You can also override the distribution version pulled in during deployment. For
+example, the case of switching to Ubuntu 24.04 on a Rocky 9 cloud:
 
 .. code-block:: yaml
 

--- a/etc/kayobe/environments/ci-builder/stackhpc-ci.yml
+++ b/etc/kayobe/environments/ci-builder/stackhpc-ci.yml
@@ -106,9 +106,7 @@ stackhpc_release_pulp_password: "{{ stackhpc_docker_registry_password }}"
 
 # Build during IPA builder workflow
 ipa_build_images: true
-ipa_build_dib_env_extra:
-  DISTRO_NAME: "{{ ipa_ci_builder_distribution | default('ubuntu') }}"
-  DIB_RELEASE: "{{ ipa_ci_builder_release | default('noble') }}"
+ipa_build_dib_env_extra: "{{ {'DISTRO_NAME': ipa_ci_builder_distribution | default('ubuntu'), 'DIB_RELEASE': ipa_ci_builder_release | default('noble')} | combine({'ARCH': ipa_ci_builder_arch} if ipa_ci_builder_arch is defined else {}) }}"
 
 # Ensure Ark repos are disabled during CI runs, this is due to
 # builder being a member of the 'overcloud' group for IPA builds.

--- a/etc/kayobe/pulp-ipa-image-versions.yml
+++ b/etc/kayobe/pulp-ipa-image-versions.yml
@@ -1,4 +1,5 @@
 ---
 # IPA image versioning tags
-stackhpc_rocky_9_ipa_image_version: "2025.1-20250929T120332"
-stackhpc_ubuntu_noble_ipa_image_version: "2025.1-20250929T120332"
+stackhpc_rocky_9_ipa_image_version: "2025.1-20260420T095100"
+stackhpc_rocky_9_ipa_image_version_aarch64: "2025.1-20260420T095100"
+stackhpc_ubuntu_noble_ipa_image_version: "2025.1-20260420T095100"

--- a/etc/kayobe/stackhpc-ipa-images.yml
+++ b/etc/kayobe/stackhpc-ipa-images.yml
@@ -8,13 +8,19 @@ stackhpc_ipa_image_bifrost_enabled: true
 # Whether to use Release Train IPA images for Overcloud Ironic
 stackhpc_ipa_image_overcloud_enabled: true
 
+# Architecture of the Release Train IPA images to consume.
+# Options are "amd64" and "aarch64".
+stackhpc_ipa_arch: amd64
+
 # The IPA image source, defined by os_distribution,
 # os_release, and the current stable version.
 stackhpc_ipa_image_url: "{{ stackhpc_release_pulp_content_url }}/ipa-images/\
                          {{ openstack_release }}/{{ os_distribution }}/\
-                         {{ os_release }}/{{ stackhpc_ipa_image_version }}"
+                         {{ os_release }}{{ '/aarch64' if os_distribution == 'rocky' and stackhpc_ipa_arch == 'aarch64' else '' }}/\
+                         {{ stackhpc_ipa_image_version }}"
 
 # IPA image version tag selection
 stackhpc_ipa_image_version: >-
-  {{ stackhpc_rocky_9_ipa_image_version if os_distribution == 'rocky' and os_release == '9' else
+  {{ stackhpc_rocky_9_ipa_image_version_aarch64 if os_distribution == 'rocky' and os_release == '9' and stackhpc_ipa_arch == 'aarch64' else
+  stackhpc_rocky_9_ipa_image_version if os_distribution == 'rocky' and os_release == '9' else
   stackhpc_ubuntu_noble_ipa_image_version if os_distribution == 'ubuntu' and os_release == 'noble' }}

--- a/releasenotes/notes/ipa-aarch64-d3128b089b7c143a.yaml
+++ b/releasenotes/notes/ipa-aarch64-d3128b089b7c143a.yaml
@@ -1,0 +1,9 @@
+---
+features:
+  - |
+    Added support for building Rocky Linux 9 Ironic Python Agent (IPA) images
+    for the ``aarch64`` architecture in the IPA image CI workflow. The
+    resulting images are published under a separate ``aarch64`` Ark path and
+    can be selected in configuration with ``stackhpc_ipa_arch``. Rocky Linux 9
+    now also has a separate ``stackhpc_rocky_9_ipa_image_version_aarch64``
+    version pin for the ``aarch64`` IPA image.


### PR DESCRIPTION
Add the Rocky 9 (CentOS Stream 9) aarch64 IPA build/upload path and a separate Rocky 9 aarch64 IPA version pin.

Multiarch IPA support will need changes in Bifrost to consume `deploy_kernel_by_arch`.