### PR TITLE
2026.1 update dependencies

### DIFF
--- a/etc/kayobe/stackhpc.yml
+++ b/etc/kayobe/stackhpc.yml
@@ -181,7 +181,7 @@ stackhpc_kolla_source_version: stackhpc/22.1.0.1
 
 # Kolla Ansible source repository.
 stackhpc_kolla_ansible_source_url: "https://github.com/stackhpc/kolla-ansible"
-stackhpc_kolla_ansible_source_version: stackhpc/22.1.0.5
+stackhpc_kolla_ansible_source_version: stackhpc/22.1.0.7
 
 ###############################################################################
 # Container image registry

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-kayobe@git+https://github.com/stackhpc/kayobe@10dad832eea1dc2aa7507c65171d3af49d5d055e
+kayobe@git+https://github.com/stackhpc/kayobe@efc80eca58238328a11ad42038f5a8b406536b6e
 ansible-modules-hashivault>=5.3.0
 pulp-glue==0.33.*
 pulp-glue-deb==0.3.*


### PR DESCRIPTION
Updates kayobe and kolla-ansible pins.

I mainly want to update the kayobe pin, because right now the commit is off the main stackhpc/2026.1 branch. This breaks the dependency bump workflow https://github.com/stackhpc/stackhpc-kayobe-config/actions/runs/33859139983/job/100979280906

Also updating kolla-ansible at the same time to fix the service-deploy image pulling bug because why not