### PR TITLE
Fix reboot prompt for multiple hosts

### DIFF
--- a/etc/kayobe/ansible/maintenance/reboot.yml
+++ b/etc/kayobe/ansible/maintenance/reboot.yml
@@ -21,6 +21,8 @@
           {{ play_hosts | join(', ') }}
           If you want to proceed type: yes
       register: pause_prompt
+      delegate_to: localhost
+      run_once: True
       when: not confirm_reboot
 
     - name: Fail if reboot is not confirmed

--- a/releasenotes/notes/fix-multi-host-reboot-08543be523e37aec.yaml
+++ b/releasenotes/notes/fix-multi-host-reboot-08543be523e37aec.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes an error in the ``maintenance/reboot.yml`` playbook when rebooting
+    multiple hosts concurrently.


### PR DESCRIPTION
When rebooting multiple hosts concurrently by overriding the serial value, Ansible would fail on the next task with:

    'pause_prompt' is undefined

Fix by using delegate_to/run_once.