### PR TITLE
Update redfish grafana dashboard.

### DIFF
--- a/etc/kayobe/kolla/config/grafana/dashboards/openstack/redfish.json
+++ b/etc/kayobe/kolla/config/grafana/dashboards/openstack/redfish.json
@@ -106,7 +106,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "count(redfish_system_power_state{group=\"$group\", job!=\"redfish-exporter-collectlog\"}) by (system_id)",
+          "expr": "count(count(redfish_system_power_state{group=\"$group\", job!=\"redfish-exporter-collectlog\"}) by (server))",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -189,7 +189,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "count(redfish_system_power_state{group=\"$group\", job!=\"redfish-exporter-collectlog\"} == 1) by (system_id)",
+          "expr": "count(count(redfish_system_power_state{group=\"$group\", job!=\"redfish-exporter-collectlog\"} == 1) by (server))",
           "format": "table",
           "hide": false,
           "instant": true,

--- a/etc/kayobe/kolla/config/grafana/dashboards/openstack/redfish.json
+++ b/etc/kayobe/kolla/config/grafana/dashboards/openstack/redfish.json
@@ -106,7 +106,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "count(redfish_system_power_state{group=\"$group\", job!=\"redfish-exporter-collectlog\"})",
+          "expr": "count(redfish_system_power_state{group=\"$group\", job!=\"redfish-exporter-collectlog\"}) by (system_id)",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -189,7 +189,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "count(redfish_system_power_state{group=\"$group\", job!=\"redfish-exporter-collectlog\"} == 1)",
+          "expr": "count(redfish_system_power_state{group=\"$group\", job!=\"redfish-exporter-collectlog\"} == 1) by (system_id)",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -327,7 +327,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "count(redfish_chassis_health{group=\"$group\", job!=\"redfish-exporter-collectlog\" } != 1)",
+          "expr": "count(max(redfish_chassis_health{group=\"$group\", job!=\"redfish-exporter-collectlog\" }) by (server) != 1)",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -897,7 +897,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sort(redfish_chassis_health{group=\"$group\", job!=\"redfish-exporter-collectlog\"})",
+          "expr": "max(sort(redfish_chassis_health{group=\"$group\", job!=\"redfish-exporter-collectlog\"})) by (server)",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -3083,7 +3083,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "redfish_chassis_health{server=~\"$server\"}",
+          "expr": "round(avg(redfish_chassis_health{server=~\"$server\"}))",
           "format": "table",
           "instant": true,
           "interval": "",


### PR DESCRIPTION
Add `by ()` to expressions to stop double counting of metrics, without loss of information.
-  `redfish_system_power_state`  returns values for the same `server`, but multiple `system_id`. This causes duplication for `Redfish Up` and `Powered On` panels. 
- `redfish_chassis_health` returns values for the same `server`, but multiple `chassis_id`. This causes duplication of `Chassis status` and `Unhealthy Nodes` and `Chassis Status` panels.
- `Chassis Status` displays max value for all returned `chassis_id` 
- `General Health` panel for specific `server` would show `critical` or `unhealthy` if one `chassis_id` returned that value. Now takes an average of all returned `chassis_id` from metric `redfish_chassis_health`.

