### PR TITLE
Build custom horizon image for 2025.1

### DIFF
--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -11,6 +11,10 @@ kolla_image_tags:
     rocky-9: 2025.1-rocky-9-20260205T152450
     rocky-10: 2025.1-rocky-10-20260423T154048
     ubuntu-noble: 2025.1-ubuntu-noble-20260205T152450
+  horizon:
+    rocky-9: 2025.1-rocky-9-20260702T190830
+    rocky-10: 2025.1-rocky-10-20260702T190830
+    ubuntu-noble: 2025.1-ubuntu-noble-20260702T190830
   ironic:
     rocky-9: 2025.1-rocky-9-20260619T155511
     rocky-10: 2025.1-rocky-10-20260619T155511

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -183,6 +183,12 @@ kolla_sources:
     type: git
     location: https://github.com/stackhpc/blazar.git
     reference: stackhpc/master
+  # TODO(technowhizz): Remove in 2026.1 on openstacksdk >= 4.9.0
+  # https://review.opendev.org/c/openstack/openstacksdk/+/970135
+  horizon:
+    type: git
+    location: https://github.com/stackhpc/horizon.git
+    reference: stackhpc/{{ openstack_release }}
 
 ###############################################################################
 # Kolla image build configuration.

--- a/releasenotes/notes/custom-horizon-image-8f6cfa9956ea96a8.yaml
+++ b/releasenotes/notes/custom-horizon-image-8f6cfa9956ea96a8.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Bumps the Horizon container image to include a fix for slow Neutron port
+    listing in Horizon.


### PR DESCRIPTION
This is needed due to lack of support for tenant_id in neutron in openstacksdk < 4.9.0