### PR TITLE
Move labelling automation to new file, improve logic

### DIFF
--- a/.github/workflows/stackhpc-pull-request-labels.yml
+++ b/.github/workflows/stackhpc-pull-request-labels.yml
@@ -1,0 +1,40 @@
+name: Auto-label Pull Requests
+'on':
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - converted_to_draft
+
+jobs:
+  auto-label:
+    runs-on: ubuntu-latest
+    if: github.repository == 'stackhpc/stackhpc-kayobe-config'
+    permissions:
+      pull-requests: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+    steps:
+
+      - name: Add waiting-review label to new ready PRs
+        if: (github.event.action == 'opened' || github.event.action == 'reopened') && github.event.pull_request.draft == false
+        run: gh pr edit "$PR_NUMBER" --add-label "waiting-review"
+
+      - name: Add waiting-author-response label to new draft PRs
+        if: (github.event.action == 'opened' || github.event.action == 'reopened') && github.event.pull_request.draft == true
+        run: gh pr edit "$PR_NUMBER" --add-label "waiting-author-response"
+
+      - name: Switch labels when PR becomes Ready for Review
+        if: github.event.action == 'ready_for_review'
+        run: |
+          gh pr edit "$PR_NUMBER" --remove-label "waiting-author-response" || true
+          gh pr edit "$PR_NUMBER" --add-label "waiting-review"
+
+      - name: Switch labels when PR is converted to Draft
+        if: github.event.action == 'converted_to_draft'
+        run: |
+          gh pr edit "$PR_NUMBER" --remove-label "waiting-review" || true
+          gh pr edit "$PR_NUMBER" --add-label "waiting-author-response"

--- a/.github/workflows/stackhpc-pull-request.yml
+++ b/.github/workflows/stackhpc-pull-request.yml
@@ -8,20 +8,6 @@ name: Pull request
 'on':
   pull_request:
 jobs:
-  # Label all newly-opened PRs as "waiting-review"
-  auto-label:
-    runs-on: ubuntu-latest
-    if: github.event.action == 'opened' && github.repository == 'stackhpc/stackhpc-kayobe-config'
-    permissions:
-      pull-requests: write
-    steps:
-      - name: Add waiting-review label
-        run: gh pr edit "$PR_NUMBER" --add-label "waiting-review"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-
   # Detect which files have changed and use this to run jobs conditionally.
   # Note that we can't use the workflow-level paths attribute since this
   # would skip the workflow entirely, and would prevent us from making the


### PR DESCRIPTION
Moving auto-label config to a new file so it doesn't interfere with CI tests.

Also added some more logic so now there are four possible actions:
1. Add waiting-review label to new ready PRs
2. Add waiting-author-response label to new draft PRs
3. Switch labels when PR becomes ready for review
4. Switch labels when PR is converted to draft

Tested conditions in #2328 