### PR TITLE
Install zstd on IPA build host

### DIFF
--- a/etc/kayobe/ipa.yml
+++ b/etc/kayobe/ipa.yml
@@ -20,7 +20,7 @@
 #ipa_builder_source_version:
 
 # List of additional build host packages to install. Default is an empty list.
-#ipa_build_dib_host_packages_extra:
+ipa_build_dib_host_packages_extra: [ 'zstd' ]
 
 # List of default Diskimage Builder (DIB) elements to use when building IPA
 # images. Default is ["centos", "dynamic-login", "enable-serial-console",


### PR DESCRIPTION
It is required because of the extra DIB_IPA_COMPRESS_CMD.