### PR TITLE
Disable l2vni trunk reconciliation

### DIFF
--- a/etc/kayobe/environments/baremetal/kolla/config/neutron/ironic_neutron_agent.ini
+++ b/etc/kayobe/environments/baremetal/kolla/config/neutron/ironic_neutron_agent.ini
@@ -1,0 +1,5 @@
+[l2vni]
+{% if kolla_enable_ironic_neutron_agent | default(False) | bool %}
+enable_l2vni_trunk_reconciliation = False
+enable_l2vni_trunk_reconciliation_events = False
+{% endif %}

--- a/etc/kayobe/environments/baremetal/kolla/config/neutron/ironic_neutron_agent.ini
+++ b/etc/kayobe/environments/baremetal/kolla/config/neutron/ironic_neutron_agent.ini
@@ -1,5 +1,5 @@
-[l2vni]
 {% if kolla_enable_ironic_neutron_agent | default(False) | bool %}
+[l2vni]
 enable_l2vni_trunk_reconciliation = False
 enable_l2vni_trunk_reconciliation_events = False
 {% endif %}


### PR DESCRIPTION
L2VNI trunk reconciliation was added to ironic neutron agent in gazpacho, and enabled by default. It assumes that neutron trunk and segment are enabled, which is not guaranteed, so it is safest if it is disabled by default instead.
See this patch: https://review.opendev.org/c/openstack/networking-baremetal/+/974619