### PR TITLE
fix: change libvirt cpu mode to none on Rocky 10 aarch64

### DIFF
--- a/etc/kayobe/environments/aio/kolla/config/nova/nova-compute.conf
+++ b/etc/kayobe/environments/aio/kolla/config/nova/nova-compute.conf
@@ -1,5 +1,10 @@
 {% if kolla_base_arch == 'aarch64' %}
+{% if kolla_base_distro_and_version == 'rocky-9' %}
 [libvirt]
 cpu_mode = custom
-cpu_model=max
+cpu_model = max
+{% elif kolla_base_distro_and_version == 'rocky-10' %}
+[libvirt]
+cpu_mode = none
+{% endif %}
 {% endif %}

--- a/releasenotes/notes/rocky-10-aarch-cpu-b7d3232282e1cd1c.yaml
+++ b/releasenotes/notes/rocky-10-aarch-cpu-b7d3232282e1cd1c.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Using the AIO environment, with ``cpu_mode`` set to ``max`` instances
+    would fail to launch on Rocky 10.2 (aarch64); ``cpu_mode`` has been set
+    to ``none`` which instructs the hypervisor to choose the default CPU
+    model and fixes instance launching.


### PR DESCRIPTION
Rocky 10 aarch64 AIOs started failing after we switched to 10.2, setting `cpu_mode` to `none` brings them back to life.

Current theory is that there's a bug with libvirt detecting the correct underlying CPU model to use with `cpu_model` set to `max` preventing instances launching.