### PR TITLE
2025.1: Bump Magnum CAPI Helm driver to v1.4.0

### DIFF
--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -11,3 +11,5 @@ kolla_image_tags:
     rocky-9: 2025.1-rocky-9-20260205T152450
     rocky-10: 2025.1-rocky-10-20260423T154048
     ubuntu-noble: 2025.1-ubuntu-noble-20260205T152450
+  magnum:
+    rocky-9: 2025.1-rocky-9-20260611T160341

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -508,7 +508,7 @@ kolla_build_customizations_common:
     - /additions/*
   magnum_base_pip_packages_override:
     - /magnum[osprofiler]
-    - magnum-capi-helm==1.3.0
+    - magnum-capi-helm==1.4.0
   neutron_server_packages_append:
     - python3-libvirt
   nova_compute_packages_append:

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -508,7 +508,7 @@ kolla_build_customizations_common:
     - /additions/*
   magnum_base_pip_packages_override:
     - /magnum[osprofiler]
-    - magnum-capi-helm==1.4.0
+    - "magnum-capi-helm@git+https://github.com/stackhpc/magnum-capi-helm@python3.9"
   neutron_server_packages_append:
     - python3-libvirt
   nova_compute_packages_append:

--- a/releasenotes/notes/bump-magnum-capi-helm-1.4.0-04413e4c4ba23ead.yaml
+++ b/releasenotes/notes/bump-magnum-capi-helm-1.4.0-04413e4c4ba23ead.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Bumps the Magnum container images to bring in v1.4.0 of the Magnum CAPI
+    Helm driver. See the Magnum CAPI Helm driver release notes for more
+    details:
+    https://static.opendev.org/docs/releasenotes/magnum-capi-helm/unreleased.html#relnotes-1-4-0


### PR DESCRIPTION
Image building here: https://github.com/stackhpc/stackhpc-kayobe-config/actions/runs/27360269310