### PR TITLE
2026.1: Purge references to RL9 from GH workflow files

### DIFF
--- a/.github/workflows/ipa-image-build.yml
+++ b/.github/workflows/ipa-image-build.yml
@@ -3,14 +3,6 @@ name: Build IPA images
 on:
   workflow_dispatch:
     inputs:
-      rocky9:
-        description: Build Rocky Linux 9
-        type: boolean
-        default: false
-      rocky9-aarch64:
-        description: Build Rocky Linux 9 aarch64
-        type: boolean
-        default: false
       rocky10:
         description: Build Rocky Linux 10
         type: boolean
@@ -65,8 +57,6 @@ jobs:
       - name: Validate inputs
         run: |
           if [[
-            "${{ inputs.rocky9 }}" == "false" &&
-            "${{ inputs.rocky9-aarch64 }}" == "false" &&
             "${{ inputs.rocky10 }}" == "false" &&
             "${{ inputs.rocky10-aarch64 }}" == "false" &&
             "${{ inputs.ubuntu-noble }}" == "false"
@@ -76,7 +66,7 @@ jobs:
           fi
 
           if [[
-            ("${{ inputs.rocky9-aarch64 }}" == "true" || "${{ inputs.rocky10-aarch64 }}" == "true") &&
+            "${{ inputs.rocky10-aarch64 }}" == "true" &&
             "${{ inputs.runner_env }}" != "SMS Lab"
           ]]; then
             echo "aarch64 builds are only supported on SMS Lab"
@@ -101,7 +91,7 @@ jobs:
 
   ipa-image-build:
     name: Build IPA images (x86_64)
-    if: github.repository == 'stackhpc/stackhpc-kayobe-config' && (inputs.rocky9 || inputs.rocky10 || inputs.ubuntu-noble)
+    if: github.repository == 'stackhpc/stackhpc-kayobe-config' && (inputs.rocky10 || inputs.ubuntu-noble)
     environment: ${{ inputs.runner_env }}
     runs-on: ${{ needs.runner-selection.outputs.runner_name_image_build }}
     needs:
@@ -324,68 +314,6 @@ jobs:
           scp -r ubuntu@$(jq -r .access_ip_v4.value src/kayobe-config/etc/kayobe/environments/ci-builder/tf-outputs.yml):/opt/kayobe/images/*/*.std* ./logs/ubuntu-noble/
         if: inputs.ubuntu-noble
 
-      - name: Build a Rocky 9 IPA image
-        id: build_rocky_9_ipa
-        continue-on-error: true
-        run: |
-          source venvs/kayobe/bin/activate &&
-          source src/kayobe-config/kayobe-env --environment ci-builder &&
-          kayobe overcloud deployment image build --force-rebuild \
-          -e ipa_build_distro="centos" \
-          -e ipa_build_release="9-stream"
-        env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
-        if: inputs.rocky9
-
-      - name: Show last error logs
-        continue-on-error: true
-        run: |
-          source venvs/kayobe/bin/activate &&
-          source src/kayobe-config/kayobe-env --environment ci-builder &&
-          kayobe seed host command run --command "tail -200 /opt/kayobe/images/ipa/ipa.stdout" --show-output
-        env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
-        if: steps.build_rocky_9_ipa.outcome == 'failure'
-
-      - name: Upload Rocky 9 IPA kernel image to Ark
-        run: |
-          source venvs/kayobe/bin/activate &&
-          source src/kayobe-config/kayobe-env --environment ci-builder &&
-          kayobe playbook run \
-          src/kayobe-config/etc/kayobe/ansible/pulp/pulp-artifact-upload.yml \
-          -e artifact_path=/opt/kayobe/images/ipa \
-          -e artifact_type=ipa-images \
-          -e artifact_tag=${{ needs.create-tag.outputs.ipa_image_tag }} \
-          -e os_distribution="rocky" \
-          -e os_release="9" \
-          -e file_regex='*.kernel'
-        env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
-        if: inputs.rocky9 && steps.build_rocky_9_ipa.outcome == 'success'
-
-      - name: Upload Rocky 9 IPA ramdisk image to Ark
-        run: |
-          source venvs/kayobe/bin/activate &&
-          source src/kayobe-config/kayobe-env --environment ci-builder &&
-          kayobe playbook run \
-          src/kayobe-config/etc/kayobe/ansible/pulp/pulp-artifact-upload.yml \
-          -e artifact_path=/opt/kayobe/images/ipa \
-          -e artifact_type=ipa-images \
-          -e artifact_tag=${{ needs.create-tag.outputs.ipa_image_tag }} \
-          -e os_distribution="rocky" \
-          -e os_release="9" \
-          -e file_regex='*.initramfs'
-        env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
-        if: inputs.rocky9 && steps.build_rocky_9_ipa.outcome == 'success'
-
-      - name: Copy logs back
-        continue-on-error: true
-        run: |
-          mkdir -p logs/rocky-9
-          scp -r ubuntu@$(jq -r .access_ip_v4.value src/kayobe-config/etc/kayobe/environments/ci-builder/tf-outputs.yml):/opt/kayobe/images/*/*.std* ./logs/rocky-9/
-        if: inputs.rocky9
-
       - name: Build a Rocky 10 IPA image
         id: build_rocky_10_ipa
         continue-on-error: true
@@ -458,8 +386,7 @@ jobs:
         run: |
           echo "Builds failed. See workflow artifacts for details." &&
           exit 1
-        if: steps.build_rocky_9_ipa.outcome == 'failure' ||
-            steps.build_rocky_10_ipa.outcome == 'failure' ||
+        if: steps.build_rocky_10_ipa.outcome == 'failure' ||
             steps.build_ubuntu_noble_ipa.outcome == 'failure'
 
       - name: Destroy
@@ -473,7 +400,7 @@ jobs:
 
   ipa-image-build-aarch64:
     name: Build IPA images (aarch64)
-    if: github.repository == 'stackhpc/stackhpc-kayobe-config' && (inputs.rocky9-aarch64 || inputs.rocky10-aarch64) && inputs.runner_env == 'SMS Lab'
+    if: github.repository == 'stackhpc/stackhpc-kayobe-config' && inputs.rocky10-aarch64 && inputs.runner_env == 'SMS Lab'
     environment: ${{ inputs.runner_env }}
     runs-on: ${{ needs.runner-selection.outputs.runner_name_image_build }}
     needs:
@@ -634,73 +561,6 @@ jobs:
         env:
           KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
 
-      - name: Build a Rocky 9 aarch64 IPA image
-        id: build_rocky_9_ipa_aarch64
-        continue-on-error: true
-        run: |
-          source venvs/kayobe/bin/activate &&
-          source src/kayobe-config/kayobe-env --environment ci-builder &&
-          kayobe overcloud deployment image build --force-rebuild \
-          -e ipa_build_distro="centos" \
-          -e ipa_build_release="9-stream" \
-          -e ipa_build_arch="aarch64"
-        env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
-        if: inputs.rocky9-aarch64
-
-      - name: Show last error logs
-        continue-on-error: true
-        run: |
-          source venvs/kayobe/bin/activate &&
-          source src/kayobe-config/kayobe-env --environment ci-builder &&
-          kayobe seed host command run --command "tail -200 /opt/kayobe/images/ipa/ipa.stdout" --show-output
-        env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
-        if: steps.build_rocky_9_ipa_aarch64.outcome == 'failure'
-
-      - name: Upload Rocky 9 aarch64 IPA kernel image to Ark
-        run: |
-          source venvs/kayobe/bin/activate &&
-          source src/kayobe-config/kayobe-env --environment ci-builder &&
-          kayobe playbook run \
-          src/kayobe-config/etc/kayobe/ansible/pulp/pulp-artifact-upload.yml \
-          -e artifact_path=/opt/kayobe/images/ipa \
-          -e artifact_type=ipa-images \
-          -e artifact_tag=${{ needs.create-tag.outputs.ipa_image_tag }} \
-          -e repository_name="ipa-images-${{ needs.create-tag.outputs.openstack_release }}-rocky-9-aarch64" \
-          -e pulp_base_path="ipa-images/${{ needs.create-tag.outputs.openstack_release }}/rocky/9/aarch64" \
-          -e os_distribution="rocky" \
-          -e os_release="9" \
-          -e file_regex='ipa.kernel'
-        env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
-        if: steps.build_rocky_9_ipa_aarch64.outcome == 'success'
-
-      - name: Upload Rocky 9 aarch64 IPA ramdisk image to Ark
-        run: |
-          source venvs/kayobe/bin/activate &&
-          source src/kayobe-config/kayobe-env --environment ci-builder &&
-          kayobe playbook run \
-          src/kayobe-config/etc/kayobe/ansible/pulp/pulp-artifact-upload.yml \
-          -e artifact_path=/opt/kayobe/images/ipa \
-          -e artifact_type=ipa-images \
-          -e artifact_tag=${{ needs.create-tag.outputs.ipa_image_tag }} \
-          -e repository_name="ipa-images-${{ needs.create-tag.outputs.openstack_release }}-rocky-9-aarch64" \
-          -e pulp_base_path="ipa-images/${{ needs.create-tag.outputs.openstack_release }}/rocky/9/aarch64" \
-          -e os_distribution="rocky" \
-          -e os_release="9" \
-          -e file_regex='ipa.initramfs'
-        env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
-        if: steps.build_rocky_9_ipa_aarch64.outcome == 'success'
-
-      - name: Copy logs back
-        continue-on-error: true
-        run: |
-          mkdir -p logs/rocky-9
-          scp -r ubuntu@$(jq -r .access_ip_v4.value src/kayobe-config/etc/kayobe/environments/ci-builder/tf-outputs.yml):/opt/kayobe/images/*/*.std* ./logs/rocky-9/
-        if: inputs.rocky9-aarch64
-
       - name: Build a Rocky 10 aarch64 IPA image
         id: build_rocky_10_ipa_aarch64
         continue-on-error: true
@@ -778,7 +638,7 @@ jobs:
         run: |
           echo "Build failed. See workflow artifacts for details." &&
           exit 1
-        if: steps.build_rocky_9_ipa_aarch64.outcome == 'failure' || steps.build_rocky_10_ipa_aarch64.outcome == 'failure'
+        if: steps.build_rocky_10_ipa_aarch64.outcome == 'failure'
 
       - name: Destroy
         run: terraform destroy -auto-approve

--- a/.github/workflows/ipa-image-promote.yml
+++ b/.github/workflows/ipa-image-promote.yml
@@ -3,14 +3,6 @@ name: Promote IPA image
 on:
   workflow_dispatch:
     inputs:
-      rocky9:
-        description: Promote Rocky Linux 9
-        type: boolean
-        default: true
-      rocky9-aarch64:
-        description: Promote Rocky Linux 9 aarch64
-        type: boolean
-        default: true
       rocky10:
         description: Promote Rocky Linux 10
         type: boolean
@@ -38,8 +30,6 @@ jobs:
       - name: Validate inputs
         run: |
           if [[
-            "${{ inputs.rocky9 }}" == "false" &&
-            "${{ inputs.rocky9-aarch64 }}" == "false" &&
             "${{ inputs.rocky10 }}" == "false" &&
             "${{ inputs.rocky10-aarch64 }}" == "false" &&
             "${{ inputs.ubuntu-noble }}" == "false"
@@ -89,7 +79,7 @@ jobs:
           source src/kayobe-config/kayobe-env --environment ci-builder &&
           kayobe control host bootstrap
 
-      - name: Promote Rocky Linux 9 IPA image artifact
+      - name: Promote Rocky Linux 10 IPA image artifact
         run: |
           source venvs/kayobe/bin/activate &&
           source src/kayobe-config/kayobe-env --environment ci-builder &&
@@ -97,24 +87,24 @@ jobs:
           src/kayobe-config/etc/kayobe/ansible/pulp/pulp-artifact-promote.yml \
           -e artifact_type="ipa-images" \
           -e os_distribution='rocky' \
-          -e os_release='9'
+          -e os_release='10'
         env:
           ARTIFACT_TAG: ${{ inputs.image_tag }}
           KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
-        if: inputs.rocky9
+        if: inputs.rocky10
 
-      - name: Promote Rocky Linux 9 aarch64 IPA image artifact
+      - name: Promote Rocky Linux 10 aarch64 IPA image artifact
         run: |
           source venvs/kayobe/bin/activate &&
           source src/kayobe-config/kayobe-env --environment ci-builder &&
           kayobe playbook run \
           src/kayobe-config/etc/kayobe/ansible/pulp/pulp-artifact-promote.yml \
-          -e repository_name="ipa-images-${{ steps.openstack_release.outputs.openstack_release }}-rocky-9-aarch64" \
-          -e pulp_base_path="ipa-images/${{ steps.openstack_release.outputs.openstack_release }}/rocky/9/aarch64"
+          -e repository_name="ipa-images-${{ steps.openstack_release.outputs.openstack_release }}-rocky-10-aarch64" \
+          -e pulp_base_path="ipa-images/${{ steps.openstack_release.outputs.openstack_release }}/rocky/10/aarch64"
         env:
           ARTIFACT_TAG: ${{ inputs.image_tag }}
           KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
-        if: inputs.rocky9-aarch64
+        if: inputs.rocky10-aarch64
 
       - name: Promote Rocky Linux 10 IPA image artifact
         run: |

--- a/.github/workflows/overcloud-host-image-build.yml
+++ b/.github/workflows/overcloud-host-image-build.yml
@@ -3,14 +3,6 @@ name: Build overcloud host images
 on:
   workflow_dispatch:
     inputs:
-      rocky9:
-        description: Build Rocky Linux 9
-        type: boolean
-        default: false
-      rocky9-aarch64:
-        description: Build Rocky Linux 9 aarch64
-        type: boolean
-        default: false
       rocky10:
         description: Build Rocky Linux 10
         type: boolean
@@ -74,8 +66,6 @@ jobs:
       - name: Validate inputs
         run: |
           if [[
-            "${{ inputs.rocky9 }}" == "false" &&
-            "${{ inputs.rocky9-aarch64 }}" == "false" &&
             "${{ inputs.rocky10 }}" == "false" &&
             "${{ inputs.rocky10-aarch64 }}" == "false" &&
             "${{ inputs.ubuntu-noble }}" == "false"
@@ -85,7 +75,7 @@ jobs:
           fi
 
           if [[
-            ("${{ inputs.rocky9-aarch64 }}" == "true" || "${{ inputs.rocky10-aarch64 }}" == "true") &&
+            ("${{ inputs.rocky10-aarch64 }}" == "true") &&
             "${{ inputs.runner_env }}" != "SMS Lab"
           ]]; then
             echo "aarch64 builds are only supported on SMS Lab"
@@ -106,7 +96,7 @@ jobs:
 
   overcloud-host-image-build:
     name: Build overcloud host images
-    if: github.repository == 'stackhpc/stackhpc-kayobe-config' && (inputs.rocky9 || inputs.rocky10 || inputs.ubuntu-noble)
+    if: github.repository == 'stackhpc/stackhpc-kayobe-config' && (inputs.rocky10 || inputs.ubuntu-noble)
     environment: ${{ inputs.runner_env }}
     runs-on: ${{ needs.runner-selection.outputs.runner_name_image_build }}
     needs:
@@ -269,74 +259,6 @@ jobs:
         env:
           KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
 
-      - name: Build a Rocky Linux 9 overcloud host image
-        id: build_rocky_9
-        continue-on-error: true
-        run: |
-          source venvs/kayobe/bin/activate &&
-          source src/kayobe-config/kayobe-env --environment ci-builder &&
-          kayobe overcloud host image build --force-rebuild \
-          -e os_distribution="rocky" \
-          -e os_release="9" \
-          -e stackhpc_overcloud_dib_name=overcloud-rocky-9
-        env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
-        if: inputs.rocky9
-
-      - name: Show last error logs
-        continue-on-error: true
-        run: |
-          source venvs/kayobe/bin/activate &&
-          source src/kayobe-config/kayobe-env --environment ci-builder &&
-          kayobe seed host command run --command "tail -200 /opt/kayobe/images/overcloud-rocky-9/overcloud-rocky-9.stdout" --show-output
-        env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
-        if: steps.build_rocky_9.outcome == 'failure'
-
-      - name: Upload Rocky Linux 9 overcloud host image to current Dev Cloud (SMS/Leafcloud)
-        run: |
-          source venvs/kayobe/bin/activate &&
-          source src/kayobe-config/kayobe-env --environment ci-builder &&
-          kayobe playbook run \
-          src/kayobe-config/etc/kayobe/ansible/tools/openstack-host-image-upload.yml \
-          -e local_image_path="/opt/kayobe/images/overcloud-rocky-9/overcloud-rocky-9.qcow2" \
-          -e image_name=overcloud-rocky-9-${{ needs.create-tag.outputs.host_image_tag }}
-        env:
-          CLOUDS_YAML: ${{ secrets.CLOUDS_YAML }}
-          OS_APPLICATION_CREDENTIAL_ID: ${{ secrets.OS_APPLICATION_CREDENTIAL_ID }}
-          OS_APPLICATION_CREDENTIAL_SECRET: ${{ secrets.OS_APPLICATION_CREDENTIAL_SECRET }}
-        if: inputs.rocky9 && steps.build_rocky_9.outcome == 'success'
-
-      - name: Upload Rocky Linux 9 overcloud host image to other Dev Cloud (Leafcloud/SMS)
-        run: |
-          source venvs/kayobe/bin/activate &&
-          source src/kayobe-config/kayobe-env --environment ci-builder &&
-          kayobe playbook run \
-          src/kayobe-config/etc/kayobe/ansible/tools/openstack-host-image-upload.yml \
-          -e local_image_path="/opt/kayobe/images/overcloud-rocky-9/overcloud-rocky-9.qcow2" \
-          -e image_name=overcloud-rocky-9-${{ needs.create-tag.outputs.host_image_tag }}
-        env:
-          CLOUDS_YAML: ${{ secrets.CLOUDS_YAML_OTHER_CLOUD }}
-          OS_APPLICATION_CREDENTIAL_ID: ${{ secrets.OS_APPLICATION_CREDENTIAL_ID_OTHER_CLOUD }}
-          OS_APPLICATION_CREDENTIAL_SECRET: ${{ secrets.OS_APPLICATION_CREDENTIAL_SECRET_OTHER_CLOUD }}
-        if: inputs.rocky9 && steps.build_rocky_9.outcome == 'success'
-
-      - name: Upload Rocky Linux 9 overcloud host image to Ark
-        run: |
-          source venvs/kayobe/bin/activate &&
-          source src/kayobe-config/kayobe-env --environment ci-builder &&
-          kayobe playbook run \
-          src/kayobe-config/etc/kayobe/ansible/pulp/pulp-artifact-upload.yml \
-          -e artifact_path=/opt/kayobe/images/overcloud-rocky-9 \
-          -e artifact_tag=${{ needs.create-tag.outputs.host_image_tag }} \
-          -e artifact_type="kayobe-images" \
-          -e file_regex="*.qcow2" \
-          -e os_distribution="rocky" \
-          -e os_release="9"
-        env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
-        if: inputs.rocky9 && steps.build_rocky_9.outcome == 'success'
-
       - name: Build a Rocky Linux 10 overcloud host image
         id: build_rocky_10
         continue-on-error: true
@@ -485,8 +407,7 @@ jobs:
         run: |
           echo "Builds failed. See workflow artifacts for details." &&
           exit 1
-        if: steps.build_rocky_9.outcome == 'failure' ||
-            steps.build_rocky_10.outcome == 'failure' ||
+        if: steps.build_rocky_10.outcome == 'failure' ||
             steps.build_ubuntu_noble.outcome == 'failure'
 
       - name: Upload logs artifact
@@ -511,7 +432,6 @@ jobs:
           update-overcloud-host-image-tags.yml \
           --repo stackhpc/stackhpc-kayobe-config \
           --ref $BRANCH_NAME \
-          $(if [[ "${{ inputs.rocky9 }}" == "true" ]]; then echo "-f rocky9_tag=${{ needs.create-tag.outputs.host_image_tag }}"; fi) \
           $(if [[ "${{ inputs.rocky10 }}" == "true" ]]; then echo "-f rocky10_tag=${{ needs.create-tag.outputs.host_image_tag }}"; fi) \
           $(if [[ "${{ inputs.ubuntu-noble }}" == "true" ]]; then echo "-f ubuntu_noble_tag=${{ needs.create-tag.outputs.host_image_tag }}"; fi)
         env:
@@ -549,7 +469,7 @@ jobs:
 
   overcloud-host-image-build-aarch64:
     name: Build aarch64 overcloud host images
-    if: github.repository == 'stackhpc/stackhpc-kayobe-config' && inputs.runner_env == 'SMS Lab' && (inputs.rocky9-aarch64 || inputs.rocky10-aarch64)
+    if: github.repository == 'stackhpc/stackhpc-kayobe-config' && inputs.runner_env == 'SMS Lab' && inputs.rocky10-aarch64
     environment: ${{ inputs.runner_env }}
     runs-on: ${{ needs.runner-selection.outputs.runner_name_image_build }}
     needs:
@@ -712,64 +632,6 @@ jobs:
         env:
           KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
 
-      - name: Build a Rocky Linux 9 aarch64 overcloud host image
-        id: build_rocky_9_aarch64
-        continue-on-error: true
-        run: |
-          source venvs/kayobe/bin/activate &&
-          source src/kayobe-config/kayobe-env --environment ci-builder &&
-          kayobe overcloud host image build --force-rebuild \
-          -e kolla_base_arch="aarch64" \
-          -e os_distribution="rocky" \
-          -e os_release="9" \
-          -e stackhpc_overcloud_dib_name=overcloud-rocky-9
-        env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
-        if: inputs.rocky9-aarch64
-
-      - name: Show last error logs
-        continue-on-error: true
-        run: |
-          source venvs/kayobe/bin/activate &&
-          source src/kayobe-config/kayobe-env --environment ci-builder &&
-          kayobe seed host command run --command "tail -200 /opt/kayobe/images/overcloud-rocky-9/overcloud-rocky-9.stdout" --show-output
-        env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
-        if: steps.build_rocky_9_aarch64.outcome == 'failure'
-
-      - name: Upload Rocky Linux 9 aarch64 overcloud host image to current Dev Cloud (SMS)
-        run: |
-          source venvs/kayobe/bin/activate &&
-          source src/kayobe-config/kayobe-env --environment ci-builder &&
-          kayobe playbook run \
-          src/kayobe-config/etc/kayobe/ansible/tools/openstack-host-image-upload.yml \
-          -e local_image_path="/opt/kayobe/images/overcloud-rocky-9/overcloud-rocky-9.qcow2" \
-          -e image_name=overcloud-rocky-9-aarch64-${{ needs.create-tag.outputs.host_image_tag }} \
-          -e '{"image_properties":{"hw_architecture":"aarch64"}}'
-        env:
-          CLOUDS_YAML: ${{ secrets.CLOUDS_YAML }}
-          OS_APPLICATION_CREDENTIAL_ID: ${{ secrets.OS_APPLICATION_CREDENTIAL_ID }}
-          OS_APPLICATION_CREDENTIAL_SECRET: ${{ secrets.OS_APPLICATION_CREDENTIAL_SECRET }}
-        if: inputs.rocky9-aarch64 && steps.build_rocky_9_aarch64.outcome == 'success'
-
-      - name: Upload Rocky Linux 9 aarch64 overcloud host image to Ark
-        run: |
-          source venvs/kayobe/bin/activate &&
-          source src/kayobe-config/kayobe-env --environment ci-builder &&
-          kayobe playbook run \
-          src/kayobe-config/etc/kayobe/ansible/pulp/pulp-artifact-upload.yml \
-          -e artifact_path=/opt/kayobe/images/overcloud-rocky-9 \
-          -e artifact_tag=${{ needs.create-tag.outputs.host_image_tag }} \
-          -e artifact_type="kayobe-images" \
-          -e file_regex="*.qcow2" \
-          -e os_distribution="rocky" \
-          -e os_release="9" \
-          -e repository_name="kayobe-images-${{ needs.create-tag.outputs.openstack_release }}-rocky-9-aarch64" \
-          -e pulp_base_path="kayobe-images/${{ needs.create-tag.outputs.openstack_release }}/rocky/9/aarch64"
-        env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
-        if: inputs.rocky9-aarch64 && steps.build_rocky_9_aarch64.outcome == 'success'
-
       - name: Build a Rocky Linux 10 aarch64 overcloud host image
         id: build_rocky_10_aarch64
         continue-on-error: true
@@ -840,8 +702,7 @@ jobs:
         run: |
           echo "Builds failed. See workflow artifacts for details." &&
           exit 1
-        if: steps.build_rocky_9_aarch64.outcome == 'failure' ||
-            steps.build_rocky_10_aarch64.outcome == 'failure'
+        if: steps.build_rocky_10_aarch64.outcome == 'failure'
 
       - name: Upload logs artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
@@ -865,7 +726,6 @@ jobs:
           update-overcloud-host-image-tags.yml \
           --repo stackhpc/stackhpc-kayobe-config \
           --ref $BRANCH_NAME \
-          $(if [[ "${{ inputs.rocky9-aarch64 }}" == "true" ]]; then echo "-f rocky9_aarch64_tag=${{ needs.create-tag.outputs.host_image_tag }}"; fi) \
           $(if [[ "${{ inputs.rocky10-aarch64 }}" == "true" ]]; then echo "-f rocky10_aarch64_tag=${{ needs.create-tag.outputs.host_image_tag }}"; fi)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/overcloud-host-image-promote.yml
+++ b/.github/workflows/overcloud-host-image-promote.yml
@@ -3,14 +3,6 @@ name: Promote overcloud host image
 on:
   workflow_dispatch:
     inputs:
-      rocky9:
-        description: Promote Rocky Linux 9
-        type: boolean
-        default: false
-      rocky9-aarch64:
-        description: Promote Rocky Linux 9 aarch64
-        type: boolean
-        default: true
       rocky10:
         description: Promote Rocky Linux 10
         type: boolean
@@ -33,7 +25,7 @@ jobs:
     steps:
       - name: Validate inputs
         run: |
-          if [[ ${{ inputs.rocky9 }} == 'false' && ${{ inputs.rocky9-aarch64 }} == 'false' && ${{ inputs.rocky10 }} == 'false' && ${{ inputs.rocky10-aarch64 }} == 'false' && ${{ inputs.ubuntu-noble }} == 'false' ]]; then
+          if [[ ${{ inputs.rocky10 }} == 'false' && ${{ inputs.rocky10-aarch64 }} == 'false' && ${{ inputs.ubuntu-noble }} == 'false' ]]; then
             echo "At least one distribution must be selected"
             exit 1
           fi
@@ -79,26 +71,12 @@ jobs:
           source src/kayobe-config/kayobe-env --environment ci-builder &&
           kayobe control host bootstrap
 
-      - name: Gather Rocky Linux 9 overcloud host image tag
-        id: rocky9_image_tag
-        run: |
-          echo image_tag=$(grep stackhpc_rocky_9_overcloud_host_image_version: etc/kayobe/pulp-host-image-versions.yml | awk '{print $2}') >> $GITHUB_OUTPUT
-        working-directory: src/kayobe-config
-        if: inputs.rocky9
-
       - name: Gather Rocky Linux 10 overcloud host image tag
         id: rocky10_image_tag
         run: |
           echo image_tag=$(grep stackhpc_rocky_10_overcloud_host_image_version: etc/kayobe/pulp-host-image-versions.yml | awk '{print $2}') >> $GITHUB_OUTPUT
         working-directory: src/kayobe-config
         if: inputs.rocky10
-
-      - name: Gather Rocky Linux 9 aarch64 overcloud host image tag
-        id: rocky9_aarch64_image_tag
-        run: |
-          echo image_tag=$(grep stackhpc_rocky_9_overcloud_host_image_version_aarch64: etc/kayobe/pulp-host-image-versions.yml | awk '{print $2}') >> $GITHUB_OUTPUT
-        working-directory: src/kayobe-config
-        if: inputs.rocky9-aarch64
 
       - name: Gather Rocky Linux 10 aarch64 overcloud host image tag
         id: rocky10_aarch64_image_tag
@@ -114,20 +92,6 @@ jobs:
         working-directory: src/kayobe-config
         if: inputs.ubuntu-noble
 
-      - name: Promote Rocky Linux 9 overcloud host image artifact
-        run: |
-          source venvs/kayobe/bin/activate &&
-          source src/kayobe-config/kayobe-env --environment ci-builder &&
-          kayobe playbook run \
-          src/kayobe-config/etc/kayobe/ansible/pulp/pulp-artifact-promote.yml \
-          -e artifact_type="kayobe-images" \
-          -e os_distribution='rocky' \
-          -e os_release='9' \
-          -e promotion_tag=${{ steps.rocky9_image_tag.outputs.image_tag }}
-        env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
-        if: inputs.rocky9
-
       - name: Promote Rocky Linux 10 overcloud host image artifact
         run: |
           source venvs/kayobe/bin/activate &&
@@ -141,22 +105,6 @@ jobs:
         env:
           KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
         if: inputs.rocky10
-
-      - name: Promote Rocky Linux 9 aarch64 overcloud host image artifact
-        run: |
-          source venvs/kayobe/bin/activate &&
-          source src/kayobe-config/kayobe-env --environment ci-builder &&
-          kayobe playbook run \
-          src/kayobe-config/etc/kayobe/ansible/pulp/pulp-artifact-promote.yml \
-          -e artifact_type="kayobe-images" \
-          -e os_distribution='rocky' \
-          -e os_release='9' \
-          -e promotion_tag=${{ steps.rocky9_aarch64_image_tag.outputs.image_tag }} \
-          -e repository_name="kayobe-images-${{ steps.openstack_release.outputs.openstack_release }}-rocky-9-aarch64" \
-          -e pulp_base_path="kayobe-images/${{ steps.openstack_release.outputs.openstack_release }}/rocky/9/aarch64"
-        env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
-        if: inputs.rocky9-aarch64
 
       - name: Promote Rocky Linux 10 aarch64 overcloud host image artifact
         run: |

--- a/.github/workflows/overcloud-host-image-upload.yml
+++ b/.github/workflows/overcloud-host-image-upload.yml
@@ -3,10 +3,6 @@ name: Upload overcloud host images
 on:
   workflow_dispatch:
     inputs:
-      rocky9:
-        description: Upload Rocky Linux 9
-        type: boolean
-        default: false
       rocky10:
         description: Upload Rocky Linux 10
         type: boolean
@@ -54,7 +50,7 @@ jobs:
     steps:
       - name: Validate inputs
         run: |
-          if [[ ${{ inputs.rocky9 }} == 'false' && ${{ inputs.rocky10 }} == 'false' && ${{ inputs.ubuntu-noble }} == 'false' ]]; then
+          if [[ ${{ inputs.rocky10 }} == 'false' && ${{ inputs.ubuntu-noble }} == 'false' ]]; then
             echo "At least one distribution must be selected"
             exit 1
           fi
@@ -99,51 +95,6 @@ jobs:
         run: |
           source venvs/kayobe/bin/activate &&
           pip install python-openstackclient -c https://raw.githubusercontent.com/stackhpc/requirements/refs/heads/stackhpc/${{ steps.openstack_release.outputs.openstack_release }}/upper-constraints.txt
-
-      - name: Output Rocky Linux 9 image tag
-        id: rocky_9_image_tag
-        run: |
-          echo image_tag=$(grep stackhpc_rocky_9_overcloud_host_image_version: src/kayobe-config/etc/kayobe/pulp-host-image-versions.yml | awk '{print $2}') >> $GITHUB_OUTPUT
-
-      - name: Check if image exists already
-        id: rocky_9_image_exists
-        run: |
-          source venvs/kayobe/bin/activate &&
-          openstack image show \
-          overcloud-rocky-9-${{ steps.rocky_9_image_tag.outputs.image_tag }}
-        env:
-          OS_CLOUD: openstack
-          OS_APPLICATION_CREDENTIAL_ID: ${{ secrets.OS_APPLICATION_CREDENTIAL_ID }}
-          OS_APPLICATION_CREDENTIAL_SECRET: ${{ secrets.OS_APPLICATION_CREDENTIAL_SECRET }}
-        continue-on-error: true
-
-      - name: Download Rocky Linux 9 overcloud host image from Ark
-        run: |
-          source venvs/kayobe/bin/activate &&
-          source src/kayobe-config/kayobe-env --environment ${{ inputs.kayobe-environment }} &&
-          kayobe playbook run \
-          src/kayobe-config/etc/kayobe/ansible/pulp/pulp-host-image-download.yml \
-          -e os_distribution="rocky" \
-          -e os_release="9"
-        env:
-          KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_BUILDER }}
-        if: inputs.rocky9 && steps.rocky_9_image_exists.outcome == 'failure'
-
-      - name: Upload Rocky Linux 9 overcloud host image to Cloud
-        run: |
-          source venvs/kayobe/bin/activate &&
-          openstack image create \
-          overcloud-rocky-9-${{ steps.rocky_9_image_tag.outputs.image_tag }} \
-          --container-format bare \
-          --disk-format qcow2 \
-          --file /tmp/rocky-9.qcow2 \
-          --private \
-          --progress
-        env:
-          OS_CLOUD: openstack
-          OS_APPLICATION_CREDENTIAL_ID: ${{ secrets.OS_APPLICATION_CREDENTIAL_ID }}
-          OS_APPLICATION_CREDENTIAL_SECRET: ${{ secrets.OS_APPLICATION_CREDENTIAL_SECRET }}
-        if: inputs.rocky9 && steps.rocky_9_image_exists.outcome == 'failure'
 
       - name: Output Rocky Linux 10 image tag
         id: rocky_10_image_tag

--- a/.github/workflows/package-build-ofed.yml
+++ b/.github/workflows/package-build-ofed.yml
@@ -3,10 +3,8 @@ name: Build OFED kernel modules
 on:
   workflow_dispatch:
     inputs:
-      rocky9:
-        description: Build Rocky Linux 9
-        type: boolean
-        default: true
+      # NOTE(Alex-Welsh): There's only one option here, but it's easier to
+      # extend in the future when there's more e.g. RL11, Ubuntu
       rocky10:
         description: Build Rocky Linux 10
         type: boolean
@@ -38,7 +36,6 @@ jobs:
       - name: Validate inputs
         run: |
           if [[
-            "${{ inputs.rocky9 }}" == "false" &&
             "${{ inputs.rocky10 }}" == "false"
           ]]; then
             echo "At least one distribution must be selected"
@@ -52,10 +49,6 @@ jobs:
         id: set-matrix
         run: |
           output="{'distro': ["
-          if [[ ${{ inputs.rocky9 }} == 'true' ]]; then
-              output+="{'name': 'rocky', 'release': '9', 'arch': 'x86_64'},"
-              output+="{'name': 'rocky', 'release': '9', 'arch': 'aarch64'},"
-          fi
           if [[ ${{ inputs.rocky10 }} == 'true' ]]; then
               output+="{'name': 'rocky', 'release': '10', 'arch': 'x86_64'},"
               output+="{'name': 'rocky', 'release': '10', 'arch': 'aarch64'},"

--- a/.github/workflows/stackhpc-build-kayobe-image.yml
+++ b/.github/workflows/stackhpc-build-kayobe-image.yml
@@ -92,7 +92,7 @@ jobs:
           build-args: |
              http_proxy=${{ inputs.http_proxy }}
              https_proxy=${{ inputs.https_proxy }}
-             BASE_IMAGE=${{ inputs.base_image || 'rockylinux/rockylinux:9' }}
+             BASE_IMAGE=${{ inputs.base_image || 'rockylinux/rockylinux:10' }}
              USE_PYTHON_312=true
              KAYOBE_USER_UID=1001
              KAYOBE_USER_GID=1001

--- a/.github/workflows/stackhpc-container-image-build.yml
+++ b/.github/workflows/stackhpc-container-image-build.yml
@@ -18,11 +18,6 @@ on:
         type: boolean
         required: false
         default: false
-      rocky-linux-9:
-        description: Build Rocky Linux 9 images?
-        type: boolean
-        required: false
-        default: false
       rocky-linux-10:
         description: Build Rocky Linux 10 images?
         type: boolean
@@ -71,7 +66,7 @@ jobs:
     steps:
       - name: Validate inputs
         run: |
-          if [[ ${{ inputs.rocky-linux-9 }} == 'false' && ${{ inputs.rocky-linux-10 }} == 'false' && ${{ inputs.ubuntu-noble }} == 'false' ]]; then
+          if [[ ${{ inputs.rocky-linux-10 }} == 'false' && ${{ inputs.ubuntu-noble }} == 'false' ]]; then
             echo "At least one distribution must be selected"
             exit 1
           fi
@@ -100,17 +95,11 @@ jobs:
       # We need a separate matrix entry for each distribution, when the relevant input is true.
       # https://stackoverflow.com/questions/65384420/how-do-i-make-a-github-action-matrix-element-conditional
       # NOTE(bbezak): Both amd64 and aarch64 need to be built in a single workflow to create a multi-architecture manifest.
-      # For now include only RL9 in aarch64
+      # For now include only RL10 in aarch64
       - name: Generate build matrix
         id: set-matrix
         run: |
           output="{'distro': ["
-          if [[ ${{ inputs.rocky-linux-9 }} == 'true' ]]; then
-              output+="{'name': 'rocky', 'release': 9, 'arch': 'amd64'},"
-              if [[ ${{ inputs.overcloud }} == 'true' ]]; then
-                output+="{'name': 'rocky', 'release': 9, 'arch': 'aarch64', 'runner': 'sms'},"
-              fi
-          fi
           if [[ ${{ inputs.rocky-linux-10 }} == 'true' ]]; then
               output+="{'name': 'rocky', 'release': 10, 'arch': 'amd64'},"
               if [[ ${{ inputs.overcloud }} == 'true' ]]; then
@@ -363,7 +352,7 @@ jobs:
   create-manifests:
     # Only for Rocky Linux for now
     name: Create Multiarch Docker Manifests
-    if: github.repository == 'stackhpc/stackhpc-kayobe-config' && inputs.push && (inputs.rocky-linux-9 || inputs.rocky-linux-10)
+    if: github.repository == 'stackhpc/stackhpc-kayobe-config' && inputs.push && inputs.rocky-linux-10
     runs-on: ${{ needs.runner-selection.outputs.runner_name_container_image_build }}
     permissions: {}
     needs:

--- a/.github/workflows/stackhpc-multinode.yml
+++ b/.github/workflows/stackhpc-multinode.yml
@@ -14,9 +14,8 @@ name: Multinode
       host_os:
         description: Host OS
         type: choice
-        default: rocky-9
+        default: rocky-10
         options:
-          - rocky-9
           - rocky-10
           - ubuntu
       neutron_plugin:
@@ -99,9 +98,9 @@ jobs:
     uses: stackhpc/stackhpc-openstack-gh-workflows/.github/workflows/multinode.yml@1.8.1
     with:
       multinode_name: ${{ inputs.multinode_name }}
-      os_distribution: ${{ inputs.host_os == 'ubuntu' && 'ubuntu' || 'rocky' }}
-      os_release: ${{ inputs.host_os == 'rocky-9' && '9' || inputs.host_os == 'rocky-10' && '10' || 'noble' }}
-      ssh_username: ${{ (inputs.host_os == 'rocky-9' || inputs.host_os == 'rocky-10') && 'cloud-user' || 'ubuntu' }}
+      os_distribution: ${{ inputs.host_os == 'rocky-10' && 'rocky' || 'ubuntu' }}
+      os_release: ${{ inputs.host_os == 'rocky-10' && '10' || 'noble' }}
+      ssh_username: ${{ inputs.host_os == 'rocky-10' && 'cloud-user' || 'ubuntu' }}
       neutron_plugin: ${{ inputs.neutron_plugin }}
       upgrade: ${{ inputs.upgrade }}
       break_on: ${{ inputs.break_on }}

--- a/.github/workflows/stackhpc-update-kolla.yml
+++ b/.github/workflows/stackhpc-update-kolla.yml
@@ -16,7 +16,9 @@ jobs:
           - version: stackhpc/2023.1
           - version: stackhpc/2024.1
           - version: stackhpc/2025.1
-          - version: stackhpc/2026.1
+          # FIXME(Alex-Welsh): The 2026.1 branches are under active development.
+          # Pin once they are stable and re-enable syncs
+          # - version: stackhpc/2026.1
     uses: ./.github/workflows/update-dependencies.yml
     with:
       branch: ${{ matrix.version }}

--- a/.github/workflows/update-overcloud-host-image-tags.yml
+++ b/.github/workflows/update-overcloud-host-image-tags.yml
@@ -4,12 +4,6 @@ name: Update overcloud host image tags
 on:
   workflow_dispatch:
     inputs:
-      rocky9_tag:
-        description: Overcloud host image tag for Rocky 9
-        type: string
-      rocky9_aarch64_tag:
-        description: Overcloud host image tag for Rocky 9 aarch64
-        type: string
       rocky10_tag:
         description: Overcloud host image tag for Rocky 10
         type: string
@@ -35,16 +29,6 @@ jobs:
           ref: stackhpc/2026.1
           path: ${{ github.workspace }}/src/kayobe-config
 
-      - name: Update Rocky 9 overcloud host image tag
-        run: |
-          sed -i "/^stackhpc_rocky_9_overcloud_host_image_version:/s/.*/stackhpc_rocky_9_overcloud_host_image_version: ${{ inputs.rocky9_tag }}/" ${{ github.workspace }}/src/kayobe-config/etc/kayobe/pulp-host-image-versions.yml
-        if: "${{ inputs.rocky9_tag != '' }}"
-
-      - name: Update Rocky 9 aarch64 overcloud host image tag
-        run: |
-          sed -i "/^stackhpc_rocky_9_overcloud_host_image_version_aarch64:/s/.*/stackhpc_rocky_9_overcloud_host_image_version_aarch64: ${{ inputs.rocky9_aarch64_tag }}/" ${{ github.workspace }}/src/kayobe-config/etc/kayobe/pulp-host-image-versions.yml
-        if: "${{ inputs.rocky9_aarch64_tag != '' }}"
-
       - name: Update Rocky 10 overcloud host image tag
         run: |
           sed -i "/^stackhpc_rocky_10_overcloud_host_image_version:/s/.*/stackhpc_rocky_10_overcloud_host_image_version: ${{ inputs.rocky10_tag }}/" ${{ github.workspace }}/src/kayobe-config/etc/kayobe/pulp-host-image-versions.yml
@@ -67,15 +51,13 @@ jobs:
           commit-message: >-
             Bump overcloud host image tags
           author: stackhpc-ci <22933334+stackhpc-ci@users.noreply.github.com>
-          branch: bump-overcloud-host-images-${{ inputs.rocky9_tag }}-${{ inputs.rocky9_aarch64_tag }}-${{ inputs.rocky10_tag }}-${{ inputs.rocky10_aarch64_tag }}-${{ inputs.ubuntu_noble_tag }}
+          branch: bump-overcloud-host-images-${{ inputs.rocky10_tag }}-${{ inputs.rocky10_aarch64_tag }}-${{ inputs.ubuntu_noble_tag }}
           delete-branch: true
           title: >-
             Bump overcloud host image tags 
           body: |
             This PR was created automatically to update the overcloud host image
             tags.
-            Rocky 9: ${{ inputs.rocky9_tag }}
-            Rocky 9 aarch64: ${{ inputs.rocky9_aarch64_tag }}
             Rocky 10: ${{ inputs.rocky10_tag }}
             Rocky 10 aarch64: ${{ inputs.rocky10_aarch64_tag }}
             Ubuntu Noble: ${{ inputs.ubuntu_noble_tag }}


### PR DESCRIPTION
Removes all references to RL9 from GitHub workflow files in the repo, and where appropriate, replaces them with RL10

I also removed a few 2025.1 references while I was there, but that's largely out of scope for this PR. I'll go through again in the future to check them properly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Updated image builds, publishing, and promotions to use Rocky Linux 10 instead of Rocky Linux 9.
  * Removed Rocky Linux 9 options from image, package, container, and overcloud workflows.
  * Retained Ubuntu 24.04 support where applicable.
  * Added Rocky Linux 10 support for aarch64 image workflows where applicable.
  * Restricted multi-architecture container manifests to Rocky Linux 10 builds.
  * Set Rocky Linux 10 as the default host operating system for multinode workflows.
  * Disabled synchronization for the development-only 2026.1 branch until it is stable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->