### PR TITLE
GT-1835: Fix IPA for stream 10

### DIFF
--- a/etc/kayobe/ipa.yml
+++ b/etc/kayobe/ipa.yml
@@ -14,10 +14,14 @@
 #ipa_build_source_version:
 
 # URL of IPA builder source repository.
-#ipa_builder_source_url:
+# NOTE(dougszu): This fork is required for centos-10 stream IPA images, which
+# are required (currently) to provide a version of qemu-img that can handle
+# 4k sectors from Dell Perc RAID controllers which don't support other block
+# sizes.
+ipa_builder_source_url: https://github.com/stackhpc/ironic-python-agent-builder.git
 
 # Version of IPA builder source repository. Default is {{ openstack_branch }}.
-#ipa_builder_source_version:
+ipa_builder_source_version: stackhpc/2025.1
 
 # List of additional build host packages to install. Default is an empty list.
 ipa_build_dib_host_packages_extra: [ 'zstd' ]


### PR DESCRIPTION
This switches to an IPA builder fork which is required for centos-10 stream IPA images, which are required (currently) to provide a version of qemu-img that can handle 4k sectors from Dell Perc RAID controllers which don't support other block sizes.

Anyone not affected can carry on using stream-9 images until Rocky ones exist.

We can drop this patch if we can backport
https://review.opendev.org/c/openstack/ironic-python-agent-builder/+/995589

Thanks to @owenjones for finding the patch ^.