### PR TITLE
Add warning around raising ceph min client version when using CephFS

### DIFF
--- a/doc/source/operations/upgrading-ceph.rst
+++ b/doc/source/operations/upgrading-ceph.rst
@@ -201,6 +201,21 @@ requires ``luminous`` or later. Similarly, the more recent `read balancer
 Run ``ceph features`` to identify client versions and consider setting the
 minimum to an appropriate value:
 
+.. warning::
+
+   Before raising ``require-min-compat-client``, verify that all clients support
+   the target release. This is particularly important for users accessing
+   CephFS via the kernel client (for example, Manila shares).
+
+   Kernel clients that encounter ``pg-upmap-primary`` entries will silently
+   route I/O to the wrong OSD, causing **I/O hangs** on the affected PGs.
+   Kernel clients that encounter CRUSH MSR rules will fail to compute a PG
+   mapping, causing **I/O errors**. Do not enable either feature while kernel
+   clients are present.
+
+   See the `upstream warning
+   <https://docs.ceph.com/en/latest/rados/operations/require-min-compat-client/>`__.
+
 .. code-block:: console
 
    ceph osd set-require-min-compat-client reef


### PR DESCRIPTION
There are some big limitations with the kernel driver. Make this more explicit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added an upgrade warning about verifying client compatibility before enabling `require-min-compat-client`.
  - Highlighted potential CephFS kernel client I/O hangs or errors caused by unsupported features.
  - Added a link to the upstream compatibility warning for further guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->