### PR TITLE
Add upgrade warning about ubuntu support

### DIFF
--- a/doc/source/operations/upgrading-openstack.rst
+++ b/doc/source/operations/upgrading-openstack.rst
@@ -43,6 +43,12 @@ The separate Ironic Inspector service was replaced by the Ironic built-in inspec
 Known issues
 ============
 
+Ubuntu Support
+--------------
+
+Ubuntu Noble is not yet supported for this release. Development is underway,
+and will be released in the next few months.
+
 RabbitMQ
 --------
 


### PR DESCRIPTION
Just adding a simple warning in case anyone tries to upgrade an ubuntu system before we're ready