### PR TITLE
Bump Pulp squeezer to latest version

### DIFF
--- a/etc/kayobe/ansible/pulp/pulp-artifact-upload.yml
+++ b/etc/kayobe/ansible/pulp/pulp-artifact-upload.yml
@@ -26,19 +26,10 @@
           - ndg-httpsclient
           - pyasn1
           - urllib3
+          - packaging
+          - pulp-glue<0.34.0,>=0.33.0
+          - pulp-glue-deb<0.4.0,>=0.3.0
         state: present
-
-    - name: Upload an artifact
-      pulp.squeezer.artifact:
-        pulp_url: "{{ remote_pulp_url }}"
-        username: "{{ remote_pulp_username }}"
-        password: "{{ remote_pulp_password }}"
-        file: "{{ found_files.files[0].path }}"
-        state: present
-      register: upload_result
-      until: upload_result is success
-      retries: 3
-      delay: 60
 
     - name: Get sha256 hash
       ansible.builtin.stat:
@@ -58,46 +49,6 @@
         checksum_algorithm: sha256
       register: checksum_stats
 
-    - name: Upload checksum artifact
-      pulp.squeezer.artifact:
-        pulp_url: "{{ remote_pulp_url }}"
-        username: "{{ remote_pulp_username }}"
-        password: "{{ remote_pulp_password }}"
-        file: "/tmp/{{ found_files.files[0].path | basename }}.sha256"
-        state: present
-      register: checksum_upload_result
-      until: checksum_upload_result is success
-      retries: 3
-      delay: 60
-      when: upload_checksum
-
-    - name: Create file content from artifact
-      pulp.squeezer.file_content:
-        pulp_url: "{{ remote_pulp_url }}"
-        username: "{{ remote_pulp_username }}"
-        password: "{{ remote_pulp_password }}"
-        sha256: "{{ file_stats.stat.checksum }}"
-        relative_path: "{{ found_files.files[0].path | basename }}"
-        state: present
-      register: file_content_result
-      until: file_content_result is success
-      retries: 3
-      delay: 5
-
-    - name: Create checksum content from artifact
-      pulp.squeezer.file_content:
-        pulp_url: "{{ remote_pulp_url }}"
-        username: "{{ remote_pulp_username }}"
-        password: "{{ remote_pulp_password }}"
-        sha256: "{{ checksum_stats.stat.checksum }}"
-        relative_path: "{{ found_files.files[0].path | basename }}.sha256"
-        state: present
-      register: checksum_content_result
-      until: checksum_content_result is success
-      retries: 3
-      delay: 5
-      when: upload_checksum
-
     - name: Ensure file repo exists
       pulp.squeezer.file_repository:
         pulp_url: "{{ remote_pulp_url }}"
@@ -110,31 +61,35 @@
       retries: 3
       delay: 5
 
-    - name: Add content to file repo
-      pulp.squeezer.file_repository_content:
+    - name: Upload artifact
+      pulp.squeezer.file_content:
         pulp_url: "{{ remote_pulp_url }}"
         username: "{{ remote_pulp_username }}"
         password: "{{ remote_pulp_password }}"
+        file: "{{ found_files.files[0].path }}"
+        sha256: "{{ file_stats.stat.checksum }}"
+        relative_path: "{{ found_files.files[0].path | basename }}"
+        state: present
         repository: "{{ repository_name }}"
-        present_content:
-          - relative_path: "{{ found_files.files[0].path | basename }}"
-            sha256: "{{ file_stats.stat.checksum }}"
-      register: file_repo_content_result
-      until: file_repo_content_result is success
+        chunk_size: 4194304
+      register: file_content_result
+      until: file_content_result is success
       retries: 3
       delay: 5
 
-    - name: Add checksum content to file repo
-      pulp.squeezer.file_repository_content:
+    - name: Upload checksum
+      pulp.squeezer.file_content:
         pulp_url: "{{ remote_pulp_url }}"
         username: "{{ remote_pulp_username }}"
         password: "{{ remote_pulp_password }}"
+        file: "/tmp/{{ found_files.files[0].path | basename }}.sha256"
+        sha256: "{{ checksum_stats.stat.checksum }}"
+        relative_path: "{{ found_files.files[0].path | basename }}.sha256"
+        state: present
         repository: "{{ repository_name }}"
-        present_content:
-          - relative_path: "{{ found_files.files[0].path | basename }}.sha256"
-            sha256: "{{ checksum_stats.stat.checksum }}"
-      register: checksum_repo_content_result
-      until: checksum_repo_content_result is success
+        chunk_size: 4194304
+      register: checksum_content_result
+      until: checksum_content_result is success
       retries: 3
       delay: 5
       when: upload_checksum

--- a/etc/kayobe/ansible/requirements.yml
+++ b/etc/kayobe/ansible/requirements.yml
@@ -2,12 +2,10 @@
 collections:
   - name: stackhpc.cephadm
     version: 1.22.0
-  # NOTE: Pinning pulp.squeezer to 0.0.13 because 0.0.14+ depends on the
-  # pulp_glue Python library being installed.
   - name: pulp.squeezer
-    version: 0.0.13
+    version: 0.3.0
   - name: stackhpc.pulp
-    version: 0.5.5
+    version: 0.6.0
   - name: stackhpc.hashicorp
     version: 2.7.1
   - name: stackhpc.kayobe_workflows

--- a/etc/kayobe/ansible/tools/push-ofed.yml
+++ b/etc/kayobe/ansible/tools/push-ofed.yml
@@ -21,28 +21,17 @@
         doca_modules_repo_base_path: "{{ doca_modules_repos.0.base_path }}"
         doca_modules_repo_distribution_name: "{{ doca_modules_repos.0.distribution_name }}"
 
-    - name: Install python dependencies
+    - name: Install pip packages
       ansible.builtin.pip:
-        name: pulp-cli
-
-    - name: Ensure Pulp configuration directory exists
-      ansible.builtin.file:
-        path: /home/stack/.config/pulp/
-        state: directory
-        recurse: true
-
-    - name: Setup Pulp credentials
-      ansible.builtin.blockinfile:
-        path: /home/stack/.config/pulp/cli.toml
-        create: true
-        block: |
-          [cli]
-          base_url = '{{ stackhpc_release_pulp_url }}'
-          verify_ssl = true
-          format = "json"
-          username = '{{ stackhpc_release_pulp_username }}'
-          password = '{{ stackhpc_release_pulp_password }}'
-      no_log: true
+        name:
+          - pyopenssl
+          - ndg-httpsclient
+          - pyasn1
+          - urllib3
+          - packaging
+          - pulp-glue<0.34.0,>=0.33.0
+          - pulp-glue-deb<0.4.0,>=0.3.0
+        state: present
 
     - name: Find DOCA kernel repo package
       ansible.builtin.shell:
@@ -60,15 +49,16 @@
       retries: "{{ pulp_timeout_retries | default(3) }}"
 
     - name: Upload OFED RPMs to Pulp
-      ansible.builtin.shell:
-        cmd: |
-          {{ venv }}/bin/pulp \
-          rpm content \
-          --type package upload \
-          --repository '{{ doca_modules_repo_name }}' \
-          --file {{ item }} \
-          --no-publish \
+      pulp.squeezer.rpm_package:
+        pulp_url: "{{ stackhpc_release_pulp_url }}"
+        username: "{{ stackhpc_release_pulp_username }}"
+        password: "{{ stackhpc_release_pulp_password }}"
+        file: "{{ item }}"
+        chunk_size: 4194304
+        repository: "{{ doca_modules_repo_name }}"
+        state: present
       with_items: "{{ doca_kernel_repo.stdout_lines }}"
+      register: package
 
     - name: Create Pulp publication for OFED
       pulp.squeezer.rpm_publication:

--- a/releasenotes/notes/squeezer-version-update-6bc582d64e6a6252.yaml
+++ b/releasenotes/notes/squeezer-version-update-6bc582d64e6a6252.yaml
@@ -1,0 +1,13 @@
+---
+upgrade:
+  - |
+    New versions of ``pulp.squeezer`` (0.3.0) and ``stackhpc.pulp`` (0.6.0)
+    are available, these collections and their dependencies can be updated
+    by running a control host bootstrap.
+features:
+  - |
+    The ``pulp.squeezer`` collection has been updated to the latest version
+    (0.3.0), with dependencies added and updated as required. The
+    ``stackhpc.pulp`` collection has also been updated to it's latest version
+    (0.6.0). Combined, these two updates drastically improve the time taken
+    for artifacts to be pushed to and pulled from Ark.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 kayobe@git+https://github.com/stackhpc/kayobe@stackhpc/18.3.0.18
 ansible-modules-hashivault>=5.3.0
-pulp-glue<0.32,>=0.29.2
+pulp-glue==0.33.*
+pulp-glue-deb==0.3.*
 jmespath


### PR DESCRIPTION
Bumps Pulp squeezer to version 0.3.0, along with bumping and adding required dependencies.

The `chunk_size` parameter has been set to 4194304 bytes in `pulp.squeezer.file_content` tasks to workaround a Python bug[0] relating to SSL errors with large requests (fixed in 3.13).

Co-Authored-by: Alex Welsh <alex@stackhpc.com>

0: https://github.com/python/cpython/issues/110467