### PR TITLE
Skip known Linux kernel vulnerabilities

### DIFF
--- a/tools/scan-images.sh
+++ b/tools/scan-images.sh
@@ -82,7 +82,7 @@ generate_summary_csv() {
   jq -r '.Results[]
       | select(.Vulnerabilities)
       | .Vulnerabilities
-      | map(select(.PkgName | test("kernel") | not ))
+      | map(select(.PkgName | test("^kernel|^linux-libc-dev") | not ))
       | group_by(.VulnerabilityID)
       | map(
         [


### PR DESCRIPTION
Ubuntu image builds are failing security scans because of Linux kernel vulnerabilities.