### PR TITLE
Remove valkey_sentinel container prefix exception

### DIFF
--- a/tools/kolla-images.py
+++ b/tools/kolla-images.py
@@ -102,7 +102,6 @@ CONTAINER_TO_PREFIX_VAR_EXCEPTIONS: Dict[str, str] = {
     "redis_sentinel": "openstack",
     "swift_object_expirer": "swift",
     "tgtd": "iscsi",
-    "valkey_sentinel": "openstack", # NOTE: Remove once https://review.opendev.org/c/openstack/kolla-ansible/+/998592 is backported to 2026.1
 }
 
 # List of supported base distributions and versions.


### PR DESCRIPTION
The fix for K-A bug LP#2161716 [1] has backported to 2026.1 [2].

[1] https://bugs.launchpad.net/kolla-ansible/+bug/2161716
[2] https://review.opendev.org/c/openstack/kolla-ansible/+/998759

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected tag resolution for the Valkey Sentinel container so it now follows the standard default hierarchy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->