### PR TITLE
Switch to Canonical Squid 7.2 image

### DIFF
--- a/etc/kayobe/seed.yml
+++ b/etc/kayobe/seed.yml
@@ -139,9 +139,9 @@ seed_squid_container_enabled: false
 
 seed_squid_container:
   squid:
-    image: ghcr.io/stackhpc/docker-squid
+    image: ubuntu/squid
     pre: "{{ kayobe_config_path }}/containers/squid_proxy/pre.yml"
-    tag: "6.10"
+    tag: "7.2-26.04_edge"
     network_mode: host
     volumes:
       - squid_spool:/var/spool/squid

--- a/releasenotes/notes/ubuntu-squid-container-75698bf1b9535163.yaml
+++ b/releasenotes/notes/ubuntu-squid-container-75698bf1b9535163.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    The Squid proxy container has been switched from a StackHPC-maintained
+    custom image, to a public image maintained by Canonical. The version of
+    Squid is bumped from 6.10 to 7.2. The old image was based on Rocky Linux 10,
+    and the new one is based on Ubuntu 26.04.


### PR DESCRIPTION
I haven't tested this new image. It looks like it should "just work", volumes mount in the same place etc.
If anyone wants to roll it out and try it, then that would be very much appreciated. Otherwise, I think it's a fairly safe switch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Updated the seed Squid container to Canonical’s public image.
  * Upgraded Squid from version 6.10 to 7.2.
  * Changed the container base operating system from Rocky Linux 10 to Ubuntu 26.04.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->