### PR TITLE
Set kolla base version with ansible facts

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -84,7 +84,7 @@ kolla_base_arch: "{{ 'aarch64' if lookup('pipe','uname -m') in ['aarch64','arm64
 # Default is kolla_base_distro_version_default_map[kolla_base_distro].
 #kolla_base_distro_version:
 
-kolla_base_distro_and_version: "{{ kolla_base_distro }}-{{ kolla_base_distro_version }}"
+# kolla_base_distro_and_version: "{{ kolla_base_distro }}-{{ kolla_base_distro_version }}"
 
 # URL of docker registry to use for Kolla images. Default is not set, in which
 # case Quay.io will be used.

--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -5,21 +5,22 @@
 # This is necessary for os migrations where mixed clouds might be deployed
 kolla_base_distro: "{% raw %}{{ ansible_facts.distribution | lower }}{% endraw %}"
 
+kolla_base_distro_version_from_facts: true
+
 # Use facts so this is determined correctly when the control host OS differs
-# from os_distribuition.
-kolla_base_distro_version: "{% raw %}{{ kolla_base_distro_version_default_map[kolla_base_distro] }}{% endraw %}"
+# from os_distribution.
+# kolla_base_distro_version: "{% raw %}{{ kolla_base_distro_version_map[kolla_base_distro] }}{% endraw %}"
 
 # Convenience variable for base distro and version string.
-kolla_base_distro_and_version: "{% raw %}{{ kolla_base_distro }}-{{ kolla_base_distro_version }}{% endraw %}"
+# kolla_base_distro_and_version: "{% raw %}{{ kolla_base_distro }}-{{ kolla_base_distro_version }}{% endraw %}"
 
-# Override the version map used, so we can deploy Rocky 10 container images
-# on Rocky 10 hosts.
-kolla_base_distro_version_default_map: {
-  "centos": "stream9",
-  "debian": "bookworm",
-  "rocky": "{{ os_release }}",
-  "ubuntu": "noble",
-}
+# Override the version map used, so we can deploy the correct container images
+# on Rocky 9/10 hosts during migration.
+# kolla_base_distro_version_map:
+#   centos: "stream9"
+#   debian: "bookworm"
+#   rocky: "{% raw %}{{ ansible_facts.distribution_major_version }}{% endraw %}"
+#   ubuntu: "noble"
 
 # Dict of Kolla image tags to deploy for each service.
 # Each key is the tag variable prefix name, and the value is another dict,

--- a/releasenotes/notes/kolla-use-host-version-c7449366dadfe92c.yaml
+++ b/releasenotes/notes/kolla-use-host-version-c7449366dadfe92c.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    ``kolla_base_distro_version`` is now set using ansible facts on
+    Rocky hosts rather than from a static mapping, to facilitate Rocky
+    9 to 10 migration.


### PR DESCRIPTION
Switch to setting `kolla_base_distro_version` using ansible facts, rather than a static mapping, so the correct containers get deployed on hosts when we have a mixture of versions (during Rocky 9 to 10 migration).