### PR TITLE
Use host facts to select Rocky 9/10 distro version

### DIFF
--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -17,7 +17,7 @@ kolla_base_distro_and_version: "{% raw %}{{ kolla_base_distro }}-{{ kolla_base_d
 kolla_base_distro_version_default_map: {
   "centos": "stream9",
   "debian": "bookworm",
-  "rocky": "{{ os_release }}",
+  "rocky": "{% raw %}{{ ansible_facts.distribution_major_version }}{% endraw %}",
   "ubuntu": "noble",
 }
 

--- a/releasenotes/notes/r9-r10-kolla-base-distro-75078c4fbae4f785.yaml
+++ b/releasenotes/notes/r9-r10-kolla-base-distro-75078c4fbae4f785.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Uses host facts in ``kolla_base_distro_version_default_map`` to select
+    Rocky 9 or Rocky 10 Kolla images for each host.


### PR DESCRIPTION
Update kolla_base_distro_version_default_map to select Rocky 9 or Rocky 10 images for each host.