### PR TITLE
Bump Ubuntu Ceph libs version to Umbrella

### DIFF
--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -10,4 +10,8 @@ kolla_image_tags:
   cinder:
     rocky-9: 2025.1-rocky-9-20260813T154329
     rocky-10: 2025.1-rocky-10-20260813T154329
-    ubuntu-noble: 2025.1-ubuntu-noble-20260813T154329
+    ubuntu-noble: 2025.1-ubuntu-noble-20260824T075836
+  manila:
+    ubuntu-noble: 2025.1-ubuntu-noble-20260824T075836
+  nova:
+    ubuntu-noble: 2025.1-ubuntu-noble-20260824T075836

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -630,6 +630,8 @@ stackhpc_kolla_build_customizations:
       - python3-ethtool
     nova_compute_packages_append:
       - python3-ethtool
+    base_remote_apt_keys_append:
+      - {name: ceph, url: "https://download.ceph.com/keys/release.asc"}
 
 # Dict mapping image customization variable names to their values.
 # Each variable takes the form:

--- a/etc/kayobe/kolla/kolla-build.conf
+++ b/etc/kayobe/kolla/kolla-build.conf
@@ -5,6 +5,7 @@
 {% if kolla_base_distro == 'ubuntu' %}
 base_tag = noble-20260610
 apt_preferences = {{ lookup('env', 'KAYOBE_CONFIG_PATH') }}/environments/ci-builder/builder-apt-preferences
+repos-yaml = {{ lookup('env', 'KAYOBE_CONFIG_PATH') }}/kolla/repos.yaml
 {# Similarly pinning to Rocky 9 minor version used in our repos #}
 {% elif kolla_base_distro == 'rocky' %}
 {% if kolla_base_distro_version == '9' %}

--- a/etc/kayobe/kolla/repos.yaml
+++ b/etc/kayobe/kolla/repos.yaml
@@ -1,0 +1,349 @@
+---
+centos:
+  ceph: "centos-ceph-reef"
+  crb: "crb"
+  docker-ce: "docker-ce"
+  epel: "epel"
+  erlang: "rabbitmq_rabbitmq-erlang"
+  extras: "extras"
+  fluentd: "fluent-package-lts"
+  grafana: "grafana"
+  hacluster: "highavailability"
+  influxdb: "influxdb"
+  mariadb: "mariadb"
+  opensearch: "opensearch-2.x"
+  opensearch-dashboards: "opensearch-dashboards-2.x"
+  openvswitch: "centos-nfv-openvswitch"
+  opstools: "centos-opstools"
+  proxysql: "proxysql"
+  proxysql-3: "proxysql-3"
+  rabbitmq: "rabbitmq_rabbitmq-server"
+
+centos-aarch64:
+  ceph: "centos-ceph-reef"
+  crb: "crb"
+  docker-ce: "docker-ce"
+  epel: "epel"
+  erlang-26: "copr-rabbitmq-erlang-26"
+  erlang-27: "copr-rabbitmq-erlang-27"
+  extras: "extras"
+  fluentd: "fluent-package-lts"
+  grafana: "grafana"
+  hacluster: "highavailability"
+  influxdb: "influxdb"
+  mariadb: "mariadb"
+  opensearch: "opensearch-2.x"
+  opensearch-dashboards: "opensearch-dashboards-2.x"
+  openvswitch: "centos-nfv-openvswitch"
+  opstools: "centos-opstools"
+  proxysql: "proxysql"
+  proxysql-3: "proxysql-3"
+  rabbitmq: "rabbitmq_rabbitmq-server"
+
+# NOTE(mnasiadka): For RabbitMQ Debuntu suite names is following:
+# https://www.rabbitmq.com/install-debian.html#apt-cloudsmith
+
+debian:
+  docker-ce:
+    url: "https://download.docker.com/linux/debian"
+    suite: "bookworm"
+    component: "stable"
+    gpg_key: "docker-ce.asc"
+  erlang-26:
+    url: "https://ppa.launchpadcontent.net/rabbitmq/rabbitmq-erlang-26/ubuntu"
+    suite: "jammy"
+    component: "main"
+    gpg_key: "erlang-ppa.gpg"
+  erlang-27:
+    url: "https://ppa.launchpadcontent.net/rabbitmq/rabbitmq-erlang-27/ubuntu"
+    suite: "jammy"
+    component: "main"
+    gpg_key: "erlang-ppa.gpg"
+  fluentd:
+    url: "https://packages.treasuredata.com/lts/5/debian/bookworm"
+    suite: "bookworm"
+    component: "contrib"
+    gpg_key: "treasuredata.asc"
+  grafana:
+    url: "https://apt.grafana.com"
+    suite: "stable"
+    component: "main"
+    gpg_key: "grafana.asc"
+  influxdb:
+    url: "https://repos.influxdata.com/ubuntu"
+    suite: "jammy"
+    component: "stable"
+    gpg_key: "influxdb.asc"
+  mariadb:
+    url: "https://dlm.mariadb.com/repo/mariadb-server/10.11/repo/debian"
+    suite: "bookworm"
+    component: "main"
+    gpg_key: "mariadb.gpg"
+  opensearch:
+    url: "https://artifacts.opensearch.org/releases/bundle/opensearch/2.x/apt/"
+    suite: "stable"
+    component: "main"
+    gpg_key: "opensearch.asc"
+  opensearch-dashboards:
+    url: "https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/2.x/apt/"
+    suite: "stable"
+    component: "main"
+    gpg_key: "opensearch.asc"
+  proxysql:
+    url: "https://repo.proxysql.com/ProxySQL/proxysql-2.7.x/bookworm/"
+    suite: "./"
+    component: ""
+    gpg_key: "proxysql.asc"
+  proxysql-3:
+    url: "https://repo.proxysql.com/ProxySQL/proxysql-3.0.x/bookworm/"
+    suite: "./"
+    component: ""
+    gpg_key: "proxysql.asc"
+  rabbitmq:
+    url: "https://deb1.rabbitmq.com/rabbitmq-server/debian/bookworm"
+    suite: "bookworm"
+    component: "main"
+    gpg_key: "rabbitmq.gpg"
+
+debian-aarch64:
+  docker-ce:
+    url: "https://download.docker.com/linux/debian"
+    suite: "bookworm"
+    component: "stable"
+    gpg_key: "docker-ce.asc"
+  erlang-26:
+    url: "https://ppa.launchpadcontent.net/rabbitmq/rabbitmq-erlang-26/ubuntu"
+    suite: "jammy"
+    component: "main"
+    gpg_key: "erlang-ppa.gpg"
+  erlang-27:
+    url: "https://ppa.launchpadcontent.net/rabbitmq/rabbitmq-erlang-27/ubuntu"
+    suite: "jammy"
+    component: "main"
+    gpg_key: "erlang-ppa.gpg"
+  fluentd:
+    url: "https://packages.treasuredata.com/lts/5/debian/bookworm"
+    suite: "bookworm"
+    component: "contrib"
+    gpg_key: "treasuredata.asc"
+  grafana:
+    url: "https://apt.grafana.com"
+    suite: "stable"
+    component: "main"
+    gpg_key: "grafana.asc"
+  influxdb:
+    url: "https://repos.influxdata.com/ubuntu"
+    suite: "jammy"
+    component: "stable"
+    gpg_key: "influxdb.asc"
+  mariadb:
+    url: "https://dlm.mariadb.com/repo/mariadb-server/10.11/repo/debian"
+    suite: "bookworm"
+    component: "main"
+    gpg_key: "mariadb.gpg"
+  opensearch:
+    url: "https://artifacts.opensearch.org/releases/bundle/opensearch/2.x/apt/"
+    suite: "stable"
+    component: "main"
+    gpg_key: "opensearch.asc"
+  opensearch-dashboards:
+    url: "https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/2.x/apt/"
+    suite: "stable"
+    component: "main"
+    gpg_key: "opensearch.asc"
+  proxysql:
+    url: "https://repo.proxysql.com/ProxySQL/proxysql-2.7.x/bookworm/"
+    suite: "./"
+    component: ""
+    gpg_key: "proxysql.asc"
+  proxysql-3:
+    url: "https://repo.proxysql.com/ProxySQL/proxysql-3.0.x/bookworm/"
+    suite: "./"
+    component: ""
+    gpg_key: "proxysql.asc"
+  rabbitmq:
+    url: "https://deb1.rabbitmq.com/rabbitmq-server/debian/bookworm"
+    suite: "bookworm"
+    component: "main"
+    # NOTE(mnasiadka): Since rabbitmq is really noarch and community mirror is not
+    # syncing binary-aarch64 - we're using amd64 here.
+    arch: "amd64"
+    gpg_key: "rabbitmq.gpg"
+
+rocky:
+  ceph: "centos-ceph-reef"
+  crb: "crb"
+  docker-ce: "docker-ce"
+  epel: "epel"
+  erlang: "rabbitmq_rabbitmq-erlang"
+  extras: "extras"
+  fluentd: "fluent-package-lts"
+  grafana: "grafana"
+  hacluster: "highavailability"
+  influxdb: "influxdb"
+  mariadb: "mariadb"
+  opensearch: "opensearch-2.x"
+  opensearch-dashboards: "opensearch-dashboards-2.x"
+  openvswitch: "centos-nfv-openvswitch"
+  opstools: "centos-opstools"
+  proxysql: "proxysql"
+  proxysql-3: "proxysql-3"
+  rabbitmq: "rabbitmq_rabbitmq-server"
+
+rocky-aarch64:
+  ceph: "centos-ceph-reef"
+  crb: "crb"
+  docker-ce: "docker-ce"
+  epel: "epel"
+  erlang-26: "copr-rabbitmq-erlang-26"
+  erlang-27: "copr-rabbitmq-erlang-27"
+  extras: "extras"
+  fluentd: "fluent-package-lts"
+  grafana: "grafana"
+  influxdb: "influxdb"
+  hacluster: "highavailability"
+  mariadb: "mariadb"
+  opensearch: "opensearch-2.x"
+  opensearch-dashboards: "opensearch-dashboards-2.x"
+  openvswitch: "centos-nfv-openvswitch"
+  opstools: "centos-opstools"
+  proxysql: "proxysql"
+  proxysql-3: "proxysql-3"
+  rabbitmq: "rabbitmq_rabbitmq-server"
+
+ubuntu:
+  ceph:
+    url: "https://download.ceph.com/debian-umbrella"
+    suite: "noble"
+    component: "main"
+    gpg_key: "ceph.asc"
+  docker-ce:
+    url: "https://download.docker.com/linux/ubuntu"
+    suite: "noble"
+    component: "stable"
+    gpg_key: "docker-ce.asc"
+  erlang-26:
+    url: "https://ppa.launchpadcontent.net/rabbitmq/rabbitmq-erlang-26/ubuntu"
+    suite: "noble"
+    component: "main"
+    gpg_key: "erlang-ppa.gpg"
+  erlang-27:
+    url: "https://ppa.launchpadcontent.net/rabbitmq/rabbitmq-erlang-27/ubuntu"
+    suite: "noble"
+    component: "main"
+    gpg_key: "erlang-ppa.gpg"
+  fluentd:
+    url: "https://packages.treasuredata.com/lts/5/ubuntu/noble/"
+    suite: "noble"
+    component: "contrib"
+    gpg_key: "treasuredata.asc"
+  grafana:
+    url: "https://apt.grafana.com"
+    suite: "stable"
+    component: "main"
+    gpg_key: "grafana.asc"
+  influxdb:
+    url: "https://repos.influxdata.com/ubuntu"
+    # TODO(mnasiadka): Switch to noble when available
+    suite: "jammy"
+    component: "stable"
+    gpg_key: "influxdb.asc"
+  mariadb:
+    url: "https://dlm.mariadb.com/repo/mariadb-server/10.11/repo/ubuntu"
+    suite: "noble"
+    component: "main"
+    gpg_key: "mariadb.gpg"
+  opensearch:
+    url: "https://artifacts.opensearch.org/releases/bundle/opensearch/2.x/apt/"
+    suite: "stable"
+    component: "main"
+    gpg_key: "opensearch.asc"
+  opensearch-dashboards:
+    url: "https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/2.x/apt/"
+    suite: "stable"
+    component: "main"
+    gpg_key: "opensearch.asc"
+  proxysql:
+    url: "https://repo.proxysql.com/ProxySQL/proxysql-2.7.x/noble/"
+    suite: "./"
+    component: ""
+    gpg_key: "proxysql.asc"
+  proxysql-3:
+    url: "https://repo.proxysql.com/ProxySQL/proxysql-3.0.x/noble/"
+    suite: "./"
+    component: ""
+    gpg_key: "proxysql.asc"
+  rabbitmq:
+    url: "https://deb1.rabbitmq.com/rabbitmq-server/ubuntu/noble"
+    suite: "noble"
+    component: "main"
+    gpg_key: "rabbitmq.gpg"
+
+ubuntu-aarch64:
+  ceph:
+    url: "https://download.ceph.com/debian-umbrella"
+    suite: "noble"
+    component: "main"
+    gpg_key: "ceph.asc"
+  docker-ce:
+    url: "https://download.docker.com/linux/ubuntu"
+    suite: "noble"
+    component: "stable"
+    gpg_key: "docker-ce.asc"
+  erlang-26:
+    url: "https://ppa.launchpadcontent.net/rabbitmq/rabbitmq-erlang-26/ubuntu"
+    suite: "noble"
+    component: "main"
+    gpg_key: "erlang-ppa.gpg"
+  erlang-27:
+    url: "https://ppa.launchpadcontent.net/rabbitmq/rabbitmq-erlang-27/ubuntu"
+    suite: "noble"
+    component: "main"
+    gpg_key: "erlang-ppa.gpg"
+  fluentd:
+    url: "https://packages.treasuredata.com/lts/5/ubuntu/noble/"
+    suite: "noble"
+    component: "contrib"
+    gpg_key: "treasuredata.asc"
+  grafana:
+    url: "https://apt.grafana.com"
+    suite: "stable"
+    component: "main"
+    gpg_key: "grafana.asc"
+  influxdb:
+    url: "https://repos.influxdata.com/ubuntu"
+    # TODO(mnasiadka): Switch to noble when available
+    suite: "jammy"
+    component: "stable"
+    gpg_key: "influxdb.asc"
+  mariadb:
+    url: "https://dlm.mariadb.com/repo/mariadb-server/10.11/repo/ubuntu"
+    suite: "noble"
+    component: "main"
+    gpg_key: "mariadb.gpg"
+  opensearch:
+    url: "https://artifacts.opensearch.org/releases/bundle/opensearch/2.x/apt/"
+    suite: "stable"
+    component: "main"
+    gpg_key: "opensearch.asc"
+  opensearch-dashboards:
+    url: "https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/2.x/apt/"
+    suite: "stable"
+    component: "main"
+    gpg_key: "opensearch.asc"
+  proxysql:
+    url: "https://repo.proxysql.com/ProxySQL/proxysql-2.7.x/noble/"
+    suite: "./"
+    component: ""
+    gpg_key: "proxysql.asc"
+  proxysql-3:
+    url: "https://repo.proxysql.com/ProxySQL/proxysql-3.0.x/noble/"
+    suite: "./"
+    component: ""
+    gpg_key: "proxysql.asc"
+  rabbitmq:
+    url: "https://deb1.rabbitmq.com/rabbitmq-server/ubuntu/noble"
+    suite: "noble"
+    component: "main"
+    arch: "amd64"
+    gpg_key: "rabbitmq.gpg"


### PR DESCRIPTION
Use download.ceph.com for that, because Ubuntu does not even have an SRU ticket for 19.2.6 (they have one for 19.2.4 that is still in progress).

Using Umbrella because Ceph upstream does not build older releases for Ubuntu Noble.