### PR TITLE
Remove hostname fix reboot

### DIFF
--- a/.github/workflows/stackhpc-all-in-one.yml
+++ b/.github/workflows/stackhpc-all-in-one.yml
@@ -278,28 +278,6 @@ jobs:
         run: |
           docker image pull $KAYOBE_IMAGE
 
-      # Rocky 9 OVN deployments will fail when the hostname contains a '.'
-      - name: Fix hostname
-        run: |
-          docker run -t --rm \
-            -v $(pwd):/stack/kayobe-automation-env/src/kayobe-config \
-            -e KAYOBE_ENVIRONMENT -e KAYOBE_VAULT_PASSWORD -e KAYOBE_AUTOMATION_SSH_PRIVATE_KEY \
-            ${{ steps.kayobe_image.outputs.kayobe_image }} \
-            /stack/kayobe-automation-env/src/kayobe-config/.automation/pipeline/playbook-run.sh etc/kayobe/ansible${{ inputs.upgrade && '/' || '/fixes/' }}fix-hostname.yml
-        env:
-          KAYOBE_AUTOMATION_SSH_PRIVATE_KEY: ${{ steps.ssh_key.outputs.ssh_key }}
-
-      # Reboot to Apply hostname change
-      - name: Reboot
-        run: |
-          docker run -t --rm \
-            -v $(pwd):/stack/kayobe-automation-env/src/kayobe-config \
-            -e KAYOBE_ENVIRONMENT -e KAYOBE_VAULT_PASSWORD -e KAYOBE_AUTOMATION_SSH_PRIVATE_KEY \
-            ${{ steps.kayobe_image.outputs.kayobe_image }} \
-            /stack/kayobe-automation-env/src/kayobe-config/.automation/pipeline/playbook-run.sh etc/kayobe/ansible${{ inputs.upgrade && '/' || '/maintenance/' }}reboot.yml -e reboot_with_bootstrap_user=true
-        env:
-          KAYOBE_AUTOMATION_SSH_PRIVATE_KEY: ${{ steps.ssh_key.outputs.ssh_key }}
-
       - name: Run growroot
         run: |
           docker run -t --rm \


### PR DESCRIPTION
Previously there was a hostname-related OVN bug that required a reboot in the AIO CI instances to mitigate. It's been fixed for years[1] so this change reverts the workaround. It'll speed up CI and it's better to know if we regress.

[1] https://bugs.launchpad.net/kolla-ansible/+bug/2080552