### PR TITLE
tox -e pep8 fixes and improvment

### DIFF
--- a/etc/kayobe/ansible/maintenance/reboot.yml
+++ b/etc/kayobe/ansible/maintenance/reboot.yml
@@ -5,7 +5,7 @@
   gather_facts: false
   vars:
     reboot_timeout_s: "{{ 20 * 60 }}"
-    post_reboot_delay_s: 5 # Extra delay to ensure SSH is working reliably
+    post_reboot_delay_s: 5  # Extra delay to ensure SSH is working reliably
     reboot_with_bootstrap_user: false
     ansible_user: "{{ bootstrap_user if reboot_with_bootstrap_user | bool else kayobe_ansible_user }}"
     ansible_ssh_common_args: "{{ '-o StrictHostKeyChecking=no' if reboot_with_bootstrap_user | bool else '' }}"

--- a/etc/kayobe/ansible/secret-store/secret-store-generate-internal-tls.yml
+++ b/etc/kayobe/ansible/secret-store/secret-store-generate-internal-tls.yml
@@ -58,9 +58,9 @@
         - "{{ kayobe_env_config_path }}/kolla/certificates/ca/root.crt"
       delegate_to: localhost
 
-# NOTE(seunghun1ee): Kolla Ansible reuses internal TLS certificate when
-# creating certificate for proxysql
-# https://opendev.org/openstack/kolla-ansible/src/branch/stable/2026.1/ansible/roles/certificates/tasks/generate.yml#L169-L183
+    # NOTE(seunghun1ee): Kolla Ansible reuses internal TLS certificate when
+    # creating certificate for proxysql
+    # https://opendev.org/openstack/kolla-ansible/src/branch/stable/2026.1/ansible/roles/certificates/tasks/generate.yml#L169-L183
     - name: Generate ProxySQL certificates
       when: kolla_enable_proxysql | bool
       block:
@@ -83,8 +83,8 @@
             mode: "0600"
           delegate_to: localhost
 
-# NOTE(seunghun1ee): When ProxySQL is used with database internal TLS, it expects the intermediate
-# certificate that signed the proxysql-cert.pem as a CA.
+        # NOTE(seunghun1ee): When ProxySQL is used with database internal TLS, it expects the intermediate
+        # certificate that signed the proxysql-cert.pem as a CA.
         - name: Copy CA for ProxySQL
           ansible.builtin.copy:
             src: "{{ kayobe_env_config_path }}/{{ stackhpc_ca_secret_store }}/OS-TLS-INT.pem"

--- a/etc/kayobe/ansible/secret-store/vault-bao-migration-all.yml
+++ b/etc/kayobe/ansible/secret-store/vault-bao-migration-all.yml
@@ -1,3 +1,4 @@
+---
 # Using lookup because Kayobe variable ``kayobe_config_path`` is not initialised at this stage
 - name: Migrate seed Vault to OpenBao
   ansible.builtin.import_playbook: "{{ lookup('env', 'KAYOBE_CONFIG_PATH') }}/ansible/secret-store/vault-bao-migration-seed.yml"

--- a/etc/kayobe/ansible/tools/wazuh-manager-purge.yml
+++ b/etc/kayobe/ansible/tools/wazuh-manager-purge.yml
@@ -7,7 +7,7 @@
   become: true
   become_user: root
   tasks:
-# Dashboard
+    # Dashboard
     - name: Disable and stop wazuh-dashboard service
       ansible.builtin.systemd_service:
         name: wazuh-dashboard
@@ -32,7 +32,7 @@
         - /var/lib/wazuh-dashboard
         - /usr/share/wazuh-dashboard
         - /etc/wazuh-dashboard
-# Manager
+    # Manager
     - name: Remove wazuh-manager service
       ansible.builtin.systemd_service:
         name: wazuh-manager
@@ -53,7 +53,7 @@
       ansible.builtin.file:
         path: /var/ossec
         state: absent
-# Filebeat
+    # Filebeat
     - name: Disable and stop filebeat service
       ansible.builtin.systemd_service:
         name: filebeat
@@ -78,7 +78,7 @@
         - /var/lib/filebeat
         - /usr/share/filebeat
         - /etc/filebeat
-# Indexer
+    # Indexer
     - name: Disable and stop wazuh-indexer service
       ansible.builtin.systemd_service:
         name: wazuh-indexer

--- a/etc/kayobe/environments/baremetal-policy/kolla/config/neutron/policy.yml
+++ b/etc/kayobe/environments/baremetal-policy/kolla/config/neutron/policy.yml
@@ -1,3 +1,4 @@
+---
 # Comments show default policy for neutron.
 #"create_port:fixed_ips:ip_address": "(rule:admin_only) or (rule:service_api) or role:manager and project_id:%(project_id)s or role:member and rule:network_owner"
 "create_port:fixed_ips:ip_address": "(rule:admin_only) or (rule:service_api) or role:manager and project_id:%(project_id)s or role:member and rule:network_owner or role:baremetaluser"

--- a/etc/kayobe/environments/baremetal-policy/kolla/config/nova/policy.yml
+++ b/etc/kayobe/environments/baremetal-policy/kolla/config/nova/policy.yml
@@ -1,3 +1,4 @@
+---
 # Comments show default policy for nova.
 #"os_compute_api:servers:create:forced_host": "rule:context_is_admin"
 "os_compute_api:servers:create:forced_host": "rule:context_is_admin or role:baremetaluser"

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps =
 
 [testenv:pep8]
 commands =
-  yamllint etc/kayobe
+  yamllint -s etc/kayobe
   reno lint
   # secret-rotation must be skipped because it includes purposeful whitespace
   doc8 README.rst doc/source --ignore D001 --ignore-path-errors doc/source/operations/secret-rotation.rst;D002


### PR DESCRIPTION
Fixing linter warnings and make CI/CD fail on any yamllint error.

Warnings are ignored when it comes to PR gatekeeping, however they are making output confusing when check will fail on real error. 
This PR is fixing all (current)  errors that yamllint is reporting and makes check more strict, so now all yamllint errors will cause whole workflow to fail.