### PR TITLE
Update documentation to reference Rocky 10

### DIFF
--- a/doc/source/configuration/ipa.rst
+++ b/doc/source/configuration/ipa.rst
@@ -34,7 +34,9 @@ deployment:
 
 The supported values are ``amd64`` and ``aarch64``. Rocky Linux 9 uses
 ``stackhpc_rocky_9_ipa_image_version`` for ``amd64`` and
-``stackhpc_rocky_9_ipa_image_version_aarch64`` for ``aarch64``.
+``stackhpc_rocky_9_ipa_image_version_aarch64`` for ``aarch64``, similarly
+Rocky Linux 10 uses ``stackhpc_rocky_10_ipa_image_version`` for ``amd64`` and
+``stackhpc_rocky_10_ipa_image_version_aarch64`` for ``aarch64``.
 
 You can also override the distribution version pulled in during deployment. For
 example, the case of switching to Ubuntu 24.04 on a Rocky 9 cloud:

--- a/doc/source/configuration/release-train.rst
+++ b/doc/source/configuration/release-train.rst
@@ -39,7 +39,8 @@ Configuration
 This configuration provides the following:
 
 * Configuration to deploy a local Pulp service as a container on the seed
-* Pulp repository definitions for Rocky Linux 9 and Ubuntu Noble 24.04
+* Pulp repository definitions for Rocky Linux 9, Rocky Linux 10, and Ubuntu
+  Noble 24.04
 * Playbooks to synchronise a local Pulp service with Ark
 * Configuration to use the local Pulp repository mirrors on control plane hosts
 * Configuration to use the local Pulp container registry on control plane hosts
@@ -94,8 +95,8 @@ The Ark pulp credentials issued by StackHPC should be configured in
 Package repositories
 --------------------
 
-Rocky Linux 9 and Ubuntu Noble package repositories are synced based on the
-value of ``os_distribution`` and ``os_release``.
+Rocky Linux 9, Rocky Linux 10, and Ubuntu Noble package repositories are synced
+based on the value of ``os_distribution`` and ``os_release``.
 
 RPM repository syncs default to the ``x86_64`` architecture. To sync
 ``aarch64`` repositories instead, or to sync both architectures, set

--- a/doc/source/contributor/environments/ci-builder.rst
+++ b/doc/source/contributor/environments/ci-builder.rst
@@ -29,7 +29,7 @@ cases.
 Prerequisites
 =============
 
-* a Rocky Linux 9 or Ubuntu Noble 24.04 host
+* a Rocky Linux 9, Rocky Linux 10, or Ubuntu Noble 24.04 host
 
 Setup
 =====

--- a/doc/source/contributor/environments/ci-tenks.rst
+++ b/doc/source/contributor/environments/ci-tenks.rst
@@ -35,7 +35,7 @@ for the local Pulp instance.
 Prerequisites
 =============
 
-* A Rocky Linux 9 or Ubuntu Noble 24.04 host
+* A Rocky Linux 9, Rocky Linux 10, or Ubuntu Noble 24.04 host
 * 16GB of memory
 * 4 cores
 * No LVM

--- a/doc/source/contributor/ofed.rst
+++ b/doc/source/contributor/ofed.rst
@@ -30,8 +30,9 @@ Before building OFED packages, the workflow will ensure that:
 build-ofed
 ----------
 
-Currently we only support building Rocky Linux 9 OFED kernel module packages.
-The workflow can build packages for ``x86_64`` and ``aarch64``.
+Currently we only support building Rocky Linux 9 and Rocky Linux 10 OFED kernel
+module packages. The workflow builds packages for ``x86_64`` and
+``aarch64`` at the same time, to keep kernel versions synchronised across architectures.
 
 The Build OFED module workflow will check that the filesystem is configured (noexec disabled)
 to allow the DOCA build script to run. The workflow will also install any necessary dependencies
@@ -45,9 +46,9 @@ push-ofed
 ---------
 
 As mentioned above, the DOCA repository is synced into the ``doca`` repository in Ark. This workflow
-will upload the ``doca-kernel-repo`` RPM to a separate repository named ``doca-modules``. The version
-for this repository is set in ``pulp-repo-versions.yml`` and is disabled for local pulp syncs by
-default.
+will upload the ``doca-kernel-repo`` RPM to a separate repository named ``doca-modules``, which is
+specific to the minor version of Rocky the modules are being built for. The versions for these
+repositories are set in ``pulp-repo-versions.yml`` and are disabled for local pulp syncs by default.
 
 Install process
 ===============

--- a/doc/source/contributor/package-updates.rst
+++ b/doc/source/contributor/package-updates.rst
@@ -100,7 +100,7 @@ Checkout the new kayobe-config branch (from the draft PR):
    git fetch
    git checkout <branch-name>
 
-For Rocky Linux 9, bump the snapshot versions in /etc/yum/repos.d with:
+For Rocky Linux 9 and Rocky Linux 10, bump the snapshot versions in /etc/yum/repos.d with:
 
 .. code-block:: console
 

--- a/doc/source/contributor/testing-ci-automation.rst
+++ b/doc/source/contributor/testing-ci-automation.rst
@@ -274,7 +274,7 @@ In order to create a VM on the cloud hosting the CI, we need a few things:
 - a ``clouds.yaml`` file
 - an application credential to authenticate with the cloud
 - a flavor for the VM (minimum 8GiB RAM)
-- a Rocky Linux 9 image for the VM
+- a Rocky Linux 9 or Rocky Linux 10 image for the VM
 - a network and subnet for the VM
 - SSH connectivity from the GitHub runner to the VM
 - access from the VM to the Internet


### PR DESCRIPTION
An initial update to SKC docs to add references to Rocky 10 where applicable - this doesn't include an upgrade guide, that will come later.