### PR TITLE
Add copy of tempest config for aio environment

### DIFF
--- a/.automation.conf/tempest/tempest-aio.overrides.conf
+++ b/.automation.conf/tempest/tempest-aio.overrides.conf
@@ -1,0 +1,2 @@
+[volume]
+catalog_type = volumev3

--- a/.automation.conf/tempest/tempest-ci-aio.overrides.conf
+++ b/.automation.conf/tempest/tempest-ci-aio.overrides.conf
@@ -1,2 +1,1 @@
-[volume]
-catalog_type = volumev3
+tempest-aio.overrides.conf


### PR DESCRIPTION
Running tempest with the ``automated-setup.sh`` for ``aio`` environment fails because it can't locate tempest override configuration for ``aio``.
Since ``ci-aio`` Kayobe environment inherits ``aio`` environment, Renamed ``tempest-ci-aio.overrides.conf`` to
``tempest-aio.overrides.conf`` then made symlink to ``tempest-ci-aio.oerrides.conf`` to make them sync.