### PR TITLE
cephadm: Rocky 10 support for deploying ceph

### DIFF
--- a/etc/kayobe/ansible/ceph/cephadm-deploy.yml
+++ b/etc/kayobe/ansible/ceph/cephadm-deploy.yml
@@ -7,6 +7,37 @@
     - cephadm
     - cephadm-deploy
   tasks:
+    # note(owenjones): the Ceph release signing key still uses SHA-1, which requires us to
+    # downgrade to the LEGACY policy on Rocky 10 until a new key is published.
+    # A later Ceph release might fix this - https://tracker.ceph.com/issues/74861
+    - name: Discover current active crypto policy (Rocky 10)
+      ansible.builtin.command:
+        cmd: update-crypto-policies --show
+      become: true
+      changed_when: false
+      register: crypto_policy
+      when:
+        - ansible_facts.os_family == 'RedHat'
+        - ansible_facts.distribution_major_version | int == 10
+    - name: Set crypto policy to LEGACY (Rocky 10)
+      ansible.builtin.command:
+        cmd: update-crypto-policies --set LEGACY
+      become: true
+      when:
+        - ansible_facts.os_family == 'RedHat'
+        - ansible_facts.distribution_major_version | int == 10
+        - crypto_policy.stdout | default('DEFAULT') != 'LEGACY'
     - name: Apply Cephadm role
-      ansible.builtin.import_role:
-        name: stackhpc.cephadm.cephadm
+      block:
+        - name: Apply Cephadm role
+          ansible.builtin.import_role:
+            name: stackhpc.cephadm.cephadm
+      always:
+        - name: Revert crypto policy (Rocky 10)
+          ansible.builtin.command:
+            cmd: update-crypto-policies --set {{ crypto_policy.stdout | default('DEFAULT') }}
+          become: true
+          when:
+            - ansible_facts.os_family == 'RedHat'
+            - ansible_facts.distribution_major_version | int == 10
+            - crypto_policy.stdout | default('DEFAULT') != 'LEGACY'

--- a/etc/kayobe/ansible/requirements.yml
+++ b/etc/kayobe/ansible/requirements.yml
@@ -1,7 +1,7 @@
 ---
 collections:
   - name: stackhpc.cephadm
-    version: 1.22.0
+    version: 1.22.1
   - name: pulp.squeezer
     version: 0.3.0
   - name: stackhpc.pulp

--- a/releasenotes/notes/cephadm-rocky-10-bdb772536ca2083c.yaml
+++ b/releasenotes/notes/cephadm-rocky-10-bdb772536ca2083c.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    cephadm deployment now supported in Rocky 10; The cephadm collection has
+    been bumped to 1.22.1 which updates the Ceph repository URL for Squid on
+    Rocky 10. The Rocky crypto policy in use during Ceph deployment is required
+    to be downgraded to LEGACY in order to use Ceph's release signing key. The
+    policy is reverted after deployment or on deployment failure.


### PR DESCRIPTION
* cephadm deployment now supported in Rocky 10; The cephadm collection has been bumped to 1.22.1 which updates the Ceph repository URL for Squid on Rocky 10. The Rocky crypto policy in use during Ceph deployment is required to be downgraded to LEGACY in order to use Ceph's release signing key. The policy is reverted after deployment or on deployment failure