### PR TITLE
Fix Cinder with NetApp ONTAP and self-signed certs

### DIFF
--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -18,8 +18,9 @@ kolla_image_tags:
     # not buildable anymore, see https://github.com/openstack/kolla/commit/34ca6e35c94ddba1e47722718f3fc81a1f03e28a
     rocky-9: 2024.1-rocky-9-20250716T041633
   cinder:
-    ubuntu-jammy: 2024.1-ubuntu-jammy-20250627T102805
-    ubuntu-noble: 2024.1-ubuntu-noble-20250627T102805
+    rocky-9: 2024.1-rocky-9-20260706T131730
+    ubuntu-jammy: 2024.1-ubuntu-jammy-20260706T131730
+    ubuntu-noble: 2024.1-ubuntu-noble-20260706T131730
   cloudkitty:
     ubuntu-jammy: 2024.1-ubuntu-jammy-20250627T102805
     ubuntu-noble: 2024.1-ubuntu-noble-20250627T102805

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -131,6 +131,10 @@ kolla_sources:
     type: git
     location: https://github.com/stackhpc/bifrost.git
     reference: stackhpc/{{ openstack_release }}
+  cinder-base:
+    type: git
+    location: https://github.com/stackhpc/cinder.git
+    reference: stackhpc/{{ openstack_release }}
   cloudkitty-base:
     type: git
     location: https://github.com/stackhpc/cloudkitty.git

--- a/releasenotes/notes/cinder-netapp-self-signed-caracal-7fc9794f6aabb76b.yaml
+++ b/releasenotes/notes/cinder-netapp-self-signed-caracal-7fc9794f6aabb76b.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Updates Cinder container images to resolve compatibility with NetApp ONTAP
+    when using self-signed certificates.


### PR DESCRIPTION
This fixes compatibility between Cinder and NetApp ONTAP when the storage backend is deployed using self-signed certificates.

https://github.com/stackhpc/cinder/pull/149 needs to be merged for the image build to be reproduced.