### PR TITLE
IPA image updates for Rocky 10

### DIFF
--- a/.github/workflows/ipa-image-build.yml
+++ b/.github/workflows/ipa-image-build.yml
@@ -71,8 +71,8 @@ jobs:
           echo "ipa_image_tag=$(date +${{ steps.openstack_release.outputs.openstack_release }}-%Y%m%dT%H%M%S)" >> $GITHUB_OUTPUT
 
   ipa-image-build:
-    name: Build IPA images
-    if: github.repository == 'stackhpc/stackhpc-kayobe-config'
+    name: Build IPA images (x86_64)
+    if: github.repository == 'stackhpc/stackhpc-kayobe-config' && (inputs.rocky9 || inputs.ubuntu-noble)
     environment: ${{ inputs.runner_env }}
     runs-on: ${{ needs.runner-selection.outputs.runner_name_image_build }}
     needs:
@@ -130,15 +130,19 @@ jobs:
           cat << EOF > terraform.tfvars
           ssh_public_key = "id_rsa.pub"
           ssh_username = "ubuntu"
-          aio_vm_name = "skc-ipa-image-builder"
+          aio_vm_name = "${{ env.VM_NAME }}"
           aio_vm_image = "${{ vars.HOST_IMAGE_BUILD_IMAGE }}"
           aio_vm_flavor = "${{ vars.HOST_IMAGE_BUILD_FLAVOR }}"
           aio_vm_network = "${{ vars.HOST_IMAGE_BUILD_NETWORK }}"
           aio_vm_subnet = "${{ vars.HOST_IMAGE_BUILD_SUBNET }}"
           aio_vm_interface = "ens3"
           aio_vm_volume_size = "${{ vars.HOST_IMAGE_BUILD_VOLUME }}"
+          aio_vm_tags = ${{ env.VM_TAGS }}
           EOF
         working-directory: ${{ github.workspace }}/src/kayobe-config/terraform/aio
+        env:
+          VM_NAME: "skc-ipa-image-builder-${{ github.run_id }}"
+          VM_TAGS: '["skc-host-image-build"]'
 
       - name: Terraform Plan
         run: terraform plan
@@ -236,10 +240,8 @@ jobs:
           source venvs/kayobe/bin/activate &&
           source src/kayobe-config/kayobe-env --environment ci-builder &&
           kayobe overcloud deployment image build --force-rebuild \
-          -e os_distribution="ubuntu" \
-          -e os_release="noble" \
-          -e ipa_ci_builder_distribution="ubuntu" \
-          -e ipa_ci_builder_release="noble"
+          -e ipa_build_distro="ubuntu" \
+          -e ipa_build_release="noble"
         env:
           KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
         if: inputs.ubuntu-noble
@@ -286,6 +288,13 @@ jobs:
           KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
         if: inputs.ubuntu-noble && steps.build_ubuntu_noble_ipa.outcome == 'success'
 
+      - name: Copy logs back
+        continue-on-error: true
+        run: |
+          mkdir -p logs/ubuntu-noble
+          scp -r ubuntu@$(jq -r .access_ip_v4.value src/kayobe-config/etc/kayobe/environments/ci-builder/tf-outputs.yml):/opt/kayobe/images/*/*.std* ./logs/ubuntu-noble/
+        if: inputs.ubuntu-noble
+
       - name: Build a Rocky 9 IPA image
         id: build_rocky_9_ipa
         continue-on-error: true
@@ -293,10 +302,8 @@ jobs:
           source venvs/kayobe/bin/activate &&
           source src/kayobe-config/kayobe-env --environment ci-builder &&
           kayobe overcloud deployment image build --force-rebuild \
-          -e os_distribution="rocky" \
-          -e os_release="9" \
-          -e ipa_ci_builder_distribution="rocky" \
-          -e ipa_ci_builder_release="9"
+          -e ipa_build_distro="centos" \
+          -e ipa_build_release="9-stream"
         env:
           KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
         if: inputs.rocky9
@@ -346,9 +353,9 @@ jobs:
       - name: Copy logs back
         continue-on-error: true
         run: |
-          mkdir logs
-          scp -r ubuntu@$(jq -r .access_ip_v4.value src/kayobe-config/etc/kayobe/environments/ci-builder/tf-outputs.yml):/opt/kayobe/images/*/*.std* ./logs/
-        if: always()
+          mkdir -p logs/rocky-9
+          scp -r ubuntu@$(jq -r .access_ip_v4.value src/kayobe-config/etc/kayobe/environments/ci-builder/tf-outputs.yml):/opt/kayobe/images/*/*.std* ./logs/rocky-9/
+        if: inputs.rocky9
 
       - name: Upload logs artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
@@ -373,7 +380,7 @@ jobs:
         if: always()
 
   ipa-image-build-aarch64:
-    name: Build Rocky 9 aarch64 IPA image
+    name: Build IPA images (aarch64)
     if: github.repository == 'stackhpc/stackhpc-kayobe-config' && inputs.rocky9-aarch64 && inputs.runner_env == 'SMS Lab'
     environment: ${{ inputs.runner_env }}
     runs-on: ${{ needs.runner-selection.outputs.runner_name_image_build }}
@@ -432,15 +439,19 @@ jobs:
           cat << EOF > terraform.tfvars
           ssh_public_key = "id_rsa.pub"
           ssh_username = "ubuntu"
-          aio_vm_name = "skc-ipa-image-builder-arm64"
+          aio_vm_name = "${{ env.VM_NAME }}"
           aio_vm_image = "${{ vars.HOST_IMAGE_BUILD_IMAGE_ARM64 }}"
           aio_vm_flavor = "${{ vars.HOST_IMAGE_BUILD_FLAVOR }}"
           aio_vm_network = "${{ vars.HOST_IMAGE_BUILD_NETWORK }}"
           aio_vm_subnet = "${{ vars.HOST_IMAGE_BUILD_SUBNET }}"
           aio_vm_interface = "ens3"
           aio_vm_volume_size = "${{ vars.HOST_IMAGE_BUILD_VOLUME }}"
+          aio_vm_tags = ${{ env.VM_TAGS }}
           EOF
         working-directory: ${{ github.workspace }}/src/kayobe-config/terraform/aio
+        env:
+          VM_NAME: "skc-ipa-image-builder-arm64-${{ github.run_id }}"
+          VM_TAGS: '["skc-host-image-build"]'
 
       - name: Terraform Plan
         run: terraform plan
@@ -538,13 +549,12 @@ jobs:
           source venvs/kayobe/bin/activate &&
           source src/kayobe-config/kayobe-env --environment ci-builder &&
           kayobe overcloud deployment image build --force-rebuild \
-          -e os_distribution="rocky" \
-          -e os_release="9" \
-          -e ipa_ci_builder_distribution="rocky" \
-          -e ipa_ci_builder_release="9" \
-          -e ipa_ci_builder_arch="aarch64"
+          -e ipa_build_distro="centos" \
+          -e ipa_build_release="9-stream" \
+          -e ipa_build_arch="aarch64"
         env:
           KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
+        if: inputs.rocky9-aarch64
 
       - name: Show last error logs
         continue-on-error: true
@@ -595,9 +605,9 @@ jobs:
       - name: Copy logs back
         continue-on-error: true
         run: |
-          mkdir logs
-          scp -r ubuntu@$(jq -r .access_ip_v4.value src/kayobe-config/etc/kayobe/environments/ci-builder/tf-outputs.yml):/opt/kayobe/images/*/*.std* ./logs/
-        if: always()
+          mkdir -p logs/rocky-9
+          scp -r ubuntu@$(jq -r .access_ip_v4.value src/kayobe-config/etc/kayobe/environments/ci-builder/tf-outputs.yml):/opt/kayobe/images/*/*.std* ./logs/rocky-9/
+        if: inputs.rocky9-aarch64
 
       - name: Upload logs artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/etc/kayobe/environments/ci-builder/stackhpc-ci.yml
+++ b/etc/kayobe/environments/ci-builder/stackhpc-ci.yml
@@ -120,7 +120,7 @@ stackhpc_release_pulp_password: "{{ stackhpc_docker_registry_password }}"
 
 # Build during IPA builder workflow
 ipa_build_images: true
-ipa_build_dib_env_extra: "{{ {'DISTRO_NAME': ipa_ci_builder_distribution | default('ubuntu'), 'DIB_RELEASE': ipa_ci_builder_release | default('noble')} | combine({'ARCH': ipa_ci_builder_arch} if ipa_ci_builder_arch is defined else {}) }}"
+ipa_build_dib_env_extra: "{{ {'DISTRO_NAME': ipa_build_distro | default('ubuntu')} | combine({'ARCH': ipa_build_arch} if ipa_build_arch is defined else {}) }}"
 
 # Ensure Ark repos are disabled during CI runs, this is due to
 # builder being a member of the 'overcloud' group for IPA builds.

--- a/etc/kayobe/environments/ci-tenks/inventory/group_vars/compute/network-interfaces
+++ b/etc/kayobe/environments/ci-tenks/inventory/group_vars/compute/network-interfaces
@@ -2,17 +2,17 @@
 ###############################################################################
 # Network interface definitions for the compute group.
 
-provision_oc_interface: "{{ 'ens2' if os_distribution == 'ubuntu' else 'eth0' }}"
+provision_oc_interface: "{{ 'eth0' if os_distribution == 'rocky' and os_release == '9' else 'ens2' }}"
 # Route via the seed-hypervisor to the outside world.
 provision_oc_gateway: 192.168.33.4
 
-internal_interface: "{{ 'ens3' if os_distribution == 'ubuntu' else 'eth1' }}.{{ internal_vlan }}"
+internal_interface: "{{ 'eth1' if os_distribution == 'rocky' and os_release == '9' else 'ens3' }}.{{ internal_vlan }}"
 
-storage_interface: "{{ 'ens3' if os_distribution == 'ubuntu' else 'eth1' }}.{{ storage_vlan }}"
+storage_interface: "{{ 'eth1' if os_distribution == 'rocky' and os_release == '9' else 'ens3' }}.{{ storage_vlan }}"
 
-tunnel_interface: "{{ 'ens3' if os_distribution == 'ubuntu' else 'eth1' }}.{{ tunnel_vlan }}"
+tunnel_interface: "{{ 'eth1' if os_distribution == 'rocky' and os_release == '9' else 'ens3' }}.{{ tunnel_vlan }}"
 
-external_interface: "{{ 'ens3' if os_distribution == 'ubuntu' else 'eth1' }}.{{ external_vlan }}"
+external_interface: "{{ 'eth1' if os_distribution == 'rocky' and os_release == '9' else 'ens3' }}.{{ external_vlan }}"
 
 ###############################################################################
 # Dummy variable to allow Ansible to accept this file.

--- a/etc/kayobe/environments/ci-tenks/inventory/group_vars/controllers/network-interfaces
+++ b/etc/kayobe/environments/ci-tenks/inventory/group_vars/controllers/network-interfaces
@@ -2,25 +2,25 @@
 ###############################################################################
 # Network interface definitions for the controller group.
 
-provision_oc_interface: "{{ 'ens2' if os_distribution == 'ubuntu' else 'eth0' }}"
+provision_oc_interface: "{{ 'eth0' if os_distribution == 'rocky' and os_release == '9' else 'ens2' }}"
 # Route via the seed-hypervisor to the outside world.
 provision_oc_gateway: 192.168.33.4
 
-mgmt_interface: "{{ 'ens3' if os_distribution == 'ubuntu' else 'eth1' }}"
+mgmt_interface: "{{ 'eth1' if os_distribution == 'rocky' and os_release == '9' else 'ens3' }}"
 
-provision_wl_interface: "br{{ 'ens4' if os_distribution == 'ubuntu' else 'eth2' }}"
+provision_wl_interface: "br{{ 'eth2' if os_distribution == 'rocky' and os_release == '9' else 'ens4' }}"
 provision_wl_bridge_ports:
-  - "{{ 'ens4' if os_distribution == 'ubuntu' else 'eth2' }}"
+  - "{{ 'eth2' if os_distribution == 'rocky' and os_release == '9' else 'ens4' }}"
 
-internal_interface: "{{ 'ens4' if os_distribution == 'ubuntu' else 'eth2' }}.{{ internal_vlan }}"
+internal_interface: "{{ 'eth2' if os_distribution == 'rocky' and os_release == '9' else 'ens4' }}.{{ internal_vlan }}"
 
-external_interface: "br{{ 'ens4' if os_distribution == 'ubuntu' else 'eth2' }}.{{ external_vlan }}"
+external_interface: "br{{ 'eth2' if os_distribution == 'rocky' and os_release == '9' else 'ens4' }}.{{ external_vlan }}"
 
-public_interface: "{{ 'ens4' if os_distribution == 'ubuntu' else 'eth2' }}.{{ public_vlan }}"
+public_interface: "{{ 'eth2' if os_distribution == 'rocky' and os_release == '9' else 'ens4' }}.{{ public_vlan }}"
 
-storage_interface: "{{ 'ens4' if os_distribution == 'ubuntu' else 'eth2' }}.{{ storage_vlan }}"
+storage_interface: "{{ 'eth2' if os_distribution == 'rocky' and os_release == '9' else 'ens4' }}.{{ storage_vlan }}"
 
-tunnel_interface: "{{ 'ens4' if os_distribution == 'ubuntu' else 'eth2' }}.{{ tunnel_vlan }}"
+tunnel_interface: "{{ 'eth2' if os_distribution == 'rocky' and os_release == '9' else 'ens4' }}.{{ tunnel_vlan }}"
 
 ###############################################################################
 # Dummy variable to allow Ansible to accept this file.

--- a/etc/kayobe/environments/ci-tenks/inventory/group_vars/seed/network-interfaces
+++ b/etc/kayobe/environments/ci-tenks/inventory/group_vars/seed/network-interfaces
@@ -2,9 +2,9 @@
 ###############################################################################
 # Network interface definitions for the seed group.
 
-mgmt_interface: "{{ 'ens2' if os_distribution == 'ubuntu' else 'eth0' }}"
+mgmt_interface: "{{ 'eth0' if os_distribution == 'rocky' and os_release == '9' else 'ens2' }}"
 
-provision_oc_interface: "{{ 'ens3' if os_distribution == 'ubuntu' else 'eth1' }}"
+provision_oc_interface: "{{ 'eth1' if os_distribution == 'rocky' and os_release == '9' else 'ens3' }}"
 # Route via the seed-hypervisor to the outside world.
 provision_oc_gateway: 192.168.33.4
 

--- a/etc/kayobe/environments/ci-tenks/inventory/group_vars/storage/network-interfaces
+++ b/etc/kayobe/environments/ci-tenks/inventory/group_vars/storage/network-interfaces
@@ -2,15 +2,15 @@
 ###############################################################################
 # Network interface definitions for the compute group.
 
-provision_oc_interface: "{{ 'ens2' if os_distribution == 'ubuntu' else 'eth0' }}"
+provision_oc_interface: "{{ 'eth0' if os_distribution == 'rocky' and os_release == '9' else 'ens2' }}"
 # Route via the seed-hypervisor to the outside world.
 provision_oc_gateway: 192.168.33.4
 
-internal_interface: "{{ 'ens3' if os_distribution == 'ubuntu' else 'eth1' }}.{{ internal_vlan }}"
+internal_interface: "{{ 'eth1' if os_distribution == 'rocky' and os_release == '9' else 'ens3' }}.{{ internal_vlan }}"
 
-storage_interface: "{{ 'ens3' if os_distribution == 'ubuntu' else 'eth1' }}.{{ storage_vlan }}"
+storage_interface: "{{ 'eth1' if os_distribution == 'rocky' and os_release == '9' else 'ens3' }}.{{ storage_vlan }}"
 
-storage_mgmt_interface: "{{ 'ens3' if os_distribution == 'ubuntu' else 'eth1' }}.{{ storage_mgmt_vlan }}"
+storage_mgmt_interface: "{{ 'eth1' if os_distribution == 'rocky' and os_release == '9' else 'ens3' }}.{{ storage_mgmt_vlan }}"
 
 ###############################################################################
 # Dummy variable to allow Ansible to accept this file.

--- a/etc/kayobe/stackhpc-ipa-images.yml
+++ b/etc/kayobe/stackhpc-ipa-images.yml
@@ -12,15 +12,20 @@ stackhpc_ipa_image_overcloud_enabled: true
 # Options are "amd64" and "aarch64".
 stackhpc_ipa_arch: amd64
 
+# NOTE(owenjones): for now we'll override the release used so we use CentOS
+# Stream 9 IPA images on both Rocky 9 and 10 - remove once Rocky 10 IPA images
+# are stable.
+stackhpc_ipa_release: "{{ '9' if os_distribution == 'rocky' and os_release == '10' else os_release }}"
+
 # The IPA image source, defined by os_distribution,
 # os_release, and the current stable version.
 stackhpc_ipa_image_url: "{{ stackhpc_release_pulp_content_url }}/ipa-images/\
                          {{ openstack_release }}/{{ os_distribution }}/\
-                         {{ os_release }}{{ '/aarch64' if os_distribution == 'rocky' and stackhpc_ipa_arch == 'aarch64' else '' }}/\
+                         {{ stackhpc_ipa_release }}{{ '/aarch64' if os_distribution == 'rocky' and stackhpc_ipa_arch == 'aarch64' else '' }}/\
                          {{ stackhpc_ipa_image_version }}"
 
 # IPA image version tag selection
 stackhpc_ipa_image_version: >-
-  {{ stackhpc_rocky_9_ipa_image_version_aarch64 if os_distribution == 'rocky' and os_release == '9' and stackhpc_ipa_arch == 'aarch64' else
-  stackhpc_rocky_9_ipa_image_version if os_distribution == 'rocky' and os_release == '9' else
+  {{ stackhpc_rocky_9_ipa_image_version_aarch64 if os_distribution == 'rocky' and stackhpc_ipa_arch == 'aarch64' else
+  stackhpc_rocky_9_ipa_image_version if os_distribution == 'rocky' else
   stackhpc_ubuntu_noble_ipa_image_version if os_distribution == 'ubuntu' and os_release == 'noble' }}

--- a/releasenotes/notes/rocky-10-centos-ipa-3c3e6a34ba86cb60.yaml
+++ b/releasenotes/notes/rocky-10-centos-ipa-3c3e6a34ba86cb60.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Updates to IPA image selection to continue using the CentOS Stream 9
+    images with Rocky 10, until Rocky 10 IPA images are stable.

--- a/releasenotes/notes/update-ipa-building-06b4d0134ae02932.yaml
+++ b/releasenotes/notes/update-ipa-building-06b4d0134ae02932.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    IPA building now uses the Kayobe ``ipa_build_distro`` and
+    ``ipa_build_release`` overrides to build, in preparation
+    for building pure Rocky IPA images.

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -38,3 +38,10 @@
       nodes:
         - name: rocky-9-tenks
           label: rocky-9-tenks
+- job:
+    name: tenks-rocky-10
+    parent: tenks-base
+    nodeset:
+      nodes:
+        - name: rocky-10-tenks
+          label: rocky-10-tenks

--- a/zuul.d/project.yaml
+++ b/zuul.d/project.yaml
@@ -9,9 +9,11 @@
       jobs:
         - tenks-ubuntu-noble
         - tenks-rocky-9
+        - tenks-rocky-10
 
     gate:
       jobs:
         - openstack-tox-pep8
         - tenks-ubuntu-noble
         - tenks-rocky-9
+        - tenks-rocky-10


### PR DESCRIPTION
* Updates to IPA build workflow to use new Kayobe overrides, and improve running ([test build](https://github.com/stackhpc/stackhpc-kayobe-config/actions/runs/26276868014))
* Update to IPA image selection to continue using CentOS Stream 9 IPA images with Rocky 10
* Update to ci-tenks environment network interfaces
* Additional Zuul job (`tenks-rocky-10`) for check-review pipeline