### PR TITLE
 fix: configure `requests` to use `CA` for `Pulp`

### DIFF
--- a/etc/kayobe/ansible/pulp/pulp-container-publish.yml
+++ b/etc/kayobe/ansible/pulp/pulp-container-publish.yml
@@ -9,3 +9,9 @@
       # NOTE: use intermediate variable to avoid distributing RPMs.
       vars:
         pulp_distribution_container: "{{ stackhpc_pulp_distribution_container }}"
+      environment: >-
+        {{
+          {
+            'REQUESTS_CA_BUNDLE': stackhpc_requests_ca_bundle
+          } if pulp_enable_tls | bool else {}
+        }}

--- a/etc/kayobe/ansible/pulp/pulp-container-sync.yml
+++ b/etc/kayobe/ansible/pulp/pulp-container-sync.yml
@@ -1,7 +1,7 @@
 ---
 - name: Sync client Pulp container repositories
   hosts: localhost
-  gather_facts: false
+  gather_facts: true
   tasks:
     - name: Sync Pulp container repositories
       ansible.builtin.import_role:
@@ -9,3 +9,9 @@
       # NOTE: use intermediate variable to avoid syncing RPMs.
       vars:
         pulp_repository_container_repos: "{{ stackhpc_pulp_repository_container_repos }}"
+      environment: >-
+        {{
+          {
+            'REQUESTS_CA_BUNDLE': stackhpc_requests_ca_bundle
+          } if pulp_enable_tls | bool else {}
+        }}

--- a/etc/kayobe/ansible/pulp/pulp-repo-promote-production.yml
+++ b/etc/kayobe/ansible/pulp/pulp-repo-promote-production.yml
@@ -9,3 +9,9 @@
       vars:
         pulp_distribution_deb: "{{ stackhpc_pulp_distribution_deb_production | selectattr('required') }}"
         pulp_distribution_rpm: "{{ stackhpc_pulp_distribution_rpm_production | selectattr('required') }}"
+      environment: >-
+        {{
+          {
+            'REQUESTS_CA_BUNDLE': stackhpc_requests_ca_bundle
+          } if pulp_enable_tls | bool else {}
+        }}

--- a/etc/kayobe/ansible/pulp/pulp-repo-publish.yml
+++ b/etc/kayobe/ansible/pulp/pulp-repo-publish.yml
@@ -1,7 +1,7 @@
 ---
 - name: Publish Pulp repositories
   hosts: localhost
-  gather_facts: false
+  gather_facts: true
   tasks:
     - name: Ensure repository publications exist
       ansible.builtin.import_role:
@@ -10,6 +10,12 @@
       vars:
         pulp_publication_deb: "{{ stackhpc_pulp_publication_deb_development | selectattr('required') }}"
         pulp_publication_rpm: "{{ stackhpc_pulp_publication_rpm_development | selectattr('required') }}"
+      environment: >-
+        {{
+          {
+            'REQUESTS_CA_BUNDLE': stackhpc_requests_ca_bundle
+          } if pulp_enable_tls | bool else {}
+        }}
 
     - name: Ensure repository distributions exist
       ansible.builtin.import_role:
@@ -17,3 +23,9 @@
       vars:
         pulp_distribution_deb: "{{ stackhpc_pulp_distribution_deb_development | selectattr('required') }}"
         pulp_distribution_rpm: "{{ stackhpc_pulp_distribution_rpm_development | selectattr('required') }}"
+      environment: >-
+        {{
+          {
+            'REQUESTS_CA_BUNDLE': stackhpc_requests_ca_bundle
+          } if pulp_enable_tls | bool else {}
+        }}

--- a/etc/kayobe/ansible/pulp/pulp-repo-sync.yml
+++ b/etc/kayobe/ansible/pulp/pulp-repo-sync.yml
@@ -1,7 +1,7 @@
 ---
 - name: Sync Pulp repositories
   hosts: localhost
-  gather_facts: false
+  gather_facts: true
   tasks:
     - name: Sync Pulp repositories
       ansible.builtin.import_role:
@@ -10,3 +10,9 @@
       vars:
         pulp_repository_deb_repos: "{{ stackhpc_pulp_repository_deb_repos | selectattr('required') }}"
         pulp_repository_rpm_repos: "{{ stackhpc_pulp_repository_rpm_repos | selectattr('required') }}"
+      environment: >-
+        {{
+          {
+            'REQUESTS_CA_BUNDLE': stackhpc_requests_ca_bundle
+          } if pulp_enable_tls else {}
+        }}

--- a/etc/kayobe/pulp.yml
+++ b/etc/kayobe/pulp.yml
@@ -62,6 +62,14 @@ stackhpc_release_pulp_content_url_with_auth: "{{ stackhpc_release_pulp_scheme }}
 # NOTE: Only RPM repositories are supported.
 stackhpc_pulp_sync_for_local_container_build: false
 
+# Set the CA bundle used by Python `requests`.
+stackhpc_requests_ca_bundle: >-
+  {{
+    '/etc/pki/tls/certs/ca-bundle.crt'
+    if ansible_facts.os_family == 'RedHat'
+    else '/etc/ssl/certs/ca-certificates.crt'
+  }}
+
 ###############################################################################
 # Debs
 

--- a/releasenotes/notes/fix-pulp-requests-ca-2a73ac6cffd433b4.yaml
+++ b/releasenotes/notes/fix-pulp-requests-ca-2a73ac6cffd433b4.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Support use of ``pulp_enable_tls`` in combination with the newer
+    ``pulp`` collection by configuring ``requests`` to use ``CA``
+    bundle where internal ``PKI`` is configured.


### PR DESCRIPTION
The `Pulp` playbooks used at client sites can fail when `Pulp` is configured to use TLS with certificates generated by our internal `TLS` process in combination with the newer `Pulp` collection and tools.