### PR TITLE
Make readthedocs config use wildcard

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,7 +13,7 @@ build:
     python: "3.12"
   jobs:
     post_checkout:
-      - git remote set-branches origin master stackhpc/master stackhpc/2026.1 stackhpc/2025.1 stackhpc/2024.1 stackhpc/2023.1 stackhpc/zed stackhpc/yoga stackhpc/xena stackhpc/wallaby
+      - git remote set-branches --add origin "stackhpc/*"
       - git fetch --unshallow
 
 # Build documentation in the doc/source/ directory with Sphinx


### PR DESCRIPTION
There's no point maintaining this ever-growing list of branches in the config when we can just use a wildcard. It might pull a few random feature branches like `stackhpc/2025.1-foo` but that's not really an issue.

I'm somewhat hoping this also fixes some recent rtd build failures if we backport it, not entirely sure it will though https://app.readthedocs.org/projects/stackhpc-kayobe-config/builds/33943470/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Read the Docs builds now automatically include all `stackhpc/*` branches, improving branch availability for documentation builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->