### PR TITLE
Update actions to org-wide pins

### DIFF
--- a/.github/workflows/stackhpc-build-kayobe-image.yml
+++ b/.github/workflows/stackhpc-build-kayobe-image.yml
@@ -56,7 +56,7 @@ jobs:
           submodules: true
 
       - name: Log in to the Container registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/stackhpc-container-image-build.yml
+++ b/.github/workflows/stackhpc-container-image-build.yml
@@ -361,7 +361,7 @@ jobs:
           find . -name 'push-attempt-images.txt' -exec cat {} + > all-pushed-images.txt
 
       - name: Log in to container registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ark.stackhpc.com
           username: ${{ secrets.RLS_TRAIN_CI_ARK_REGISTRY_USER }}


### PR DESCRIPTION
Updates GH actions to versions required by the organisation-wide whitelist: https://github.com/stackhpc/github-actions-list/blob/main/stackhpc.pinned.txt