### PR TITLE
VAST support

### DIFF
--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -7,6 +7,10 @@ kolla_image_tags:
     rocky-9: 2025.1-rocky-9-20260205T152450
     rocky-10: 2025.1-rocky-10-20260423T154048
     ubuntu-noble: 2025.1-ubuntu-noble-20260205T152450
+  cinder:
+    rocky-9: 2025.1-rocky-9-20260512T204620
+    rocky-10: 2025.1-rocky-10-20260529T102322
+    ubuntu-noble: 2025.1-ubuntu-noble-20260515T083354
   etcd:
     rocky-9: 2025.1-rocky-9-20260303T104901
   glance:
@@ -31,6 +35,10 @@ kolla_image_tags:
   magnum:
     rocky-9: 2025.1-rocky-9-20260413T112937
     ubuntu-noble: 2025.1-ubuntu-noble-20260413T112937
+  manila:
+    rocky-9: 2025.1-rocky-9-20260511T100757
+    rocky-10: 2025.1-rocky-10-20260529T102322
+    ubuntu-noble: 2025.1-ubuntu-noble-20260515T083354
   multipathd:
     rocky-9: 2025.1-rocky-9-20260421T115054
     ubuntu-noble: 2025.1-ubuntu-noble-20260421T115054

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -131,6 +131,10 @@ kolla_sources:
     type: git
     location: https://github.com/stackhpc/stackhpc-inspector-plugins.git
     reference: 1.3.0
+  cinder-base:
+    type: git
+    location: https://github.com/stackhpc/cinder.git
+    reference: stackhpc/{{ openstack_release }}
   horizon-plugin-cloudkitty-dashboard:
     type: git
     location: https://github.com/stackhpc/cloudkitty-dashboard.git
@@ -145,6 +149,10 @@ kolla_sources:
     sha256:
       amd64: 70b2c30a19da4db264dfd68c8a3664e05093a361cefd89572ffb36f8abfa3d09
       arm64: 13d03672be289045d2ff00e4e345d61de1c6f21c1257a45955a30e8ae036d8f1
+  manila-base:
+    type: git
+    location: https://github.com/stackhpc/manila.git
+    reference: stackhpc/{{ openstack_release }}
   neutron-base-plugin-networking-generic-switch:
     type: git
     location: https://github.com/stackhpc/networking-generic-switch.git

--- a/releasenotes/notes/vast-images-2025.1-3f81aaf7f5c9188f.yaml
+++ b/releasenotes/notes/vast-images-2025.1-3f81aaf7f5c9188f.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Adds Cinder support for VAST storage backends and Manila support for VAST
+    multitenancy.


### PR DESCRIPTION
Update images to include VAST support for Cinder and VAST multitenancy support for Manila.

- Cinder: https://github.com/stackhpc/cinder/pull/128
- Manila: https://github.com/stackhpc/manila/pull/7