### PR TITLE
Revert "GT-1835: Fix IPA for stream 10 (#2448)"

### DIFF
--- a/etc/kayobe/ipa.yml
+++ b/etc/kayobe/ipa.yml
@@ -14,14 +14,10 @@
 #ipa_build_source_version:
 
 # URL of IPA builder source repository.
-# NOTE(dougszu): This fork is required for centos-10 stream IPA images, which
-# are required (currently) to provide a version of qemu-img that can handle
-# 4k sectors from Dell Perc RAID controllers which don't support other block
-# sizes.
-ipa_builder_source_url: https://github.com/stackhpc/ironic-python-agent-builder.git
+#ipa_builder_source_url:
 
 # Version of IPA builder source repository. Default is {{ openstack_branch }}.
-ipa_builder_source_version: stackhpc/2025.1
+#ipa_builder_source_version:
 
 # List of additional build host packages to install. Default is an empty list.
 ipa_build_dib_host_packages_extra: [ 'zstd' ]


### PR DESCRIPTION
This reverts commit d6b67b69781d8f53b4de52aade75d7e81743b134.

Reason for revert: fixes have been merged upstream.