### PR TITLE
Fix artifact promotion playbook

### DIFF
--- a/etc/kayobe/ansible/pulp/pulp-artifact-promote.yml
+++ b/etc/kayobe/ansible/pulp/pulp-artifact-promote.yml
@@ -16,7 +16,6 @@
         username: "{{ remote_pulp_username }}"
         password: "{{ remote_pulp_password }}"
         name: "{{ repository_name }}_{{ promotion_tag }}"
-        base_path: "{{ pulp_base_path }}/{{ promotion_tag }}"
       register: distribution_details
       until: distribution_details is success
       retries: 3

--- a/releasenotes/notes/fix-artifact-promote-9f178086f00f0c63.yaml
+++ b/releasenotes/notes/fix-artifact-promote-9f178086f00f0c63.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fix for pulp artifact promotion playbook following on from updates
+    to pulp.squeezer collection - the ``base_path`` attribute cannot be
+    used when querying a file distribution.


### PR DESCRIPTION
`base_path` can't be set when querying for a distribution - "Cannot use attributes when querying entities"

[Before](https://github.com/stackhpc/stackhpc-kayobe-config/actions/runs/26155212403)
[After](https://github.com/stackhpc/stackhpc-kayobe-config/actions/runs/26158140656)