### PR TITLE
Add support for GA107GL A2 GPUS

### DIFF
--- a/etc/kayobe/stackhpc-compute.yml
+++ b/etc/kayobe/stackhpc-compute.yml
@@ -125,7 +125,7 @@ stackhpc_gpu_data:
     vendor_id: "10de"
     product_id: "233b"
     device_type: "type-PF"
-  #Nvidia GA107GL
+  # Nvidia GA107GL A2
   a2:
     resource_name: "{{ a2_resource_name | default('a2') }}"
     vendor_id: "10de"

--- a/etc/kayobe/stackhpc-compute.yml
+++ b/etc/kayobe/stackhpc-compute.yml
@@ -125,3 +125,9 @@ stackhpc_gpu_data:
     vendor_id: "10de"
     product_id: "233b"
     device_type: "type-PF"
+  #Nvidia GA107GL
+  a2:
+    resource_name: "{{ a2_resource_name | default('a2') }}"
+    vendor_id: "10de"
+    product_id: "25b6"
+    device_type: "type-PF"

--- a/releasenotes/notes/add-nvidia-ga107gla2-702ff80df543bea9.yaml
+++ b/releasenotes/notes/add-nvidia-ga107gla2-702ff80df543bea9.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Adds a definition for ``NVIDIA GA107GL A2`` to the
+    ``stackhpc_gpu_data``.


### PR DESCRIPTION
86:00.0 3D controller [0302]: NVIDIA Corporation GA107GL [A2 / A16] [10de:25b6] (rev a1)