### PR TITLE
Switch to upstream blazar

### DIFF
--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -7,3 +7,7 @@ kolla_image_tags:
     rocky-9: 2025.1-rocky-9-20260707T061355
     rocky-10: 2025.1-rocky-10-20260707T061355
     ubuntu-noble: 2025.1-ubuntu-noble-20260707T061355
+  blazar:
+    rocky-9: 2025.1-rocky-9-20260730T151535
+    rocky-10: 2025.1-rocky-10-20260730T151535
+    ubuntu-noble: 2025.1-ubuntu-noble-20260730T151535

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -179,10 +179,6 @@ kolla_sources:
     type: git
     location: https://github.com/stackhpc/networking-mlnx.git
     reference: stackhpc/{{ openstack_release }}
-  blazar-base:
-    type: git
-    location: https://github.com/stackhpc/blazar.git
-    reference: stackhpc/master
   # TODO(technowhizz): Remove in 2026.1 on openstacksdk >= 4.9.0
   # https://review.opendev.org/c/openstack/openstacksdk/+/970135
   horizon:

--- a/releasenotes/notes/build-blazar-from-upstream-fd5fc48f9bd677e0.yaml
+++ b/releasenotes/notes/build-blazar-from-upstream-fd5fc48f9bd677e0.yaml
@@ -1,0 +1,11 @@
+---
+features:
+  - |
+    Rebuilt Blazar containers using the upstream Blazar source code, instead of
+    the StackHPC fork. The StackHPC fork was based on an older version of
+    Blazar, but contained additional features relating to coral credits, which
+    are now no longer in use.
+deprecations:
+  - |
+    The StackHPC-specific Coral Credits features of Blazar are no longer
+    included, and the Blazar source has been reverted to the upstream default.


### PR DESCRIPTION
Switches from stackhpc/master in our Blazar fork to upstream 2025.1.
Our "master" fork was created around 2024.2, but was never updated since then.
It had a few customisations for coral credits which are now no longer in use, so we can go back to tracking upstream.