### PR TITLE
CI: add aarch64 Rocky AIO jobs

### DIFF
--- a/.github/workflows/stackhpc-all-in-one.yml
+++ b/.github/workflows/stackhpc-all-in-one.yml
@@ -23,6 +23,10 @@ on:
         description: Host OS release
         type: string
         default: '9'
+      architecture:
+        description: Host architecture
+        type: string
+        default: x86_64
       ssh_username:
         description: User for terraform to access the all-in-one VM
         type: string
@@ -126,14 +130,14 @@ jobs:
       - name: Output image tag
         id: image_tag
         run: |
-          echo image_tag=$(grep stackhpc_${{ inputs.os_distribution }}_$(sed s/-/_/ <(echo "${{ inputs.os_release }}"))_overcloud_host_image_version: etc/kayobe/pulp-host-image-versions.yml | awk '{print $2}') >> $GITHUB_OUTPUT
+          echo image_tag=$(grep stackhpc_${{ inputs.os_distribution }}_$(sed s/-/_/ <(echo "${{ inputs.os_release }}"))_overcloud_host_image_version${{ inputs.architecture == 'aarch64' && '_aarch64' || '' }}: etc/kayobe/pulp-host-image-versions.yml | awk '{print $2}') >> $GITHUB_OUTPUT
 
       # Use the image override if set, otherwise use overcloud-os_distribution-os_release-tag
       - name: Output image name
         id: image_name
         run: |
           if [ -z "${{ inputs.vm_image_override }}" ]; then
-            echo image_name=overcloud-${{ inputs.os_distribution }}-${{ inputs.os_release }}-${{ steps.image_tag.outputs.image_tag }} >> $GITHUB_OUTPUT
+            echo image_name=overcloud-${{ inputs.os_distribution }}-${{ inputs.os_release }}${{ inputs.architecture == 'aarch64' && '-aarch64' || '' }}-${{ steps.image_tag.outputs.image_tag }} >> $GITHUB_OUTPUT
           else
             echo image_name=${{ inputs.vm_image_override }} >> $GITHUB_OUTPUT
           fi
@@ -173,7 +177,7 @@ jobs:
         working-directory: ${{ github.workspace }}/terraform/aio
         env:
           SSH_USERNAME: "${{ inputs.ssh_username }}"
-          VM_NAME: "skc-ci-aio-${{ inputs.neutron_plugin }}-${{ github.run_id }}"
+          VM_NAME: "skc-ci-aio-${{ inputs.architecture }}-${{ inputs.neutron_plugin }}-${{ github.run_id }}"
           VM_IMAGE: ${{ steps.image_name.outputs.image_name }}
           VM_INTERFACE: ${{ inputs.vm_interface }}
           VM_VOLUME_SIZE: ${{ inputs.upgrade && '100' || '50' }}
@@ -245,9 +249,11 @@ jobs:
           ---
           os_distribution: ${{ env.OS_DISTRIBUTION }}
           os_release: "${{ env.OS_RELEASE }}"
+          kolla_base_arch: ${{ env.ARCHITECTURE }}
           kolla_enable_ovn: ${{ env.ENABLE_OVN }}
           EOF
         env:
+          ARCHITECTURE: ${{ inputs.architecture }}
           ENABLE_OVN: ${{ inputs.neutron_plugin == 'ovn' }}
           OS_DISTRIBUTION: ${{ inputs.os_distribution }}
           OS_RELEASE: ${{ inputs.os_release }}
@@ -499,7 +505,7 @@ jobs:
       - name: Upload test result artifacts
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: test-results-${{ inputs.os_distribution }}-${{ inputs.os_release }}-${{ inputs.neutron_plugin }}${{ inputs.upgrade && '-upgrade' || '' }}
+          name: test-results-${{ inputs.os_distribution }}-${{ inputs.os_release }}-${{ inputs.architecture }}-${{ inputs.neutron_plugin }}${{ inputs.upgrade && '-upgrade' || '' }}
           path: |
             diagnostics/
             tempest-artifacts/

--- a/.github/workflows/stackhpc-pull-request.yml
+++ b/.github/workflows/stackhpc-pull-request.yml
@@ -187,6 +187,25 @@ jobs:
     secrets: inherit
     if: ${{ ! failure() && ! cancelled() && github.repository == 'stackhpc/stackhpc-kayobe-config' }}
 
+  all-in-one-rocky-9-aarch64-ovs:
+    name: aio (Rocky 9 aarch64 OVS)
+    permissions: {}
+    needs:
+      - check-changes
+      - build-kayobe-image
+    uses: ./.github/workflows/stackhpc-all-in-one.yml
+    with:
+      kayobe_image: ${{ needs.build-kayobe-image.outputs.kayobe_image }}
+      architecture: aarch64
+      os_distribution: rocky
+      os_release: "9"
+      ssh_username: cloud-user
+      neutron_plugin: ovs
+      OS_CLOUD: openstack
+      if: ${{ needs.check-changes.outputs.aio == 'true' }}
+    secrets: inherit
+    if: ${{ ! failure() && ! cancelled() && github.repository == 'stackhpc/stackhpc-kayobe-config' }}
+
   all-in-one-rocky-9-ovn:
     name: aio (Rocky 9 OVN)
     permissions: {}
@@ -196,6 +215,25 @@ jobs:
     uses: ./.github/workflows/stackhpc-all-in-one.yml
     with:
       kayobe_image: ${{ needs.build-kayobe-image.outputs.kayobe_image }}
+      os_distribution: rocky
+      os_release: "9"
+      ssh_username: cloud-user
+      neutron_plugin: ovn
+      OS_CLOUD: openstack
+      if: ${{ needs.check-changes.outputs.aio == 'true' }}
+    secrets: inherit
+    if: ${{ ! failure() && ! cancelled() && github.repository == 'stackhpc/stackhpc-kayobe-config' }}
+
+  all-in-one-rocky-9-aarch64-ovn:
+    name: aio (Rocky 9 aarch64 OVN)
+    permissions: {}
+    needs:
+      - check-changes
+      - build-kayobe-image
+    uses: ./.github/workflows/stackhpc-all-in-one.yml
+    with:
+      kayobe_image: ${{ needs.build-kayobe-image.outputs.kayobe_image }}
+      architecture: aarch64
       os_distribution: rocky
       os_release: "9"
       ssh_username: cloud-user
@@ -223,6 +261,25 @@ jobs:
     secrets: inherit
     if: ${{ ! failure() && ! cancelled() && github.repository == 'stackhpc/stackhpc-kayobe-config' }}
 
+  all-in-one-rocky-10-aarch64-ovs:
+    name: aio (Rocky 10 aarch64 OVS)
+    permissions: {}
+    needs:
+      - check-changes
+      - build-kayobe-image
+    uses: ./.github/workflows/stackhpc-all-in-one.yml
+    with:
+      kayobe_image: ${{ needs.build-kayobe-image.outputs.kayobe_image }}
+      architecture: aarch64
+      os_distribution: rocky
+      os_release: "10"
+      ssh_username: cloud-user
+      neutron_plugin: ovs
+      OS_CLOUD: openstack
+      if: ${{ needs.check-changes.outputs.aio == 'true' }}
+    secrets: inherit
+    if: ${{ ! failure() && ! cancelled() && github.repository == 'stackhpc/stackhpc-kayobe-config' }}
+
   all-in-one-rocky-10-ovn:
     name: aio (Rocky 10 OVN)
     permissions: {}
@@ -232,6 +289,25 @@ jobs:
     uses: ./.github/workflows/stackhpc-all-in-one.yml
     with:
       kayobe_image: ${{ needs.build-kayobe-image.outputs.kayobe_image }}
+      os_distribution: rocky
+      os_release: "10"
+      ssh_username: cloud-user
+      neutron_plugin: ovn
+      OS_CLOUD: openstack
+      if: ${{ needs.check-changes.outputs.aio == 'true' }}
+    secrets: inherit
+    if: ${{ ! failure() && ! cancelled() && github.repository == 'stackhpc/stackhpc-kayobe-config' }}
+
+  all-in-one-rocky-10-aarch64-ovn:
+    name: aio (Rocky 10 aarch64 OVN)
+    permissions: {}
+    needs:
+      - check-changes
+      - build-kayobe-image
+    uses: ./.github/workflows/stackhpc-all-in-one.yml
+    with:
+      kayobe_image: ${{ needs.build-kayobe-image.outputs.kayobe_image }}
+      architecture: aarch64
       os_distribution: rocky
       os_release: "10"
       ssh_username: cloud-user

--- a/etc/kayobe/environments/ci-aio/kolla/config/nova/nova-compute.conf
+++ b/etc/kayobe/environments/ci-aio/kolla/config/nova/nova-compute.conf
@@ -1,0 +1,5 @@
+{% if kolla_base_arch == 'aarch64' %}
+[libvirt]
+cpu_mode = custom
+cpu_model=max
+{% endif %}

--- a/releasenotes/notes/aio-aarch64-rocky-9db87f57a0e0dd22.yaml
+++ b/releasenotes/notes/aio-aarch64-rocky-9db87f57a0e0dd22.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Adds Rocky Linux ``aarch64`` all-in-one CI jobs.


### PR DESCRIPTION
currently no upgrade jobs, as not all upgrade prerequisites are in 2024.1

aarch64 CI jobs are finishing ~40/50 minutes longer than x86 counterparts, but still earlier than x86 upgrade jobs - therefore not slowing down PR processing