### PR TITLE
Re-enable 2026.1 automated dependency sync

### DIFF
--- a/.github/workflows/stackhpc-update-kolla.yml
+++ b/.github/workflows/stackhpc-update-kolla.yml
@@ -16,9 +16,7 @@ jobs:
           - version: stackhpc/2023.1
           - version: stackhpc/2024.1
           - version: stackhpc/2025.1
-          # FIXME(Alex-Welsh): The 2026.1 branches are under active development.
-          # Pin once they are stable and re-enable syncs
-          # - version: stackhpc/2026.1
+          - version: stackhpc/2026.1
     uses: ./.github/workflows/update-dependencies.yml
     with:
       branch: ${{ matrix.version }}


### PR DESCRIPTION
Syncs were originally disabled on 2026.1 while the branch was being actively developed. We're now correctly pinned to tags, and all backports/fixes are merged.