### PR TITLE
CI: Skip kolla-packages during AIO upgrade

### DIFF
--- a/.github/workflows/stackhpc-all-in-one.yml
+++ b/.github/workflows/stackhpc-all-in-one.yml
@@ -410,7 +410,7 @@ jobs:
             -v $(pwd):/stack/kayobe-automation-env/src/kayobe-config \
             -e KAYOBE_ENVIRONMENT -e KAYOBE_VAULT_PASSWORD -e KAYOBE_AUTOMATION_SSH_PRIVATE_KEY \
             $KAYOBE_IMAGE \
-            /stack/kayobe-automation-env/src/kayobe-config/.automation/pipeline/overcloud-host-configure.sh
+            /stack/kayobe-automation-env/src/kayobe-config/.automation/pipeline/overcloud-host-configure.sh --skip-tags kolla-packages
         env:
           KAYOBE_AUTOMATION_SSH_PRIVATE_KEY: ${{ steps.ssh_key.outputs.ssh_key }}
         if: inputs.upgrade


### PR DESCRIPTION
AIO upgrade jobs on Rocky Linux are currently broken because ansible-collection-kolla tries to install kernel-modules-extra matching the running kernel after DNF repositories have been updated. The package can be unavailable if there is a minor version change (9.7 to 9.8) or if the kernel snapshot of the newer release is behind the one of the previous release.

Skip kolla-packages for the second overcloud-host-configure execution to avoid this issue until we find a better solution.