### PR TITLE
Switch to upstream blazar

### DIFF
--- a/etc/kayobe/kolla-image-tags.yml
+++ b/etc/kayobe/kolla-image-tags.yml
@@ -8,6 +8,8 @@ kolla_image_tags:
     ubuntu-noble: 2026.1-ubuntu-noble-20260817T131119
   bifrost_deploy:
     rocky-10: 2026.1-rocky-10-20260813T100543
+  blazar:
+    rocky-10: 2026.1-rocky-10-20260826T141623
   ironic_http:
     rocky-10: 2026.1-rocky-10-20260818T103546
   keystone_httpd:

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -131,10 +131,6 @@ kolla_sources:
     type: git
     location: https://github.com/stackhpc/stackhpc-inspector-plugins.git
     reference: 1.3.0
-  blazar-base:
-    type: git
-    location: https://github.com/stackhpc/blazar.git
-    reference: stackhpc/master
   cinder-base:
     type: git
     location: https://github.com/stackhpc/cinder.git

--- a/etc/kayobe/stackhpc.yml
+++ b/etc/kayobe/stackhpc.yml
@@ -177,13 +177,11 @@ stackhpc_repo_almalinux_10_proxysql_3_0_version: "{{ stackhpc_repo_distribution 
 
 # Kolla source repository.
 stackhpc_kolla_source_url: "https://github.com/stackhpc/kolla"
-# FIXME: Merge cherry picks and revert to tag
-stackhpc_kolla_source_version: 2026_1_backports
+stackhpc_kolla_source_version: stackhpc/22.0.0.11
 
 # Kolla Ansible source repository.
 stackhpc_kolla_ansible_source_url: "https://github.com/stackhpc/kolla-ansible"
-# FIXME: Merge cherry picks and revert to tag
-stackhpc_kolla_ansible_source_version: stackhpc/2026.1
+stackhpc_kolla_ansible_source_version: stackhpc/22.1.0.3
 
 ###############################################################################
 # Container image registry


### PR DESCRIPTION
Switches to upstream blazar instead of our stackhpc fork.

Also bumps our kolla/kolla-ansible pins and switches back to using tags. This should let them auto-update with our weekly syncs again