### PR TITLE
Add aio net vip to ci-builder env

### DIFF
--- a/etc/kayobe/environments/ci-builder/networks.yml
+++ b/etc/kayobe/environments/ci-builder/networks.yml
@@ -84,6 +84,7 @@ cleaning_net_name: aio
 aio_cidr: 192.168.33.0/24
 aio_allocation_pool_start: 192.168.33.3
 aio_allocation_pool_end: 192.168.33.30
+aio_vip_address: 192.168.33.2
 
 ###############################################################################
 # Network virtual patch link configuration.


### PR DESCRIPTION
A precheck will fail builds unless the vip is defined even when it's not used:

```
8
[ERROR]: Task failed: The filter plugin 'ansible.builtin.length' failed: object of type 'NoneType' has no len()

Task failed.
Origin: /home/runner/_work/stackhpc-kayobe-config/stackhpc-kayobe-config/venvs/kayobe/share/kayobe/ansible/kolla-ansible.yml:70:7

68
69     # Configuration and validation of network host networking.
70     - name: Validate Kolla Ansible API address configuration
         ^ column 7

<<< caused by >>>

The filter plugin 'ansible.builtin.length' failed: object of type 'NoneType' has no len()
Origin: /home/runner/_work/stackhpc-kayobe-config/stackhpc-kayobe-config/venvs/kayobe/share/kayobe/ansible/kolla-ansible.yml:74:13

72         that:
73           - hostvars[inventory_hostname][item.var_name] is defined
74           - hostvars[inventory_hostname][item.var_name] | length > 0
               ^ column 13

failed: [localhost] (item={'var_name': 'kolla_internal_vip_address', 'description': 'Internal API VIP address', 'required': True}) =>
    ansible_loop_var: item
    changed: false
    item:
        description: Internal API VIP address
        required: true
        var_name: kolla_internal_vip_address
    msg: 'Task failed: The filter plugin ''ansible.builtin.length'' failed: object of
        type ''NoneType'' has no len()'
failed: [localhost] (item={'var_name': 'kolla_internal_fqdn', 'description': 'Internal API Fully Qualified Domain Name (FQDN)', 'required': True}) =>
    ansible_loop_var: item
    changed: false
    item:
        description: Internal API Fully Qualified Domain Name (FQDN)
        required: true
        var_name: kolla_internal_fqdn
    msg: 'Task failed: The filter plugin ''ansible.builtin.length'' failed: object of
        type ''NoneType'' has no len()'
```