### PR TITLE
CI: Stop adding release labels to pull requests

### DIFF
--- a/.github/workflows/stackhpc-update-kolla.yml
+++ b/.github/workflows/stackhpc-update-kolla.yml
@@ -14,15 +14,11 @@ jobs:
       matrix:
         include:
           - version: stackhpc/2023.1
-            codename: Antelope
           - version: stackhpc/2024.1
-            codename: Caracal
           - version: stackhpc/2025.1
-            codename: Epoxy
     uses: ./.github/workflows/update-dependencies.yml
     with:
       branch: ${{ matrix.version }}
-      openstack_codename: ${{ matrix.codename }}
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -7,18 +7,10 @@ on:
         description: Branch to update. Must exist in all repositories. e.g. stackhpc/2025.1
         type: string
         required: true
-      openstack_codename:
-        description: OpenStack codename e.g. Epoxy
-        type: string
-        required: true
   workflow_dispatch:
     inputs:
       branch:
         description: Branch to update. Must exist in all repositories. e.g. stackhpc/2025.1
-        type: string
-        required: true
-      openstack_codename:
-        description: OpenStack codename e.g. Epoxy
         type: string
         required: true
 
@@ -185,5 +177,4 @@ jobs:
             --title "(automated) Bump dependencies for OpenStack ${{ inputs.branch }}" \
             --body-file ../../pr_body.md \
             --label "automated" \
-            --label "${{ inputs.openstack_codename }}"
 


### PR DESCRIPTION
The labels have been removed which broke this workflow.