### PR TITLE
Use StackHPC Ironic fork

### DIFF
--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -20,11 +20,9 @@ kolla_image_tags:
     rocky-9: 2025.1-rocky-9-20260303T104901
     ubuntu-noble: 2025.1-ubuntu-noble-20260223T134735
   ironic:
-    rocky-9: 2025.1-rocky-9-20260303T104021
-    ubuntu-noble: 2025.1-ubuntu-noble-20260303T104021
-  ironic_dnsmasq:
-    rocky-9: 2025.1-rocky-9-20260205T152450
-    ubuntu-noble: 2025.1-ubuntu-noble-20260205T152450
+    rocky-9: 2025.1-rocky-9-20260602T072908
+    rocky-10: 2025.1-rocky-10-20260602T072908
+    ubuntu-noble: 2025.1-ubuntu-noble-20260602T072908
   ironic_neutron_agent:
     rocky-9: 2025.1-rocky-9-20260205T152450
     ubuntu-noble: 2025.1-ubuntu-noble-20260205T152450

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -139,6 +139,10 @@ kolla_sources:
     type: git
     location: https://github.com/stackhpc/cloudkitty-dashboard.git
     reference: stackhpc/{{ openstack_release }}
+  ironic-base:
+    type: git
+    location: https://github.com/stackhpc/ironic.git
+    reference: stackhpc/{{ openstack_release }}
   ironic-inspector-additions-stackhpc-inspector-plugins:
     # Install our custom inspector plugins.
     type: git

--- a/releasenotes/notes/ironic-features-backports-2025.1-bbe03278e01bcb14.yaml
+++ b/releasenotes/notes/ironic-features-backports-2025.1-bbe03278e01bcb14.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Uses the StackHPC Ironic fork to include diskless boot support and
+    architecture-specific virtual media ESP bootloader selection.


### PR DESCRIPTION
Use the StackHPC Ironic fork to include diskless boot support and architecture-specific virtual media ESP bootloader selection.

The required changes are provided by:
[1] https://github.com/stackhpc/ironic/pull/4
[2] https://github.com/stackhpc/ironic/pull/9