### PR TITLE
Fix OS venv creation

### DIFF
--- a/etc/kayobe/ansible/nova-compute-disable.yml
+++ b/etc/kayobe/ansible/nova-compute-disable.yml
@@ -9,6 +9,7 @@
     disabled_reason: Down for maintenance by nova-compute-disable.yml
   tasks:
     - name: Set up openstack cli virtualenv
+      become: true
       ansible.builtin.pip:
         virtualenv: "{{ venv }}"
         virtualenv_command: /usr/bin/python3 -m venv

--- a/etc/kayobe/ansible/nova-compute-drain.yml
+++ b/etc/kayobe/ansible/nova-compute-drain.yml
@@ -9,6 +9,7 @@
     live_migration_fatal: true
   tasks:
     - name: Set up openstack cli virtualenv
+      become: true
       ansible.builtin.pip:
         virtualenv: "{{ venv }}"
         virtualenv_command: /usr/bin/python3 -m venv

--- a/etc/kayobe/ansible/nova-compute-enable.yml
+++ b/etc/kayobe/ansible/nova-compute-enable.yml
@@ -9,6 +9,7 @@
     disabled_reason: Down for maintenance by nova-compute-disable.yml
   tasks:
     - name: Set up openstack cli virtualenv
+      become: true
       ansible.builtin.pip:
         virtualenv: "{{ venv }}"
         virtualenv_command: /usr/bin/python3 -m venv


### PR DESCRIPTION
Fixes this error observed on Ubuntu Jammy:
```
TASK [Set up openstack cli virtualenv] ***********************************************************
Wednesday 17 June 2026  14:29:51 +0200 (0:00:02.368)       0:00:02.400 ********
fatal: [compute-> controller({{ hostvars[groups['controllers'][0]].ansible_host }})]: FAILED! =>
    changed: false
    cmd:
    - /opt/kayobe/venvs/openstack/bin/pip3
    - install
    - -U
    - -c
    - https://raw.githubusercontent.com/stackhpc/requirements/refs/heads/stackhpc/2024.1/upper-constraints.txt
    - python-openstackclient
    msg: |-
        stdout: Collecting python-openstackclient
          Using cached python_openstackclient-6.6.1-py3-none-any.whl.metadata (6.6 kB)
...
        Installing collected packages: wcwidth, requestsexceptions, pyperclip, netifaces, netaddr, wrapt, urllib3, tzdata, simplejson, setuptools, rfc3986, PyYAML, pyparsing, pycparser, PrettyTable, platformdirs, packaging, msgpack, jsonpointer, jmespath, iso8601, idna, decorator, charset-normalizer, certifi, autopage, attrs, requests, pbr, jsonpatch, debtcollector, cmd2, cffi, stevedore, oslo.i18n, os-service-types, cryptography, oslo.utils, oslo.config, keystoneauth1, dogpile.cache, cliff, python-cinderclient, oslo.serialization, openstacksdk, python-novaclient, python-keystoneclient, osc-lib, python-openstackclient

        :stderr: ERROR: Could not install packages due to an OSError: [Errno 13] Permission denied: '/opt/kayobe/venvs/openstack/lib/python3.12/site-packages/wcwidth'
        Check the permissions.