### PR TITLE
Fix dracut warnings caused by PCI passthrough configuration

### DIFF
--- a/etc/kayobe/ansible/maintenance/pci-passthrough.yml
+++ b/etc/kayobe/ansible/maintenance/pci-passthrough.yml
@@ -26,7 +26,7 @@
       ansible.builtin.blockinfile:
         path: /etc/dracut.conf.d/gpu-vfio.conf
         block: |
-          add_drivers+="vfio vfio_iommu_type1 vfio_pci"
+          add_drivers+=" vfio vfio_iommu_type1 vfio_pci "
         owner: root
         group: root
         mode: 0660

--- a/etc/kayobe/ansible/maintenance/pci-passthrough.yml
+++ b/etc/kayobe/ansible/maintenance/pci-passthrough.yml
@@ -1,5 +1,5 @@
 ---
-- name: Enable GPU passthough
+- name: Enable GPU passthrough
   hosts: "{{ (gpu_group_map | default({})).keys() }}"
   vars:
     # This playbook will execute after nodes are deployed

--- a/etc/kayobe/ansible/maintenance/pci-passthrough.yml
+++ b/etc/kayobe/ansible/maintenance/pci-passthrough.yml
@@ -26,7 +26,7 @@
       ansible.builtin.blockinfile:
         path: /etc/dracut.conf.d/gpu-vfio.conf
         block: |
-          add_drivers+="vfio vfio_iommu_type1 vfio_pci vfio_virqfd"
+          add_drivers+="vfio vfio_iommu_type1 vfio_pci"
         owner: root
         group: root
         mode: 0660
@@ -43,7 +43,6 @@
           vfio
           vfio_iommu_type1
           vfio_pci
-          vfio_virqfd
         owner: root
         group: root
         mode: 0664

--- a/releasenotes/notes/pci-passthrough-fixes-e86adf1ae4d41659.yaml
+++ b/releasenotes/notes/pci-passthrough-fixes-e86adf1ae4d41659.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes PCI passthrough configuration following the removal of the
+    ``vfio_virqfd`` module from modern Linux kernels.


### PR DESCRIPTION
Fixes the following warnings:

```
/etc/dracut.conf.d/gpu-vfio.conf:add_drivers+="vfio vfio_iommu_type1 vfio_pci vfio_virqfd"                                                                                                                
                                                                                                                                                                                                          
dracut: WARNING: <key>+=" <values> ": <values> should have surrounding white spaces!                                                                                                                      
dracut: WARNING: This will lead to unwanted side effects! Please fix the configuration file.                                                                                                              
                                                                                                                                                                                                          
dracut-install: Failed to find module 'vfio_virqfd'                                                                                                                                                       
dracut: FAILED:  /usr/lib/dracut/dracut-install -D /var/tmp/dracut.9JxDzp/initramfs --kerneldir /lib/modules/5.14.0-687.25.1.el9_8.x86_64/ -m vfio vfio_iommu_type1 vfio_pci vfio_virqfd
```