### PR TITLE
Bump cinder image tag to fix cinder NetApp ONTAP and self-signed certs

### DIFF
--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -7,3 +7,7 @@ kolla_image_tags:
     rocky-9: 2025.1-rocky-9-20260809T130341
     rocky-10: 2025.1-rocky-10-20260809T130341
     ubuntu-noble: 2025.1-ubuntu-noble-20260809T130341
+  cinder:
+    rocky-9: 2025.1-rocky-9-20260813T154329
+    rocky-10: 2025.1-rocky-10-20260813T154329
+    ubuntu-noble: 2025.1-ubuntu-noble-20260813T154329

--- a/releasenotes/notes/cinder-netapp-self-signed-epoxy-a97a71c9b2266cf8.yaml
+++ b/releasenotes/notes/cinder-netapp-self-signed-epoxy-a97a71c9b2266cf8.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Updates Cinder container images to resolve compatibility with NetApp ONTAP when using self-signed certificates.


### PR DESCRIPTION
This fixes compatibility between Cinder and NetApp ONTAP when the storage backend is deployed using self-signed certificates.
[stackhpc/cinder#153](https://github.com/stackhpc/cinder/pull/153) has been merged and is included for the 2025.1 image build.