### PR TITLE
cephadm: revert LEGACY crypto-policy workaround

### DIFF
--- a/etc/kayobe/ansible/ceph/cephadm-deploy.yml
+++ b/etc/kayobe/ansible/ceph/cephadm-deploy.yml
@@ -7,37 +7,6 @@
     - cephadm
     - cephadm-deploy
   tasks:
-    # note(owenjones): the Ceph release signing key still uses SHA-1, which requires us to
-    # downgrade to the LEGACY policy on Rocky 10 until a new key is published.
-    # A later Ceph release might fix this - https://tracker.ceph.com/issues/74861
-    - name: Discover current active crypto policy (Rocky 10)
-      ansible.builtin.command:
-        cmd: update-crypto-policies --show
-      become: true
-      changed_when: false
-      register: crypto_policy
-      when:
-        - ansible_facts.os_family == 'RedHat'
-        - ansible_facts.distribution_major_version | int == 10
-    - name: Set crypto policy to LEGACY (Rocky 10)
-      ansible.builtin.command:
-        cmd: update-crypto-policies --set LEGACY
-      become: true
-      when:
-        - ansible_facts.os_family == 'RedHat'
-        - ansible_facts.distribution_major_version | int == 10
-        - crypto_policy.stdout | default('DEFAULT') != 'LEGACY'
     - name: Apply Cephadm role
-      block:
-        - name: Apply Cephadm role
-          ansible.builtin.import_role:
-            name: stackhpc.cephadm.cephadm
-      always:
-        - name: Revert crypto policy (Rocky 10)
-          ansible.builtin.command:
-            cmd: update-crypto-policies --set {{ crypto_policy.stdout | default('DEFAULT') }}
-          become: true
-          when:
-            - ansible_facts.os_family == 'RedHat'
-            - ansible_facts.distribution_major_version | int == 10
-            - crypto_policy.stdout | default('DEFAULT') != 'LEGACY'
+      ansible.builtin.import_role:
+        name: stackhpc.cephadm.cephadm


### PR DESCRIPTION
Ceph have released a new package signing key[0] which is compatible with Rocky 10 crypto-policies DEFAULT and up, so we can now remove the workaround we had in place to drop the policy to LEGACY around cephadm deployment.

0: https://tracker.ceph.com/issues/74861#note-7

[Multinode run](https://github.com/stackhpc/stackhpc-kayobe-config/actions/runs/28931005052) - has already got beyond cephadm deployment.

Have tested new key properly imports into Rocky 9.[6-8] also.