### PR TITLE
Implement CIS benchmark hardening for Rocky Linux 10

### DIFF
--- a/doc/source/configuration/security-hardening.rst
+++ b/doc/source/configuration/security-hardening.rst
@@ -14,6 +14,7 @@ The following operating systems are supported:
 
 - Ubuntu 24.04
 - Rocky 9
+- Rocky 10
 
 Configuration
 --------------
@@ -27,6 +28,7 @@ about what each variable does. The documentation can be found here:
 
 - `Ubuntu 24.04 <https://github.com/ansible-lockdown/UBUNTU24-CIS>`__
 - `Rocky 9 <https://github.com/ansible-lockdown/RHEL9-CIS>`__
+- `Rocky 10 <https://github.com/ansible-lockdown/RHEL10-CIS>`__
 
 Running the playbooks
 ---------------------

--- a/etc/kayobe/ansible/maintenance/cis.yml
+++ b/etc/kayobe/ansible/maintenance/cis.yml
@@ -52,6 +52,11 @@
         name: ansible-lockdown.rhel9_cis
       when: ansible_facts.os_family == 'RedHat' and ansible_facts.distribution_major_version == '9'
 
+    - name: Run CIS hardening role (RHEL 10)
+      ansible.builtin.include_role:
+        name: ansible-lockdown.rhel10_cis
+      when: ansible_facts.os_family == 'RedHat' and ansible_facts.distribution_major_version == '10'
+
     - name: Run CIS hardening role (Ubuntu 24)
       ansible.builtin.include_role:
         name: ansible-lockdown.ubuntu24_cis

--- a/etc/kayobe/ansible/requirements.yml
+++ b/etc/kayobe/ansible/requirements.yml
@@ -21,6 +21,9 @@ roles:
   - name: ansible-lockdown.rhel9_cis
     src: https://github.com/ansible-lockdown/RHEL9-CIS
     version: v1.3.4
+  - name: ansible-lockdown.rhel10_cis
+    src: https://github.com/ansible-lockdown/RHEL10-CIS
+    version: 1.0.2
   - name: wazuh-ansible
     src: https://github.com/stackhpc/wazuh-ansible
     version: stackhpc-v4.10.0

--- a/etc/kayobe/environments/ci-aio/inventory/group_vars/cis-hardening/cis
+++ b/etc/kayobe/environments/ci-aio/inventory/group_vars/cis-hardening/cis
@@ -11,6 +11,17 @@ rhel9cis_crypto_policy: DEFAULT
 rhel9cis_rule_5_4_3_2: false
 
 ##############################################################################
+# Rocky 10 CIS Hardening Configuration
+
+# NOTE: Using DEFAULT crypto policy in CI. FIPS breaks ed25519 SSH keys, and
+# FUTURE breaks wazuh agent repo metadata download.
+rhel10cis_crypto_policy: DEFAULT
+
+# Disable shell timeout for inactivity which can be disruptive to
+# development work.
+rhel10cis_rule_5_4_3_2: false
+
+##############################################################################
 # Ubuntu Noble CIS Hardening Configuration
 # TODO: Test CIS rules for Ubuntu Noble
 

--- a/etc/kayobe/environments/ci-multinode/inventory/group_vars/cis-hardening/cis
+++ b/etc/kayobe/environments/ci-multinode/inventory/group_vars/cis-hardening/cis
@@ -11,6 +11,17 @@ rhel9cis_crypto_policy: DEFAULT
 rhel9cis_rule_5_4_3_2: false
 
 ##############################################################################
+# Rocky 10 CIS Hardening Configuration
+
+# NOTE: Using DEFAULT crypto policy in CI. FIPS breaks ed25519 SSH keys, and
+# FUTURE breaks wazuh agent repo metadata download.
+rhel10cis_crypto_policy: DEFAULT
+
+# Disable shell timeout for inactivity which can be disruptive to
+# development work.
+rhel10cis_rule_5_4_3_2: false
+
+##############################################################################
 # Ubuntu Noble CIS Hardening Configuration
 # TODO: Test CIS rules for Ubuntu Noble
 

--- a/etc/kayobe/inventory/group_vars/cis-hardening/cis
+++ b/etc/kayobe/inventory/group_vars/cis-hardening/cis
@@ -78,6 +78,78 @@ rhel9cis_set_boot_pass: false
 rhel9cis_rule_5_6_1_1: false
 
 ##############################################################################
+# Rocky 10 CIS Hardening Configuration
+
+# Configure log rotation to prevent audit logs from filling the disk
+rhel10cis_auditd_action_mail_acct: root
+rhel10cis_auditd_admin_space_left_action: syslog
+rhel10cis_auditd_max_log_file_action: rotate
+rhel10cis_auditd_max_log_file_size: 1024
+rhel10cis_auditd_max_log_file: 10
+rhel10cis_auditd_space_left_action: syslog
+
+# Set an authselect profile name (required)
+rhel10cis_authselect_custom_profile_name: "stack"
+
+# Set crypto policy
+# NOTE: FUTURE breaks wazuh agent repo metadata download
+rhel10cis_crypto_policy: FIPS
+
+# Skip configuration of the firewall
+rhel10cis_firewall: None
+
+# Allow IP forwarding
+rhel10cis_is_router: true
+
+# The following rules change permissions on all files on every mounted
+# filesystem. We do not want to change /var/lib/docker permissions.
+rhel10cis_no_world_write_adjust: false
+
+# Prevent remounting of /tmp
+rhel10cis_rule_1_1_2_1_1: false
+rhel10cis_rule_1_1_2_1_2: false
+rhel10cis_rule_1_1_2_1_3: false
+rhel10cis_rule_1_1_2_1_4: false
+
+# Skip enabling gpgcheck on all yum repos.
+# This conflicts with our configured doca repos, which need gpgcheck disabled.
+rhel10cis_rule_1_2_1_2: false
+
+# Skip package updates
+rhel10cis_rule_1_2_2_1: false
+
+# Skip configuration of chrony
+rhel10cis_rule_2_3_1: false
+rhel10cis_rule_2_3_2: false
+
+# Disable requirement for password when using sudo
+rhel10cis_rule_5_2_4: false
+
+# Disable password expiration limit
+rhel10cis_rule_5_4_1_1: false
+
+# Disable check for root password being set, we should be locking root passwords instead.
+# Please double-check yourself with: sudo passwd -S root
+rhel10cis_rule_5_4_2_4: false
+
+# Prevent hardening from recursively changing permissions on log files
+rhel10cis_rule_6_2_4_1: false
+
+# Stop the CIS benchmark scanning all files on every filesystem since this
+# takes a long time. Related to the changing permissions block
+# (no_world_write_adjust). This would normally warn you about violations, but we
+# can use Wazuh to continually monitor this.
+rhel10cis_rule_7_1_11: false
+rhel10cis_rule_7_1_12: false
+rhel10cis_rule_7_1_13: false
+
+# Don't configure selinux
+rhel10cis_selinux_disable: true
+
+# Disable setting of bootloader password
+rhel10cis_set_boot_pass: false
+
+##############################################################################
 # Ubuntu Noble CIS Hardening Configuration
 
 # Stop general "High Disruption" tasks

--- a/releasenotes/notes/add-cis-hardening-rocky-10-c4a411e24d9467fc.yaml
+++ b/releasenotes/notes/add-cis-hardening-rocky-10-c4a411e24d9467fc.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    CIS benchmark hardening has been implemented for Rocky 10 using the
+    RHEL10-CIS role. Rules overridden have been mapped to the overrides
+    previously used for Rocky 9.


### PR DESCRIPTION
CIS benchmark hardening has been implemented for Rocky 10 using the RHEL10-CIS[0] role. Rules we override have been mapped to the overrides previously used for Rocky 9.

0: https://github.com/ansible-lockdown/RHEL10-CIS