### PR TITLE
Fix missed playbook paths update in 2025.1 docs

### DIFF
--- a/doc/source/operations/ceph-management.rst
+++ b/doc/source/operations/ceph-management.rst
@@ -27,7 +27,7 @@ Those groups are usually defined in ``$KAYOBE_CONFIG_PATH/inventory/groups``.
 Running Cephadm playbooks
 -------------------------
 
-In kayobe-config repository, under ``$KAYOBE_CONFIG_PATH/ansible`` there is a set of
+In kayobe-config repository, under ``$KAYOBE_CONFIG_PATH/ansible/ceph/`` there is a set of
 Cephadm based playbooks utilising stackhpc.cephadm Ansible Galaxy collection.
 
 ``cephadm.yml`` runs the end to end process of Cephadm deployment and

--- a/doc/source/operations/upgrading-openstack.rst
+++ b/doc/source/operations/upgrading-openstack.rst
@@ -1030,7 +1030,7 @@ or powered off:
 
 .. code-block:: console
 
-   kayobe playbook run $KAYOBE_CONFIG_PATH/ansible/nova-compute-{disable,drain}.yml --limit <host>
+   kayobe playbook run $KAYOBE_CONFIG_PATH/ansible/maintenance/nova-compute-{disable,drain}.yml --limit <host>
 
 To update all eligible packages, use ``*``, escaping if necessary:
 


### PR DESCRIPTION
Fixing playbook paths that were missed from [1]

[1] https://github.com/stackhpc/stackhpc-kayobe-config/pull/1744