### PR TITLE
Remove outdated comment

### DIFF
--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -16,8 +16,7 @@ when used with Kayobe's :kayobe-doc:`multiple environments
 <multiple-environments>` feature.
 
 This configuration should be consumed using the `StackHPC Kayobe fork
-<https://github.com/stackhpc/kayobe/tree/stackhpc/2025.1>`__, which includes
-backported support for Ansible collections.
+<https://github.com/stackhpc/kayobe/tree/stackhpc/2025.1>`__.
 
 New deployments
 ---------------


### PR DESCRIPTION
Support for Ansible collections was backported for an old release of Kayobe.