### PR TITLE
Bump Ironic Kolla image tags

### DIFF
--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -15,6 +15,10 @@ kolla_image_tags:
     rocky-9: 2025.1-rocky-9-20260619T155511
     rocky-10: 2025.1-rocky-10-20260619T155511
     ubuntu-noble: 2025.1-ubuntu-noble-20260619T155511
+  ironic_dnsmasq:
+    rocky-9: 2025.1-rocky-9-20260603T214242
+    rocky-10: 2025.1-rocky-10-20260612T161908
+    ubuntu-noble: 2025.1-ubuntu-noble-20260603T214242
   ovn:
     rocky-9: 2025.1-rocky-9-20260608T100935
   valkey:

--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -11,6 +11,10 @@ kolla_image_tags:
     rocky-9: 2025.1-rocky-9-20260205T152450
     rocky-10: 2025.1-rocky-10-20260423T154048
     ubuntu-noble: 2025.1-ubuntu-noble-20260205T152450
+  ironic:
+    rocky-9: 2025.1-rocky-9-20260619T155511
+    rocky-10: 2025.1-rocky-10-20260619T155511
+    ubuntu-noble: 2025.1-ubuntu-noble-20260619T155511
   ovn:
     rocky-9: 2025.1-rocky-9-20260608T100935
   valkey:

--- a/releasenotes/notes/ironic-bump-d0df1942c1077d40.yaml
+++ b/releasenotes/notes/ironic-bump-d0df1942c1077d40.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Updates Ironic images to fix invalid cross device links when deploying
+    baremetal images using the virtualmedia boot interface.


### PR DESCRIPTION
Update the Ironic Kolla images to create a temp directory inside the Docker volume. Fixes an issue with deploying baremetal ramdisk images using virtualmedia boot.