### PR TITLE
Fix Redfish exporter scrape configuration

### DIFF
--- a/doc/source/configuration/monitoring.rst
+++ b/doc/source/configuration/monitoring.rst
@@ -313,7 +313,7 @@ To configure the exporter, adjust the variables in
     redfish_exporter_default_password: "{{ ipmi_password }}"
 
     # The address of the BMC that is queried by redfish exporter for metrics.
-    redfish_exporter_target_address: "{{ ipmi_address }}"
+    redfish_exporter_target_address: "{{ redfish_address | default(ipmi_address, true) }}"
 
 Deploy the exporter on the seed:
 

--- a/etc/kayobe/stackhpc-monitoring.yml
+++ b/etc/kayobe/stackhpc-monitoring.yml
@@ -62,7 +62,7 @@ redfish_exporter_default_username: "{{ ipmi_username }}"
 redfish_exporter_default_password: "{{ ipmi_password }}"
 
 # The address of the BMC that is used to query redfish metrics.
-redfish_exporter_target_address: "{{ ipmi_address }}"
+redfish_exporter_target_address: "{{ redfish_address | default(ipmi_address, true) }}"
 
 # How often to scrape OpenStack Exporter in seconds.
 stackhpc_prometheus_openstack_exporter_interval: 300

--- a/releasenotes/notes/use-redfish-address-for-redfish-exporter-ae1504867ef77d59.yaml
+++ b/releasenotes/notes/use-redfish-address-for-redfish-exporter-ae1504867ef77d59.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes Redfish exporter scrape configuration when hosts are defined with
+    ``redfish_address`` instead of ``ipmi_address``.


### PR DESCRIPTION
When hosts are enrolled with Redfish, the generated inventory uses redfish_address instead of ipmi_address, resulting in wrong Prometheus scrape configuration for the Redfish exporter.