### PR TITLE
Fix RabbitMQ reset for 2026.1

### DIFF
--- a/etc/kayobe/ansible/fixes/rabbitmq-reset.yml
+++ b/etc/kayobe/ansible/fixes/rabbitmq-reset.yml
@@ -12,7 +12,7 @@
       ansible.builtin.shell:
         cmd: >-
           set -o pipefail &&
-          systemctl -a | grep -E 'kolla-(barbican|blazar|cinder|cloudkitty|designate|heat|ironic|keystone|magnum|manila|neutron|nova|octavia)' |
+          systemctl -a --state=loaded | grep -E 'kolla-(barbican|blazar|cinder|cloudkitty|designate|heat|ironic|keystone|magnum|manila|neutron|nova|octavia)' |
           awk '{ print $NF }' |
           xargs systemctl stop
         executable: "/bin/bash"
@@ -62,8 +62,8 @@
     - name: Stop app
       ansible.builtin.command: docker exec {{ container_name }} /bin/bash -c 'rabbitmqctl stop_app'
 
-    - name: Force reset app
-      ansible.builtin.command: docker exec {{ container_name }} /bin/bash -c 'rabbitmqctl force_reset'
+    - name: Reset app
+      ansible.builtin.command: docker exec {{ container_name }} /bin/bash -c 'rabbitmqctl reset'
 
     - name: Start app
       ansible.builtin.command: docker exec {{ container_name }} /bin/bash -c 'rabbitmqctl start_app'
@@ -86,7 +86,7 @@
       ansible.builtin.shell:
         cmd: >-
           set -o pipefail &&
-          systemctl list-units --type=service --all --no-legend --plain |
+          systemctl list-units --state=loaded --type=service --all --no-legend --plain |
           grep -E 'kolla-(barbican|blazar|cinder|cloudkitty|designate|heat|ironic|keystone|magnum|manila|neutron|nova|octavia)' |
           awk '{ print $1 }' |
           xargs -r systemctl restart


### PR DESCRIPTION
Two fixes:
1. unloaded `neutron_tls_proxy` service fails the stop check
```
cmd: set -o pipefail && systemctl -a | grep -E 'kolla-(barbican|blazar|cinder|cloudkitty|designate|heat|ironic|keystone|magnum|manila|neutron|nova|octavia)' | awk '{print $NF }' | xargs systemctl stop                                                                                                                                                                                                              delta: '0:01:01.410096'                                                                                                                                                                                                                                   end: '2026-07-15 11:52:13.342289' msg: non-zero return code
    rc: 123 
    start: '2026-07-15 11:51:11.932193'
    stderr: 'Failed to stop kolla-neutron_tls_proxy-container.service: Unit kolla-neutron_tls_proxy-container.service not loaded.' 
```
2. looks like rabbitmq force reset no longer works in this rmq version, replacing it with plain `reset` seems to work:
```
fatal: [mn-epoxy-controller-02]: FAILED! => 
    changed: true
    cmd:
    - docker
    - exec
    - rabbitmq
    - /bin/bash
    - -c
    - rabbitmqctl force_reset
    delta: '0:00:00.837238'
    end: '2026-07-15 12:07:35.372525'
    msg: non-zero return code
    rc: 69
    start: '2026-07-15 12:07:34.535287'
    stderr: |-
        Error:
        Forced reset is unsupported with Khepri
    stderr_lines: <omitted>
    stdout: |-
        Forcefully resetting node rabbit@mn-epoxy-controller-02 ...
        12:07:35.352 [error] DB: resetting node forcefully is unsupported with Khepri
    stdout_lines: <omitted> ```