### PR TITLE
Stop templating empty sections in glance.conf

### DIFF
--- a/etc/kayobe/kolla/config/glance.conf
+++ b/etc/kayobe/kolla/config/glance.conf
@@ -1,10 +1,8 @@
-[DEFAULT]
 {% if stackhpc_enable_ceph_glance_cow_optimisations | bool %}
+[DEFAULT]
 show_image_direct_url = true
 show_multiple_locations = true
-{% endif %}
 
 [glance_store]
-{% if stackhpc_enable_ceph_glance_cow_optimisations | bool %}
 rbd_thin_provisioning = true
 {% endif %}


### PR DESCRIPTION
On envs with those optimisations disabled we template out empty sections which are at least counter-productive and counter-intuitive