### PR TITLE
Separate aarch64 container builds onto different vms

### DIFF
--- a/.github/workflows/stackhpc-container-image-build.yml
+++ b/.github/workflows/stackhpc-container-image-build.yml
@@ -107,11 +107,11 @@ jobs:
           output="{'distro': ["
           if [[ ${{ inputs.rocky-linux-9 }} == 'true' ]]; then
               output+="{'name': 'rocky', 'release': 9, 'arch': 'amd64'},"
-              output+="{'name': 'rocky', 'release': 9, 'arch': 'aarch64'},"
+              output+="{'name': 'rocky', 'release': 9, 'arch': 'aarch64', 'runner': 'sms'},"
           fi
           if [[ ${{ inputs.rocky-linux-10 }} == 'true' ]]; then
               output+="{'name': 'rocky', 'release': 10, 'arch': 'amd64'},"
-              output+="{'name': 'rocky', 'release': 10, 'arch': 'aarch64'},"
+              output+="{'name': 'rocky', 'release': 10, 'arch': 'aarch64', 'runner': 'sms-alternate'},"
           fi
           if [[ ${{ inputs.ubuntu-noble }} == 'true' ]]; then
               output+="{'name': 'ubuntu', 'release': 'noble', 'arch': 'amd64'},"
@@ -134,7 +134,7 @@ jobs:
     name: Build Kolla container images
     if: github.repository == 'stackhpc/stackhpc-kayobe-config'
     runs-on: ${{ matrix.distro.arch == 'aarch64'
-      && fromJson('["self-hosted","sms","arm64"]')
+      && fromJson(format('["self-hosted", "{0}", "arm64"]', matrix.distro.runner))
       || needs.runner-selection.outputs.runner_name_container_image_build }}
     timeout-minutes: 720
     permissions: {}


### PR DESCRIPTION
As a short-term solution to aarch64 container build jobs experiencing apt lock conflicts, we now have two additional aarch64 actions runners on a separate vm which Rocky 10 builds will fall on to.

[Test build](https://github.com/stackhpc/stackhpc-kayobe-config/actions/runs/26103938346/job/76762434780)