### PR TITLE
Add support for consumer grade gpus

### DIFF
--- a/etc/kayobe/ansible/maintenance/pci-passthrough.yml
+++ b/etc/kayobe/ansible/maintenance/pci-passthrough.yml
@@ -18,6 +18,9 @@
       {% endfor %}
       {% for item in gpu_list | flatten | unique %}
       {% set _ = output.append(stackhpc_gpu_data[item]['vendor_id'] + ':' + stackhpc_gpu_data[item]['product_id']) %}
+      {% if stackhpc_gpu_data[item].product_audio_id is defined %}
+      {% set _ = output.append(stackhpc_gpu_data[item]['vendor_id'] + ':' + stackhpc_gpu_data[item]['product_audio_id']) %}
+      {% endif %}
       {% endfor %}
       {{ output | join(',') }}
     reboot_timeout_s: "{{ 20 * 60 }}"

--- a/etc/kayobe/stackhpc-compute.yml
+++ b/etc/kayobe/stackhpc-compute.yml
@@ -137,3 +137,9 @@ stackhpc_gpu_data:
     vendor_id: "10de"
     product_id: "25b6"
     device_type: "type-PF"
+  p4000:
+    resource_name: "{{ p4000_resource_name | default('p4000') }}"
+    vendor_id: "10de"
+    product_id: "1bb1"
+    product_audio_id: "10f0"
+    device_type: "type-PCI"

--- a/releasenotes/notes/add-consumer-grade-gpu-support-770dd9a77367c198.yml
+++ b/releasenotes/notes/add-consumer-grade-gpu-support-770dd9a77367c198.yml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Add support for consumer-grade NVIDIA GPUs. These cards expose audio
+    devices whose IDs must be added to the `vfio-pci.ids` kernel argument
+    with the display `product_id` for passthrough to work correctly.
+    Add NVIDIA P4000 support as a working example.


### PR DESCRIPTION
Add suppot for consumer grade nvidia gpus. Those cards expose
audio devices which id, needs to be added as one of kernel 
arguments in vfio-pci.id variable along with display_id to work properly.
Support for Nvidia p4000 is also added as working example of those cards.