### PR TITLE
Add GitHub workflows to auto-label PRs

### DIFF
--- a/.github/workflows/stackhpc-pr-review.yml
+++ b/.github/workflows/stackhpc-pr-review.yml
@@ -1,0 +1,25 @@
+---
+name: Handle GitHub PR Review responses
+
+on:
+  pull_request_review:
+    types:
+      - submitted
+
+permissions:
+  pull-requests: write
+
+jobs:
+  # Label PR as "waiting-author-response" when changes are requested
+  review-changes-requested:
+    runs-on: ubuntu-latest
+    if: github.event.review.state == 'changes_requested' && github.repository == 'stackhpc/stackhpc-kayobe-config'
+    steps:
+      - name: Update PR Labels
+        run: |
+          gh pr edit "$PR_NUMBER" --remove-label "waiting-review" || true
+          gh pr edit "$PR_NUMBER" --add-label "waiting-author-response"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/stackhpc-pull-request.yml
+++ b/.github/workflows/stackhpc-pull-request.yml
@@ -8,6 +8,20 @@ name: Pull request
 'on':
   pull_request:
 jobs:
+  # Label all newly-opened PRs as "waiting-review"
+  auto-label:
+    runs-on: ubuntu-latest
+    if: github.event.action == 'opened' && github.repository == 'stackhpc/stackhpc-kayobe-config'
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Add waiting-review label
+        run: gh pr edit "$PR_NUMBER" --add-label "waiting-review"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+
   # Detect which files have changed and use this to run jobs conditionally.
   # Note that we can't use the workflow-level paths attribute since this
   # would skip the workflow entirely, and would prevent us from making the


### PR DESCRIPTION
Adds two new jobs:
One labels PRs with "waiting-review" when they are opened
The other changes the label to "waiting-author-response" when it is reviewed as "Changes requested"
