### PR TITLE
Ensure root.crt cert exists for proxysql

### DIFF
--- a/doc/source/operations/upgrading-openstack.rst
+++ b/doc/source/operations/upgrading-openstack.rst
@@ -72,12 +72,14 @@ version of the playbook ``secret-store-generate-internal-tls.yml`` before runnin
 
 After running the playbook, check if the following files are generated.
 
+* ``$KAYOBE_CONFIG_PATH/kolla/certificates/ca/root.crt``
 * ``$KAYOBE_CONFIG_PATH/kolla/certificates/proxysql-cert.pem``
 * ``$KAYOBE_CONFIG_PATH/kolla/certificates/proxysql-key.pem``
 * ``$KAYOBE_CONFIG_PATH/kolla/certificates/proxysql-ca.pem``
 
 If Kayobe environment is used, check these paths.
 
+* ``$KAYOBE_CONFIG_PATH/environments/$KAYOBE_ENVIRONMENT/kolla/certificates/ca/root.crt``
 * ``$KAYOBE_CONFIG_PATH/environments/$KAYOBE_ENVIRONMENT/kolla/certificates/proxysql-cert.pem``
 * ``$KAYOBE_CONFIG_PATH/environments/$KAYOBE_ENVIRONMENT/kolla/certificates/proxysql-key.pem``
 * ``$KAYOBE_CONFIG_PATH/environments/$KAYOBE_ENVIRONMENT/kolla/certificates/proxysql-ca.pem``

--- a/etc/kayobe/ansible/secret-store/secret-store-generate-internal-tls.yml
+++ b/etc/kayobe/ansible/secret-store/secret-store-generate-internal-tls.yml
@@ -51,8 +51,11 @@
     - name: Copy root CA
       ansible.builtin.copy:
         src: "{{ kayobe_env_config_path }}/{{ stackhpc_ca_secret_store }}/OS-TLS-ROOT.pem"
-        dest: "{{ kayobe_env_config_path }}/kolla/certificates/ca/{{ stackhpc_ca_secret_store }}.crt"
+        dest: "{{ item }}"
         mode: "0600"
+      loop:
+        - "{{ kayobe_env_config_path }}/kolla/certificates/ca/{{ stackhpc_ca_secret_store }}.crt"
+        - "{{ kayobe_env_config_path }}/kolla/certificates/ca/root.crt"
       delegate_to: localhost
 
 # NOTE(seunghun1ee): Kolla Ansible reuses internal TLS certificate when


### PR DESCRIPTION
Without this, proxysql upgrade to Gazpacho will fail saying 
`ERROR MissingRequiredSource:
/var/lib/kolla/config_files/ca-certificates/root.crt file is not found etc/kayobe/ansible/secret-store/secret-store-generate-internal-tls.yml`