### PR TITLE
Amphorae build fixes

### DIFF
--- a/etc/kayobe/ansible/maintenance/octavia-amphora-image-build.yml
+++ b/etc/kayobe/ansible/maintenance/octavia-amphora-image-build.yml
@@ -2,7 +2,6 @@
 - name: Build an Octavia Amphora image
   hosts: "{{ amphora_builder_group | default('seed') }}"
   vars:
-    amphora_dib_upper_constraints_file: "{{ pip_upper_constraints_file }}"
     amphora_image_dest: "{{ image_cache_path }}/amphora-x64-haproxy-{{ openstack_release }}.qcow2"
   tasks:
     - name: Install EPEL

--- a/etc/kayobe/ansible/maintenance/octavia-amphora-image-build.yml
+++ b/etc/kayobe/ansible/maintenance/octavia-amphora-image-build.yml
@@ -18,16 +18,17 @@
         packages_common:
           - debootstrap
           - git
-          - python3-venv
         packages_for_os_family:
           RedHat:
             - qemu-img
             - e2fsprogs
             - policycoreutils-python-utils
+            - python3-devel
             - yum-utils
           Debian:
             - qemu-utils
             - kpartx
+            - python3-venv
       ansible.builtin.package:
         name: "{{ packages_common + packages_for_os_family[ansible_facts.os_family] }}"
 

--- a/etc/kayobe/stackhpc.yml
+++ b/etc/kayobe/stackhpc.yml
@@ -270,6 +270,9 @@ download_amphora_from_ark: true
 # Octavia Amphora image version
 stackhpc_amphora_image_version: "2025.1-20260319T131237"
 
+# Whether to use a constraint for diskimage-builder version, default is none.
+amphora_dib_upper_constraints_file: ""
+
 ################################################################################
 # Certificate Authority
 

--- a/etc/kayobe/stackhpc.yml
+++ b/etc/kayobe/stackhpc.yml
@@ -268,7 +268,7 @@ stackhpc_enable_kolla_ansible_check: true
 download_amphora_from_ark: true
 
 # Octavia Amphora image version
-stackhpc_amphora_image_version: "2025.1-20260319T131237"
+stackhpc_amphora_image_version: "2025.1-20260730T080800"
 
 # Whether to use a constraint for diskimage-builder version, default is none.
 amphora_dib_upper_constraints_file: ""

--- a/releasenotes/notes/use-latest-dib-amphorae-c43d903780c08123.yaml
+++ b/releasenotes/notes/use-latest-dib-amphorae-c43d903780c08123.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Amphora image build playbook now uses the latest diskimage-builder version
+    by default. This ensures better operation and compatibility in general.


### PR DESCRIPTION
Arguably, we should be using the latest DIB and not pinned to the OpenStack release. This ensures recent OS versions compatibility and generic fixes and improvements included.

Also, fix Ubuntu vs. Rocky dependencies installation.