### PR TITLE
Make StorageFillingUp alert customisable

### DIFF
--- a/etc/kayobe/kolla/config/prometheus/ceph.rules
+++ b/etc/kayobe/kolla/config/prometheus/ceph.rules
@@ -160,8 +160,8 @@ groups:
 
   - alert: StorageFillingUp
     expr: |
-      predict_linear(node_filesystem_avail_bytes[2d], 3600 * 24 * 5) *
-      on(instance) group_left(nodename) node_uname_info < 0
+      predict_linear(node_filesystem_avail_bytes{mountpoint!~"{% endraw %}{{ alertmanager_storage_filling_up_excluded_mountpoints }}{% raw %}"}[2d], 3600 * 24 * 5) *
+      on(instance) group_left(nodename) node_uname_info{nodename!~"{% endraw %}{{ alertmanager_storage_filling_up_excluded_hosts }}{% raw %}"} < 0
     labels:
       severity: warning
     annotations:

--- a/etc/kayobe/stackhpc-monitoring.yml
+++ b/etc/kayobe/stackhpc-monitoring.yml
@@ -26,6 +26,16 @@ alertmanager_packet_drop_threshold: 1
 # packets/s averaged over 5 minutes.
 alertmanager_packet_errors_threshold: 1
 
+# Regular expression used to exclude mountpoints from the StorageFillingUp
+# alert. Any mountpoint matching this regex will not trigger the alert.
+# Empty by default, meaning no mountpoints are excluded.
+alertmanager_storage_filling_up_excluded_mountpoints: ""
+
+# Regular expression used to exclude hosts from the StorageFillingUp alert.
+# Any host whose nodename matches this regex will not trigger the alert.
+# Empty by default, meaning no hosts are excluded.
+alertmanager_storage_filling_up_excluded_hosts: ""
+
 # Number of RabbitMQ nodes in the cluster.
 alertmanager_number_of_rabbitmq_nodes: "{{ groups['controllers'] | length }}"
 

--- a/releasenotes/notes/customise-storage-filling-up-alert-9f6b1c2e1a4d8b3f.yaml
+++ b/releasenotes/notes/customise-storage-filling-up-alert-9f6b1c2e1a4d8b3f.yaml
@@ -1,0 +1,10 @@
+---
+features:
+  - |
+    The ``StorageFillingUp`` Prometheus alert can now be customised. The new
+    ``alertmanager_storage_filling_up_excluded_mountpoints`` variable excludes
+    mountpoints matching a regular expression (defaults to ``""``, excluding
+    no mountpoints), and the new
+    ``alertmanager_storage_filling_up_excluded_hosts`` variable excludes
+    hosts whose nodename matches a regular expression (defaults to ``""``,
+    excluding no hosts).


### PR DESCRIPTION
Add alertmanager_storage_filling_up_excluded_mountpoints and alertmanager_storage_filling_up_excluded_hosts variables to allow excluding specific mountpoints and hosts from the StorageFillingUp Prometheus alert.