### PR TITLE
Bump Ceph to v19.2.5

### DIFF
--- a/etc/kayobe/cephadm.yml
+++ b/etc/kayobe/cephadm.yml
@@ -12,7 +12,7 @@ cephadm_ceph_release: "squid"
 cephadm_image: "{{ stackhpc_docker_registry if stackhpc_sync_ceph_images | bool else 'quay.io' }}/ceph/ceph:{{ cephadm_image_tag }}"
 
 # Ceph container image tag.
-cephadm_image_tag: "v19.2.4"
+cephadm_image_tag: "v19.2.5"
 
 # HAProxy container image.
 cephadm_haproxy_image: "{{ stackhpc_docker_registry if stackhpc_sync_ceph_images | bool else 'quay.io' }}/ceph/haproxy:{{ cephadm_haproxy_image_tag }}"

--- a/releasenotes/notes/ceph-19.2.5-33d2bf497425bfad.yaml
+++ b/releasenotes/notes/ceph-19.2.5-33d2bf497425bfad.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Bumps Ceph to Squid v19.2.5.


### PR DESCRIPTION
https://ceph.io/en/news/blog/2026/v19-2-5-squid-released/