### PR TITLE
Implement AIO testing for Rocky 10

### DIFF
--- a/.github/workflows/stackhpc-pull-request.yml
+++ b/.github/workflows/stackhpc-pull-request.yml
@@ -191,7 +191,43 @@ jobs:
     secrets: inherit
     if: ${{ ! failure() && ! cancelled() && github.repository == 'stackhpc/stackhpc-kayobe-config' }}
 
-  # Test two upgrade scenarios: Ubuntu Jammy to Noble OVN and Rocky 9 OVN.
+  all-in-one-rocky-10-ovs:
+    name: aio (Rocky 10 OVS)
+    permissions: {}
+    needs:
+      - check-changes
+      - build-kayobe-image
+    uses: ./.github/workflows/stackhpc-all-in-one.yml
+    with:
+      kayobe_image: ${{ needs.build-kayobe-image.outputs.kayobe_image }}
+      os_distribution: rocky
+      os_release: "10"
+      ssh_username: cloud-user
+      neutron_plugin: ovs
+      OS_CLOUD: openstack
+      if: ${{ needs.check-changes.outputs.aio == 'true' }}
+    secrets: inherit
+    if: ${{ ! failure() && ! cancelled() && github.repository == 'stackhpc/stackhpc-kayobe-config' }}
+
+  all-in-one-rocky-10-ovn:
+    name: aio (Rocky 10 OVN)
+    permissions: {}
+    needs:
+      - check-changes
+      - build-kayobe-image
+    uses: ./.github/workflows/stackhpc-all-in-one.yml
+    with:
+      kayobe_image: ${{ needs.build-kayobe-image.outputs.kayobe_image }}
+      os_distribution: rocky
+      os_release: "10"
+      ssh_username: cloud-user
+      neutron_plugin: ovn
+      OS_CLOUD: openstack
+      if: ${{ needs.check-changes.outputs.aio == 'true' }}
+    secrets: inherit
+    if: ${{ ! failure() && ! cancelled() && github.repository == 'stackhpc/stackhpc-kayobe-config' }}
+
+  # Test three upgrade scenarios: Ubuntu Jammy to Noble OVN and Rocky 9 OVN.
 
   all-in-one-upgrade-ubuntu-jammy-to-noble-ovn:
     name: aio upgrade (Ubuntu Jammy to Noble OVN)

--- a/etc/kayobe/environments/ci-aio/inventory/group_vars/controllers/network-interfaces
+++ b/etc/kayobe/environments/ci-aio/inventory/group_vars/controllers/network-interfaces
@@ -10,7 +10,7 @@ ethernet_interface: "{{ ansible_facts['default_ipv4']['interface'] }}"
 # Controller interface on all-in-one network.
 aio_interface: breth1
 # Use dummy1 if it exists, otherwise the bridge will have no ports.
-aio_bridge_ports: "{{ ['dummy1'] if ('dummy1' in hostvars[inventory_hostname].ansible_facts) or (os_distribution == 'rocky' and os_release == '9') else [] }}"
+aio_bridge_ports: "{{ ['dummy1'] if 'dummy1' in hostvars[inventory_hostname].ansible_facts or os_distribution == 'rocky' else [] }}"
 
 ###############################################################################
 # Dummy variable to allow Ansible to accept this file.

--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -12,6 +12,15 @@ kolla_base_distro_version: "{% raw %}{{ kolla_base_distro_version_default_map[ko
 # Convenience variable for base distro and version string.
 kolla_base_distro_and_version: "{% raw %}{{ kolla_base_distro }}-{{ kolla_base_distro_version }}{% endraw %}"
 
+# Override the version map used, so we can deploy Rocky 10 container images
+# on Rocky 10 hosts.
+kolla_base_distro_version_default_map: {
+  "centos": "stream9",
+  "debian": "bookworm",
+  "rocky": "{{ os_release }}",
+  "ubuntu": "noble",
+}
+
 # Dict of Kolla image tags to deploy for each service.
 # Each key is the tag variable prefix name, and the value is another dict,
 # where the key is the OS distro and the value is the tag to deploy.


### PR DESCRIPTION
New Rocky 10 AIO jobs added to the PR workflow. An override for `kolla_base_distro_version_default_map` has been added to Kolla globals so we can deploy Rocky 10 images (K-A maps to Rocky 9 by default).