### PR TITLE
Valkey containers for Rocky 9 and Ubuntu Noble

### DIFF
--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -13,3 +13,9 @@ kolla_image_tags:
     ubuntu-noble: 2025.1-ubuntu-noble-20260205T152450
   ovn:
     rocky-9: 2025.1-rocky-9-20260608T100935
+  valkey:
+    rocky-9: 2025.1-rocky-9-20260618T122602
+    ubuntu-noble: 2025.1-ubuntu-noble-20260618T122602
+  valkey_sentinel:
+    rocky-9: 2025.1-rocky-9-20260618T122602
+    ubuntu-noble: 2025.1-ubuntu-noble-20260618T122602

--- a/etc/kayobe/pulp.yml
+++ b/etc/kayobe/pulp.yml
@@ -971,15 +971,11 @@ stackhpc_pulp_images_kolla:
 
 # List of images for each base distribution which should not/cannot be built.
 stackhpc_kolla_unbuildable_images:
-  ubuntu-noble:
-    - valkey-server
-    - valkey-sentinel
-  rocky-9:
-    - valkey-server
-    - valkey-sentinel
+  rocky-9: []
   rocky-10:
     - redis
     - redis-sentinel
+  ubuntu-noble: []
 
 # Whitespace-separated list of regular expressions matching Kolla image names.
 # Usage is similar to kolla-build CLI arguments.

--- a/releasenotes/notes/valkey-890e4773a158e73d.yaml
+++ b/releasenotes/notes/valkey-890e4773a158e73d.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Valkey containers have been built for Rocky 9 and Ubuntu Noble, to
+    facilitate migrations from redis.
+


### PR DESCRIPTION
To enable redis -> valkey migrations, we need valkey images buildable on OSes other than Rocky 10.