### PR TITLE
Add compatibility for NIC names with dashes

### DIFF
--- a/etc/kayobe/ansible/secret-store/vault-bao-migration-overcloud.yml
+++ b/etc/kayobe/ansible/secret-store/vault-bao-migration-overcloud.yml
@@ -3,10 +3,6 @@
   any_errors_fatal: true
   gather_facts: true
   hosts: controllers
-  vars:
-    secret_store_bind_interface: "{{ internal_net_name | net_interface | replace('-', '_') }}"
-    secret_store_bind_address: "{{ ansible_facts[secret_store_bind_interface].ipv4.address }}"
-    secret_store_api_address: "https://{{ secret_store_bind_address }}:8200"
   tasks:
     - name: Fail if secret store is already configured to be OpenBao
       ansible.builtin.fail:

--- a/etc/kayobe/ansible/secret-store/vault-bao-migration-overcloud.yml
+++ b/etc/kayobe/ansible/secret-store/vault-bao-migration-overcloud.yml
@@ -4,7 +4,7 @@
   gather_facts: true
   hosts: controllers
   vars:
-    secret_store_bind_interface: "{{ internal_net_name | net_interface }}"
+    secret_store_bind_interface: "{{ internal_net_name | net_interface | replace('-', '_') }}"
     secret_store_bind_address: "{{ ansible_facts[secret_store_bind_interface].ipv4.address }}"
     secret_store_api_address: "https://{{ secret_store_bind_address }}:8200"
   tasks:
@@ -39,7 +39,7 @@
   ansible.builtin.import_playbook: stackhpc.hashicorp.vault_bao_migration
   vars:
     vault_hosts_group: controllers
-    secret_store_bind_interface: "{{ internal_net_name | net_interface }}"
+    secret_store_bind_interface: "{{ internal_net_name | net_interface | replace('-', '_') }}"
     secret_store_bind_address: "{{ ansible_facts[secret_store_bind_interface].ipv4.address }}"
     secret_store_api_address: "https://{{ secret_store_bind_address }}:8200"
     migration_consul_docker_image: "{{ overcloud_consul_docker_image }}"

--- a/etc/kayobe/ansible/secret-store/vault-bao-migration-seed.yml
+++ b/etc/kayobe/ansible/secret-store/vault-bao-migration-seed.yml
@@ -3,10 +3,6 @@
   any_errors_fatal: true
   gather_facts: true
   hosts: seed
-  vars:
-    secret_store_bind_interface: lo
-    secret_store_bind_address: "{{ ansible_facts[secret_store_bind_interface].ipv4.address }}"
-    secret_store_api_address: "http://{{ secret_store_bind_address }}:8200"
   tasks:
     - name: Fail if secret store is already configured to be OpenBao
       ansible.builtin.fail:


### PR DESCRIPTION
When Ansible gathers facts, it silently converts dashes in network interface names into underscores, resulting precheck failure on Vault to OpenBao migration for overcloud.

Fixed with adding ``replace()`` filter when getting ``secret_store_bind_interface``.