### PR TITLE
feat: add `retries` to `ssh_connection`

### DIFF
--- a/etc/kayobe/ansible.cfg
+++ b/etc/kayobe/ansible.cfg
@@ -20,3 +20,4 @@ any_unparsed_is_failed = True
 [ssh_connection]
 pipelining = True
 ssh_extra_args = -o ControlPersist=1h
+retries = 3


### PR DESCRIPTION
Some environments do not have a stable provisioning network and it is common to observe

```
Data could not be sent to remote host "10.144.0.174". Make sure this
host can be reached over ssh: ssh: connect to host 10.144.0.174
port 22: No route to host
```

By setting `retries` in `ssh_connection` these outages have not be observed.