### PR TITLE
Remove inspector and add agent to enabled_inspect_interfaces for baremetal mixin

### DIFF
--- a/etc/kayobe/environments/baremetal/ironic.yml
+++ b/etc/kayobe/environments/baremetal/ironic.yml
@@ -49,7 +49,7 @@ kolla_ironic_default_deploy_interface:
 
 # Specify the list of inspect interfaces to load during service initialization.
 kolla_ironic_enabled_inspect_interfaces:
-  - inspector
+  - agent
   - no-inspect
 
 # Default inspect interface to be used for nodes that do not have


### PR DESCRIPTION
Deploying the baremetal mixin, `ironic_conductor` container would show as unhealthy. `docker logs` show error:
```
  File "/var/lib/kolla/venv/lib64/python3.12/site-packages/ironic/common/driver_factory.py", line 381, in _missing_callback
    raise exception.DriverNotFoundInEntrypoint(
ironic.common.exception.DriverNotFoundInEntrypoint: Could not find the following items in the 'ironic.hardware.interfaces.inspect' entrypoint: inspector.
```

Which relates to the removal of standalone Ironic inspector. To fix, removed `inspector` and added `agent` to list for `kolla_enabled_inspect_interfaces` resolved the error. `ironic_conductor` container deploys healthy.