### PR TITLE
Add Rocky 9/10 aarch64 overcloud host image support

### DIFF
--- a/.github/workflows/overcloud-host-image-build.yml
+++ b/.github/workflows/overcloud-host-image-build.yml
@@ -7,8 +7,16 @@ on:
         description: Build Rocky Linux 9
         type: boolean
         default: true
+      rocky9-aarch64:
+        description: Build Rocky Linux 9 aarch64
+        type: boolean
+        default: true
       rocky10:
         description: Build Rocky Linux 10
+        type: boolean
+        default: true
+      rocky10-aarch64:
+        description: Build Rocky Linux 10 aarch64
         type: boolean
         default: true
       ubuntu-noble:
@@ -56,11 +64,33 @@ jobs:
       actions: write
     outputs:
       host_image_tag: ${{ steps.host_image_tag.outputs.host_image_tag }}
+      openstack_release: ${{ steps.openstack_release.outputs.openstack_release }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: src/kayobe-config
+
+      - name: Validate inputs
+        run: |
+          if [[
+            "${{ inputs.rocky9 }}" == "false" &&
+            "${{ inputs.rocky9-aarch64 }}" == "false" &&
+            "${{ inputs.rocky10 }}" == "false" &&
+            "${{ inputs.rocky10-aarch64 }}" == "false" &&
+            "${{ inputs.ubuntu-noble }}" == "false"
+          ]]; then
+            echo "At least one distribution must be selected"
+            exit 1
+          fi
+
+          if [[
+            ("${{ inputs.rocky9-aarch64 }}" == "true" || "${{ inputs.rocky10-aarch64 }}" == "true") &&
+            "${{ inputs.runner_env }}" != "SMS Lab"
+          ]]; then
+            echo "aarch64 builds are only supported on SMS Lab"
+            exit 1
+          fi
 
       - name: Determine OpenStack release
         id: openstack_release
@@ -76,7 +106,7 @@ jobs:
 
   overcloud-host-image-build:
     name: Build overcloud host images
-    if: github.repository == 'stackhpc/stackhpc-kayobe-config'
+    if: github.repository == 'stackhpc/stackhpc-kayobe-config' && (inputs.rocky9 || inputs.rocky10 || inputs.ubuntu-noble)
     environment: ${{ inputs.runner_env }}
     runs-on: ${{ needs.runner-selection.outputs.runner_name_image_build }}
     needs:
@@ -85,13 +115,6 @@ jobs:
     permissions:
       actions: write
     steps:
-      - name: Validate inputs
-        run: |
-          if [[ ${{ inputs.rocky9 }} == 'false' && ${{ inputs.rocky10 }} == 'false' && ${{ inputs.ubuntu-noble }} == 'false' ]]; then
-            echo "At least one distribution must be selected"
-            exit 1
-          fi
-
       - name: Display overcloud host image tag
         run: |
           echo "${{ needs.create-tag.outputs.host_image_tag }}"
@@ -523,3 +546,333 @@ jobs:
           RESULTS_URL: "N/A"
           WORKFLOW_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         if: failure() && inputs.create_skc_pr
+
+  overcloud-host-image-build-aarch64:
+    name: Build aarch64 overcloud host images
+    if: github.repository == 'stackhpc/stackhpc-kayobe-config' && inputs.runner_env == 'SMS Lab' && (inputs.rocky9-aarch64 || inputs.rocky10-aarch64)
+    environment: ${{ inputs.runner_env }}
+    runs-on: ${{ needs.runner-selection.outputs.runner_name_image_build }}
+    needs:
+      - runner-selection
+      - create-tag
+    permissions:
+      actions: write
+    steps:
+      - name: Display overcloud host image tag
+        run: |
+          echo "${{ needs.create-tag.outputs.host_image_tag }}"
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: src/kayobe-config
+
+      - name: Install Package dependencies
+        run: |
+          sudo apt update &&
+          sudo apt install -y git unzip nodejs python3-pip python3-venv openssh-server openssh-client jq gh
+
+      - name: Start the SSH service
+        run: |
+          sudo /etc/init.d/ssh start
+
+      - name: Install Kayobe
+        run: |
+          mkdir -p venvs &&
+          pushd venvs &&
+          python3 -m venv kayobe &&
+          source kayobe/bin/activate &&
+          pip install -U pip &&
+          pip install -r ../src/kayobe-config/requirements.txt
+
+      - name: Install terraform
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
+
+      - name: Initialise terraform
+        run: terraform init
+        working-directory: ${{ github.workspace }}/src/kayobe-config/terraform/aio
+
+      - name: Generate SSH keypair
+        run: ssh-keygen -f id_rsa -N ''
+        working-directory: ${{ github.workspace }}/src/kayobe-config/terraform/aio
+
+      - name: Generate clouds.yaml
+        run: |
+          cat << EOF > clouds.yaml
+          ${{ secrets.CLOUDS_YAML }}
+          EOF
+        working-directory: ${{ github.workspace }}/src/kayobe-config/terraform/aio
+
+      - name: Generate terraform.tfvars
+        run: |
+          cat << EOF > terraform.tfvars
+          ssh_public_key = "id_rsa.pub"
+          ssh_username = "ubuntu"
+          aio_vm_name = "skc-host-image-builder-arm64"
+          # Must be an Ubuntu Noble host to successfully build all images
+          # This MUST NOT be an LVM image. It can cause confusing conficts with the built image.
+          aio_vm_image = "${{ vars.HOST_IMAGE_BUILD_IMAGE_ARM64 }}"
+          aio_vm_flavor = "${{ vars.HOST_IMAGE_BUILD_FLAVOR }}"
+          aio_vm_network = "${{ vars.HOST_IMAGE_BUILD_NETWORK }}"
+          aio_vm_subnet = "${{ vars.HOST_IMAGE_BUILD_SUBNET }}"
+          aio_vm_interface = "ens3"
+          EOF
+        working-directory: ${{ github.workspace }}/src/kayobe-config/terraform/aio
+
+      - name: Terraform Plan
+        run: terraform plan
+        working-directory: ${{ github.workspace }}/src/kayobe-config/terraform/aio
+        env:
+          OS_CLOUD: ${{ vars.OS_CLOUD }}
+          OS_APPLICATION_CREDENTIAL_ID: ${{ secrets.OS_APPLICATION_CREDENTIAL_ID }}
+          OS_APPLICATION_CREDENTIAL_SECRET: ${{ secrets.OS_APPLICATION_CREDENTIAL_SECRET }}
+
+      - name: Terraform Apply
+        run: |
+          for attempt in $(seq 5); do
+              if terraform apply -auto-approve; then
+                  echo "Created infrastructure on attempt $attempt"
+                  exit 0
+              fi
+              echo "Failed to create infrastructure on attempt $attempt"
+              sleep 10
+              terraform destroy -auto-approve
+              sleep 60
+          done
+          echo "Failed to create infrastructure after $attempt attempts"
+          exit 1
+        working-directory: ${{ github.workspace }}/src/kayobe-config/terraform/aio
+        env:
+          OS_CLOUD: ${{ vars.OS_CLOUD }}
+          OS_APPLICATION_CREDENTIAL_ID: ${{ secrets.OS_APPLICATION_CREDENTIAL_ID }}
+          OS_APPLICATION_CREDENTIAL_SECRET: ${{ secrets.OS_APPLICATION_CREDENTIAL_SECRET }}
+
+      - name: Get Terraform outputs
+        id: tf_outputs
+        run: |
+          terraform output -json
+        working-directory: ${{ github.workspace }}/src/kayobe-config/terraform/aio
+
+      - name: Write Terraform outputs
+        run: |
+          cat << EOF > src/kayobe-config/etc/kayobe/environments/ci-builder/tf-outputs.yml
+          ${{ steps.tf_outputs.outputs.stdout }}
+          EOF
+
+      - name: Write Terraform network config
+        run: |
+          cat << EOF > src/kayobe-config/etc/kayobe/environments/ci-builder/tf-network-allocation.yml
+          ---
+          aio_ips:
+            builder: "{{ access_ip_v4.value }}"
+          EOF
+
+      - name: Write Terraform network interface config
+        run: |
+          mkdir -p src/kayobe-config/etc/kayobe/environments/$KAYOBE_ENVIRONMENT/inventory/group_vars/seed
+          rm -f src/kayobe-config/etc/kayobe/environments/$KAYOBE_ENVIRONMENT/inventory/group_vars/seed/network-interfaces
+          cat << EOF > src/kayobe-config/etc/kayobe/environments/$KAYOBE_ENVIRONMENT/inventory/group_vars/seed/network-interfaces
+          admin_interface: "{{ access_interface.value }}"
+          aio_interface: "{{ access_interface.value }}"
+          EOF
+
+      - name: Manage SSH keys
+        run: |
+          mkdir -p ~/.ssh
+          touch ~/.ssh/authorized_keys
+          cat src/kayobe-config/terraform/aio/id_rsa.pub >> ~/.ssh/authorized_keys
+          cp src/kayobe-config/terraform/aio/id_rsa* ~/.ssh/
+
+      - name: Bootstrap the control host
+        run: |
+          source venvs/kayobe/bin/activate &&
+          source src/kayobe-config/kayobe-env --environment ci-builder &&
+          kayobe control host bootstrap
+
+      - name: Configure the seed host (Builder VM)
+        run: |
+          source venvs/kayobe/bin/activate &&
+          source src/kayobe-config/kayobe-env --environment ci-builder &&
+          kayobe seed host configure -e seed_bootstrap_user=ubuntu --skip-tags network
+
+      - name: Install dependencies
+        run: |
+          source venvs/kayobe/bin/activate &&
+          source src/kayobe-config/kayobe-env --environment ci-builder &&
+          kayobe seed host command run \
+          --command "sudo apt update && sudo apt -y install gcc git libffi-dev python3-dev python-is-python3 python3-venv containerd docker.io docker-buildx" --show-output
+        env:
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
+
+      - name: Create bifrost_httpboot Docker volume
+        run: |
+          source venvs/kayobe/bin/activate &&
+          source src/kayobe-config/kayobe-env --environment ci-builder &&
+          kayobe seed host command run --command "sudo mkdir -p /var/lib/docker/volumes/bifrost_httpboot/_data" --show-output
+        env:
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
+
+      - name: Build a Rocky Linux 9 aarch64 overcloud host image
+        id: build_rocky_9_aarch64
+        continue-on-error: true
+        run: |
+          source venvs/kayobe/bin/activate &&
+          source src/kayobe-config/kayobe-env --environment ci-builder &&
+          kayobe overcloud host image build --force-rebuild \
+          -e kolla_base_arch="aarch64" \
+          -e os_distribution="rocky" \
+          -e os_release="9" \
+          -e stackhpc_overcloud_dib_name=overcloud-rocky-9
+        env:
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
+        if: inputs.rocky9-aarch64
+
+      - name: Show last error logs
+        continue-on-error: true
+        run: |
+          source venvs/kayobe/bin/activate &&
+          source src/kayobe-config/kayobe-env --environment ci-builder &&
+          kayobe seed host command run --command "tail -200 /opt/kayobe/images/overcloud-rocky-9/overcloud-rocky-9.stdout" --show-output
+        env:
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
+        if: steps.build_rocky_9_aarch64.outcome == 'failure'
+
+      - name: Upload Rocky Linux 9 aarch64 overcloud host image to current Dev Cloud (SMS)
+        run: |
+          source venvs/kayobe/bin/activate &&
+          source src/kayobe-config/kayobe-env --environment ci-builder &&
+          kayobe playbook run \
+          src/kayobe-config/etc/kayobe/ansible/tools/openstack-host-image-upload.yml \
+          -e local_image_path="/opt/kayobe/images/overcloud-rocky-9/overcloud-rocky-9.qcow2" \
+          -e image_name=overcloud-rocky-9-aarch64-${{ needs.create-tag.outputs.host_image_tag }} \
+          -e '{"image_properties":{"hw_architecture":"aarch64"}}'
+        env:
+          CLOUDS_YAML: ${{ secrets.CLOUDS_YAML }}
+          OS_APPLICATION_CREDENTIAL_ID: ${{ secrets.OS_APPLICATION_CREDENTIAL_ID }}
+          OS_APPLICATION_CREDENTIAL_SECRET: ${{ secrets.OS_APPLICATION_CREDENTIAL_SECRET }}
+        if: inputs.rocky9-aarch64 && steps.build_rocky_9_aarch64.outcome == 'success'
+
+      - name: Upload Rocky Linux 9 aarch64 overcloud host image to Ark
+        run: |
+          source venvs/kayobe/bin/activate &&
+          source src/kayobe-config/kayobe-env --environment ci-builder &&
+          kayobe playbook run \
+          src/kayobe-config/etc/kayobe/ansible/pulp/pulp-artifact-upload.yml \
+          -e artifact_path=/opt/kayobe/images/overcloud-rocky-9 \
+          -e artifact_tag=${{ needs.create-tag.outputs.host_image_tag }} \
+          -e artifact_type="kayobe-images" \
+          -e file_regex="*.qcow2" \
+          -e os_distribution="rocky" \
+          -e os_release="9" \
+          -e repository_name="kayobe-images-${{ needs.create-tag.outputs.openstack_release }}-rocky-9-aarch64" \
+          -e pulp_base_path="kayobe-images/${{ needs.create-tag.outputs.openstack_release }}/rocky/9/aarch64"
+        env:
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
+        if: inputs.rocky9-aarch64 && steps.build_rocky_9_aarch64.outcome == 'success'
+
+      - name: Build a Rocky Linux 10 aarch64 overcloud host image
+        id: build_rocky_10_aarch64
+        continue-on-error: true
+        run: |
+          source venvs/kayobe/bin/activate &&
+          source src/kayobe-config/kayobe-env --environment ci-builder &&
+          kayobe overcloud host image build --force-rebuild \
+          -e kolla_base_arch="aarch64" \
+          -e os_distribution="rocky" \
+          -e os_release="10" \
+          -e stackhpc_overcloud_dib_name=overcloud-rocky-10
+        env:
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
+        if: inputs.rocky10-aarch64
+
+      - name: Show last error logs
+        continue-on-error: true
+        run: |
+          source venvs/kayobe/bin/activate &&
+          source src/kayobe-config/kayobe-env --environment ci-builder &&
+          kayobe seed host command run --command "tail -200 /opt/kayobe/images/overcloud-rocky-10/overcloud-rocky-10.stdout" --show-output
+        env:
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
+        if: steps.build_rocky_10_aarch64.outcome == 'failure'
+
+      - name: Upload Rocky Linux 10 aarch64 overcloud host image to current Dev Cloud (SMS)
+        run: |
+          source venvs/kayobe/bin/activate &&
+          source src/kayobe-config/kayobe-env --environment ci-builder &&
+          kayobe playbook run \
+          src/kayobe-config/etc/kayobe/ansible/tools/openstack-host-image-upload.yml \
+          -e local_image_path="/opt/kayobe/images/overcloud-rocky-10/overcloud-rocky-10.qcow2" \
+          -e image_name=overcloud-rocky-10-aarch64-${{ needs.create-tag.outputs.host_image_tag }} \
+          -e '{"image_properties":{"hw_architecture":"aarch64"}}'
+        env:
+          CLOUDS_YAML: ${{ secrets.CLOUDS_YAML }}
+          OS_APPLICATION_CREDENTIAL_ID: ${{ secrets.OS_APPLICATION_CREDENTIAL_ID }}
+          OS_APPLICATION_CREDENTIAL_SECRET: ${{ secrets.OS_APPLICATION_CREDENTIAL_SECRET }}
+        if: inputs.rocky10-aarch64 && steps.build_rocky_10_aarch64.outcome == 'success'
+
+      - name: Upload Rocky Linux 10 aarch64 overcloud host image to Ark
+        run: |
+          source venvs/kayobe/bin/activate &&
+          source src/kayobe-config/kayobe-env --environment ci-builder &&
+          kayobe playbook run \
+          src/kayobe-config/etc/kayobe/ansible/pulp/pulp-artifact-upload.yml \
+          -e artifact_path=/opt/kayobe/images/overcloud-rocky-10 \
+          -e artifact_tag=${{ needs.create-tag.outputs.host_image_tag }} \
+          -e artifact_type="kayobe-images" \
+          -e file_regex="*.qcow2" \
+          -e os_distribution="rocky" \
+          -e os_release="10" \
+          -e repository_name="kayobe-images-${{ needs.create-tag.outputs.openstack_release }}-rocky-10-aarch64" \
+          -e pulp_base_path="kayobe-images/${{ needs.create-tag.outputs.openstack_release }}/rocky/10/aarch64"
+        env:
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
+        if: inputs.rocky10-aarch64 && steps.build_rocky_10_aarch64.outcome == 'success'
+
+      - name: Copy logs back
+        continue-on-error: true
+        run: |
+          mkdir logs
+          scp -r ubuntu@$(jq -r .access_ip_v4.value src/kayobe-config/etc/kayobe/environments/ci-builder/tf-outputs.yml):/opt/kayobe/images/*/*.std* ./logs/
+          scp -r ubuntu@$(jq -r .access_ip_v4.value src/kayobe-config/etc/kayobe/environments/ci-builder/tf-outputs.yml):/tmp/updated_images.txt ./logs/ || true
+        if: always()
+
+      - name: Fail if any aarch64 overcloud host image builds failed
+        run: |
+          echo "Builds failed. See workflow artifacts for details." &&
+          exit 1
+        if: steps.build_rocky_9_aarch64.outcome == 'failure' ||
+            steps.build_rocky_10_aarch64.outcome == 'failure'
+
+      - name: Upload logs artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: Build logs aarch64
+          path: ./logs
+        if: always()
+
+      - name: Destroy
+        run: terraform destroy -auto-approve
+        working-directory: ${{ github.workspace }}/src/kayobe-config/terraform/aio
+        env:
+          OS_CLOUD: openstack
+          OS_APPLICATION_CREDENTIAL_ID: ${{ secrets.OS_APPLICATION_CREDENTIAL_ID }}
+          OS_APPLICATION_CREDENTIAL_SECRET: ${{ secrets.OS_APPLICATION_CREDENTIAL_SECRET }}
+        if: always()
+
+      - name: Trigger update overcloud host image tags
+        run: |
+          gh workflow run \
+          update-overcloud-host-image-tags.yml \
+          --repo stackhpc/stackhpc-kayobe-config \
+          --ref $BRANCH_NAME \
+          $(if [[ "${{ inputs.rocky9-aarch64 }}" == "true" ]]; then echo "-f rocky9_aarch64_tag=${{ needs.create-tag.outputs.host_image_tag }}"; fi) \
+          $(if [[ "${{ inputs.rocky10-aarch64 }}" == "true" ]]; then echo "-f rocky10_aarch64_tag=${{ needs.create-tag.outputs.host_image_tag }}"; fi)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+        if: inputs.create_skc_pr
+
+      - name: Display link to update overcloud host image tags workflows
+        run: |
+          echo "::notice Overcloud host image promote workflow: https://github.com/stackhpc/stackhpc-kayobe-config/actions/workflows/update-overcloud-host-image-tags.yml"
+        if: inputs.create_skc_pr

--- a/.github/workflows/overcloud-host-image-promote.yml
+++ b/.github/workflows/overcloud-host-image-promote.yml
@@ -7,10 +7,18 @@ on:
         description: Promote Rocky Linux 9
         type: boolean
         default: true
+      rocky9-aarch64:
+        description: Promote Rocky Linux 9 aarch64
+        type: boolean
+        default: false
       rocky10:
         description: Promote Rocky Linux 10
         type: boolean
         default: true
+      rocky10-aarch64:
+        description: Promote Rocky Linux 10 aarch64
+        type: boolean
+        default: false
       ubuntu-noble:
         description: Promote Ubuntu 24.04 Noble
         type: boolean
@@ -25,7 +33,7 @@ jobs:
     steps:
       - name: Validate inputs
         run: |
-          if [[ ${{ inputs.rocky9 }} == 'false' && ${{ inputs.rocky10 }} == 'false' && ${{ inputs.ubuntu-noble }} == 'false' ]]; then
+          if [[ ${{ inputs.rocky9 }} == 'false' && ${{ inputs.rocky9-aarch64 }} == 'false' && ${{ inputs.rocky10 }} == 'false' && ${{ inputs.rocky10-aarch64 }} == 'false' && ${{ inputs.ubuntu-noble }} == 'false' ]]; then
             echo "At least one distribution must be selected"
             exit 1
           fi
@@ -85,6 +93,20 @@ jobs:
         working-directory: src/kayobe-config
         if: inputs.rocky10
 
+      - name: Gather Rocky Linux 9 aarch64 overcloud host image tag
+        id: rocky9_aarch64_image_tag
+        run: |
+          echo image_tag=$(grep stackhpc_rocky_9_overcloud_host_image_version_aarch64: etc/kayobe/pulp-host-image-versions.yml | awk '{print $2}') >> $GITHUB_OUTPUT
+        working-directory: src/kayobe-config
+        if: inputs.rocky9-aarch64
+
+      - name: Gather Rocky Linux 10 aarch64 overcloud host image tag
+        id: rocky10_aarch64_image_tag
+        run: |
+          echo image_tag=$(grep stackhpc_rocky_10_overcloud_host_image_version_aarch64: etc/kayobe/pulp-host-image-versions.yml | awk '{print $2}') >> $GITHUB_OUTPUT
+        working-directory: src/kayobe-config
+        if: inputs.rocky10-aarch64
+
       - name: Gather Ubuntu Noble overcloud host image tag
         id: ubuntu_noble_image_tag
         run: |
@@ -119,6 +141,38 @@ jobs:
         env:
           KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
         if: inputs.rocky10
+
+      - name: Promote Rocky Linux 9 aarch64 overcloud host image artifact
+        run: |
+          source venvs/kayobe/bin/activate &&
+          source src/kayobe-config/kayobe-env --environment ci-builder &&
+          kayobe playbook run \
+          src/kayobe-config/etc/kayobe/ansible/pulp/pulp-artifact-promote.yml \
+          -e artifact_type="kayobe-images" \
+          -e os_distribution='rocky' \
+          -e os_release='9' \
+          -e promotion_tag=${{ steps.rocky9_aarch64_image_tag.outputs.image_tag }} \
+          -e repository_name="kayobe-images-${{ steps.openstack_release.outputs.openstack_release }}-rocky-9-aarch64" \
+          -e pulp_base_path="kayobe-images/${{ steps.openstack_release.outputs.openstack_release }}/rocky/9/aarch64"
+        env:
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
+        if: inputs.rocky9-aarch64
+
+      - name: Promote Rocky Linux 10 aarch64 overcloud host image artifact
+        run: |
+          source venvs/kayobe/bin/activate &&
+          source src/kayobe-config/kayobe-env --environment ci-builder &&
+          kayobe playbook run \
+          src/kayobe-config/etc/kayobe/ansible/pulp/pulp-artifact-promote.yml \
+          -e artifact_type="kayobe-images" \
+          -e os_distribution='rocky' \
+          -e os_release='10' \
+          -e promotion_tag=${{ steps.rocky10_aarch64_image_tag.outputs.image_tag }} \
+          -e repository_name="kayobe-images-${{ steps.openstack_release.outputs.openstack_release }}-rocky-10-aarch64" \
+          -e pulp_base_path="kayobe-images/${{ steps.openstack_release.outputs.openstack_release }}/rocky/10/aarch64"
+        env:
+          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
+        if: inputs.rocky10-aarch64
 
       - name: Promote Ubuntu Noble 24.04 overcloud host image artifact
         run: |

--- a/.github/workflows/update-overcloud-host-image-tags.yml
+++ b/.github/workflows/update-overcloud-host-image-tags.yml
@@ -7,8 +7,14 @@ on:
       rocky9_tag:
         description: Overcloud host image tag for Rocky 9
         type: string
+      rocky9_aarch64_tag:
+        description: Overcloud host image tag for Rocky 9 aarch64
+        type: string
       rocky10_tag:
         description: Overcloud host image tag for Rocky 10
+        type: string
+      rocky10_aarch64_tag:
+        description: Overcloud host image tag for Rocky 10 aarch64
         type: string
       ubuntu_noble_tag:
         description: Overcloud host image tag for Ubuntu
@@ -31,17 +37,27 @@ jobs:
 
       - name: Update Rocky 9 overcloud host image tag
         run: |
-          sed -i "/stackhpc_rocky_9_overcloud_host_image_version/s/.*/stackhpc_rocky_9_overcloud_host_image_version: ${{ inputs.rocky9_tag }}/" ${{ github.workspace }}/src/kayobe-config/etc/kayobe/pulp-host-image-versions.yml
+          sed -i "/^stackhpc_rocky_9_overcloud_host_image_version:/s/.*/stackhpc_rocky_9_overcloud_host_image_version: ${{ inputs.rocky9_tag }}/" ${{ github.workspace }}/src/kayobe-config/etc/kayobe/pulp-host-image-versions.yml
         if: "${{ inputs.rocky9_tag != '' }}"
+
+      - name: Update Rocky 9 aarch64 overcloud host image tag
+        run: |
+          sed -i "/^stackhpc_rocky_9_overcloud_host_image_version_aarch64:/s/.*/stackhpc_rocky_9_overcloud_host_image_version_aarch64: ${{ inputs.rocky9_aarch64_tag }}/" ${{ github.workspace }}/src/kayobe-config/etc/kayobe/pulp-host-image-versions.yml
+        if: "${{ inputs.rocky9_aarch64_tag != '' }}"
 
       - name: Update Rocky 10 overcloud host image tag
         run: |
-          sed -i "/stackhpc_rocky_10_overcloud_host_image_version/s/.*/stackhpc_rocky_10_overcloud_host_image_version: ${{ inputs.rocky10_tag }}/" ${{ github.workspace }}/src/kayobe-config/etc/kayobe/pulp-host-image-versions.yml
+          sed -i "/^stackhpc_rocky_10_overcloud_host_image_version:/s/.*/stackhpc_rocky_10_overcloud_host_image_version: ${{ inputs.rocky10_tag }}/" ${{ github.workspace }}/src/kayobe-config/etc/kayobe/pulp-host-image-versions.yml
         if: "${{ inputs.rocky10_tag != '' }}"
+
+      - name: Update Rocky 10 aarch64 overcloud host image tag
+        run: |
+          sed -i "/^stackhpc_rocky_10_overcloud_host_image_version_aarch64:/s/.*/stackhpc_rocky_10_overcloud_host_image_version_aarch64: ${{ inputs.rocky10_aarch64_tag }}/" ${{ github.workspace }}/src/kayobe-config/etc/kayobe/pulp-host-image-versions.yml
+        if: "${{ inputs.rocky10_aarch64_tag != '' }}"
 
       - name: Update Ubuntu Noble overcloud host image tag
         run: |
-          sed -i "/stackhpc_ubuntu_noble_overcloud_host_image_version/s/.*/stackhpc_ubuntu_noble_overcloud_host_image_version: ${{ inputs.ubuntu_noble_tag }}/" ${{ github.workspace }}/src/kayobe-config/etc/kayobe/pulp-host-image-versions.yml
+          sed -i "/^stackhpc_ubuntu_noble_overcloud_host_image_version:/s/.*/stackhpc_ubuntu_noble_overcloud_host_image_version: ${{ inputs.ubuntu_noble_tag }}/" ${{ github.workspace }}/src/kayobe-config/etc/kayobe/pulp-host-image-versions.yml
         if: "${{ inputs.ubuntu_noble_tag != '' }}"
 
       - name: Propose changes via PR if required
@@ -51,7 +67,7 @@ jobs:
           commit-message: >-
             Bump overcloud host image tags
           author: stackhpc-ci <22933334+stackhpc-ci@users.noreply.github.com>
-          branch: bump-overcloud-host-images-${{ inputs.rocky9_tag }}-${{ inputs.rocky10_tag }}-${{ inputs.ubuntu_noble_tag }}
+          branch: bump-overcloud-host-images-${{ inputs.rocky9_tag }}-${{ inputs.rocky9_aarch64_tag }}-${{ inputs.rocky10_tag }}-${{ inputs.rocky10_aarch64_tag }}-${{ inputs.ubuntu_noble_tag }}
           delete-branch: true
           title: >-
             Bump overcloud host image tags 
@@ -59,7 +75,9 @@ jobs:
             This PR was created automatically to update the overcloud host image
             tags.
             Rocky 9: ${{ inputs.rocky9_tag }}
+            Rocky 9 aarch64: ${{ inputs.rocky9_aarch64_tag }}
             Rocky 10: ${{ inputs.rocky10_tag }}
+            Rocky 10 aarch64: ${{ inputs.rocky10_aarch64_tag }}
             Ubuntu Noble: ${{ inputs.ubuntu_noble_tag }}
           labels: |
             automated

--- a/doc/source/configuration/host-images.rst
+++ b/doc/source/configuration/host-images.rst
@@ -20,11 +20,17 @@ in ``etc/kayobe/stackhpc-overcloud-host-images.yml``.
 Currently, images exist for the following operating systems:
 
 * Rocky Linux 9
+* Rocky Linux 10
 * Ubuntu Noble 24.04
 
 The image to download is selected automatically using the ``os_distribution``
 and ``os_release`` variables. These images are versioned and a variable for
 each OS is stored in ``pulp-host-image-versions.yml``.
+
+The architecture of the Rocky Linux release train overcloud host images can be
+selected using ``stackhpc_overcloud_host_image_arch``. Valid values are
+``amd64`` and ``aarch64``. Rocky Linux 9 and Rocky Linux 10 ``aarch64`` images
+use separate version variables in ``pulp-host-image-versions.yml``.
 
 This content requires the same set of credentials as is used for other
 release train content.

--- a/etc/kayobe/ansible/pulp/pulp-host-image-download.yml
+++ b/etc/kayobe/ansible/pulp/pulp-host-image-download.yml
@@ -6,7 +6,7 @@
     # without the auth credentials in it. Auth is handled by username and
     # password in the get_url task of this playbook
     stackhpc_overcloud_host_image_url_no_auth: "{{ stackhpc_release_pulp_content_url }}/kayobe-images/\
-      {{ openstack_release }}/{{ os_distribution }}/{{ os_release }}/\
+      {{ openstack_release }}/{{ os_distribution }}/{{ os_release }}{{ '/aarch64' if os_distribution == 'rocky' and stackhpc_overcloud_host_image_arch == 'aarch64' else '' }}/\
       {{ stackhpc_overcloud_host_image_version }}/\
       overcloud-{{ os_distribution }}-{{ os_release }}.qcow2"
   tasks:

--- a/etc/kayobe/ansible/tools/openstack-host-image-upload.yml
+++ b/etc/kayobe/ansible/tools/openstack-host-image-upload.yml
@@ -40,6 +40,7 @@
             name: "{{ image_name }}"
             container_format: bare
             disk_format: qcow2
+            properties: "{{ image_properties | default(omit) }}"
             state: present
             filename: "{{ local_image_path }}"
 

--- a/etc/kayobe/pulp-host-image-versions.yml
+++ b/etc/kayobe/pulp-host-image-versions.yml
@@ -1,6 +1,8 @@
 ---
 # Overcloud host image versioning tags
 # These images must be in SMS, since they are used by our AIO CI runners
-stackhpc_rocky_9_overcloud_host_image_version: 2025.1-20260306T094256
-stackhpc_rocky_10_overcloud_host_image_version: 2025.1-20260318T110608
-stackhpc_ubuntu_noble_overcloud_host_image_version: 2025.1-20260206T132408
+stackhpc_rocky_9_overcloud_host_image_version: 2025.1-20260420T162634
+stackhpc_rocky_9_overcloud_host_image_version_aarch64: 2025.1-20260420T162634
+stackhpc_rocky_10_overcloud_host_image_version: 2025.1-20260420T162634
+stackhpc_rocky_10_overcloud_host_image_version_aarch64: 2025.1-20260420T162634
+stackhpc_ubuntu_noble_overcloud_host_image_version: 2025.1-20260420T162634

--- a/etc/kayobe/stackhpc-overcloud-host-images.yml
+++ b/etc/kayobe/stackhpc-overcloud-host-images.yml
@@ -8,15 +8,19 @@ stackhpc_download_overcloud_host_images: false
 # Whether or not to build overcloud host images from Ark
 stackhpc_build_overcloud_image_from_pulp_package_mirrors: false
 
+# Architecture of the Release Train overcloud host images to consume.
+# Valid values are amd64 and aarch64.
+stackhpc_overcloud_host_image_arch: amd64
+
 # The overcloud host image source, defined by os_distribution, os_release,
 # and the current stable version.
 stackhpc_overcloud_host_image_url: "{{ stackhpc_release_pulp_content_url_with_auth }}/kayobe-images/\
-                                    {{ openstack_release }}/{{ os_distribution }}/{{ os_release }}/\
+                                    {{ openstack_release }}/{{ os_distribution }}/{{ os_release }}{{ '/aarch64' if os_distribution == 'rocky' and stackhpc_overcloud_host_image_arch == 'aarch64' else '' }}/\
                                     {{ stackhpc_overcloud_host_image_version }}/\
                                     overcloud-{{ os_distribution }}-{{ os_release }}.qcow2"
 
 # Overcloud host image version tag selection
 stackhpc_overcloud_host_image_version: >-
-  {{ stackhpc_rocky_9_overcloud_host_image_version if os_distribution == 'rocky' and os_release == '9' else
-  stackhpc_rocky_10_overcloud_host_image_version if os_distribution == 'rocky' and os_release == '10' else
-  stackhpc_ubuntu_noble_overcloud_host_image_version if os_distribution == 'ubuntu' and os_release == 'noble' }}
+  {{ lookup('vars', 'stackhpc_' ~ os_distribution ~ '_' ~ os_release ~
+     '_overcloud_host_image_version' ~
+     ('_aarch64' if os_distribution == 'rocky' and stackhpc_overcloud_host_image_arch == 'aarch64' else '')) }}

--- a/releasenotes/notes/overcloud-host-aarch64-2a308c8b68aac778.yaml
+++ b/releasenotes/notes/overcloud-host-aarch64-2a308c8b68aac778.yaml
@@ -1,0 +1,5 @@
+features:
+  - |
+    Add Rocky Linux 9 and Rocky Linux 10 ``aarch64`` overcloud host image
+    build and promotion support. The architecture consumed from Ark can be
+    selected with ``stackhpc_overcloud_host_image_arch``.


### PR DESCRIPTION
This part is for building and single-arch image consume.

For multiarch, we probably should move away from the single global custom_deploy_image_upstream_url.
We would need both deploy images in httpboot, and set kolla_bifrost_deploy_image_filename per host.