### PR TITLE
Fix triggering host image builds

### DIFF
--- a/.github/workflows/trigger-overcloud-host-image-build.yml
+++ b/.github/workflows/trigger-overcloud-host-image-build.yml
@@ -25,6 +25,8 @@ jobs:
   trigger-overcloud-host-image-build:
     runs-on: ubuntu-24.04
     name: Trigger overcloud host image build
+    permissions:
+      actions: write
     needs:
       - check-changes
     if: ${{ needs.check-changes.outputs.pulp-repo-versions == 'true' }}


### PR DESCRIPTION
Triggering another workflow requires the `actions:write` permission.