### PR TITLE
RHEL9_CIS tag update

### DIFF
--- a/etc/kayobe/ansible/requirements.yml
+++ b/etc/kayobe/ansible/requirements.yml
@@ -18,7 +18,7 @@ roles:
     version: 1.0.4
   - name: ansible-lockdown.rhel9_cis
     src: https://github.com/ansible-lockdown/RHEL9-CIS
-    version: v1.3.4
+    version: 1.3.4
   - name: ansible-lockdown.rhel10_cis
     src: https://github.com/ansible-lockdown/RHEL10-CIS
     version: 1.0.2

--- a/releasenotes/notes/rhel9_cis-retag-3c2eba13228721e8.yaml
+++ b/releasenotes/notes/rhel9_cis-retag-3c2eba13228721e8.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    The ``rhel9_cis`` role has retagged its releases to standardise
+    tags, the required version has been updated from v1.3.4 to 1.3.4
+    to match this modified tag.


### PR DESCRIPTION
The `rhel9_cis` role has retagged its releases to standardise tags, the required version has been updated from v1.3.4 to 1.3.4 to match this modified tag.

The ansible-galaxy hosted version of the role has been compared with the tagged version of the repository to confirm that only the tag has changed.
