### PR TITLE
Bump pulp container to latest stable release

### DIFF
--- a/etc/kayobe/seed.yml
+++ b/etc/kayobe/seed.yml
@@ -114,17 +114,17 @@ seed_pulp_container_enabled: true
 
 seed_pulp_container:
   pulp:
-    image: quay.io/pulp/pulp
+    image: "quay.io/pulp/pulp"
     pre: "{{ kayobe_config_path }}/containers/pulp/pre.yml"
     post: "{{ kayobe_config_path }}/containers/pulp/post.yml"
-    tag: "3.81.0"
+    tag: "3.105.12"
     network_mode: host
     # Override deploy_containers_defaults.init == true to ensure
     # s6-overlay-suexec starts as pid 1
     init: false
     env:
-      PULP_CONTENT_WORKERS: "{{ [ansible_facts.processor_vcpus * 2 + 1, 12] | min }}"
-      PULP_API_WORKERS: "{{ [ansible_facts.processor_vcpus * 2 + 1, 12] | min }}"
+      PULP_CONTENT_WORKERS: "{{ [ansible_facts.processor_vcpus * 2 + 1, 12] | min | string }}"
+      PULP_API_WORKERS: "{{ [ansible_facts.processor_vcpus * 2 + 1, 12] | min | string }}"
       PULP_HTTPS: "{{ 'true' if pulp_enable_tls | bool else 'false' }}"
     volumes:
       - /opt/kayobe/containers/pulp:/etc/pulp


### PR DESCRIPTION
Bumps pulp to the latest stable release, with a side quest of making the check-review pipeline work on the 2026.1 branch.

check-review runs a simple pulp deploy and sync, but isn't (yet) smart enough to do an upgrade

This has the potential to have unexpected issues when upgrading, but IMO it's fine to just try it when we do the SMS upgrade, and revert if we have any issues.