### PR TITLE
Skip kernel vulnerabilities for container images

### DIFF
--- a/tools/scan-images.sh
+++ b/tools/scan-images.sh
@@ -82,7 +82,7 @@ generate_summary_csv() {
   jq -r '.Results[]
       | select(.Vulnerabilities)
       | .Vulnerabilities
-      | map(select(.PkgName | test("kernel") | not ))
+      | map(select(.PkgName | test("^kernel|^linux-libc-dev") | not ))
       | group_by(.VulnerabilityID)
       | map(
         [


### PR DESCRIPTION
Ubuntu container image builds are failing security scans because of Linux kernel vulnerabilities reported against linux-libc-dev.

Also tighten the kernel package name test to avoid matching on an unrelated <something>-kernel package.

(cherry picked from commit 3ca9ed7678ec53394961f746ba6c4af43f4dfc00)