### PR TITLE
ci: use diff of previous patchset for path filters

### DIFF
--- a/.github/workflows/stackhpc-pull-request.yml
+++ b/.github/workflows/stackhpc-pull-request.yml
@@ -43,11 +43,30 @@ jobs:
     steps:
       - name: GitHub Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      # Diff previous head vs current head to check when a new patchset is
+      # pushed, and only run CI again if it's needed
+      - name: Determine Base Commit
+        id: base-commit
+        run: |
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          
+          if [ "${{ github.event.action }}" = "synchronize" ]; then
+            BEFORE_SHA="${{ github.event.before }}"
+            if git cat-file -e "$BEFORE_SHA" 2>/dev/null; then
+              BASE_SHA="$BEFORE_SHA"
+            fi
+          fi
+          
+          echo "base_sha=$BASE_SHA" >> $GITHUB_OUTPUT
 
       - name: Check changed files
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: changes
         with:
+          base: ${{ steps.base-commit.outputs.base_sha }}
           # Filters are defined in this file.
           filters: .github/stackhpc-pull-request-path-filters.yml
 


### PR DESCRIPTION
When a user makes a PR, CI is run conditionally based on the files that change. If a second commit is then pushed, e.g. to update docs or add a relase note, that commit would retrigger all CI even though it doesn't affect the filtered files. This change fixes that interaction, so the new patchset is compared to the previous, instead of the branch it is merging into.