### PR TITLE
upgrade: bump roles used by `kayobe-automation`

### DIFF
--- a/etc/kayobe/ansible/requirements.yml
+++ b/etc/kayobe/ansible/requirements.yml
@@ -23,12 +23,12 @@ roles:
     src: https://github.com/stackhpc/wazuh-ansible
     version: stackhpc-v4.10.0
   - name: geerlingguy.pip
-    version: 3.1.0
+    version: 3.1.2
   - name: monolithprojects.github_actions_runner
     src: https://github.com/MonolithProjects/ansible-github_actions_runner
-    version: 1.25.1
+    version: 1.28.1
   - name: geerlingguy.docker
-    version: 7.9.0
+    version: 8.0.0
     # (jackhodgkiss) Update once patch is merged and released upstream.
   - src: https://github.com/stackhpc/ansible-gitlab-runner
     name: riemers.gitlab-runner

--- a/releasenotes/notes/bump-kayobe-automation-deps-a3b84b88b5f84495.yaml
+++ b/releasenotes/notes/bump-kayobe-automation-deps-a3b84b88b5f84495.yaml
@@ -1,0 +1,7 @@
+---
+upgrade:
+  - |
+    Updated the following Ansible requirements
+    * geerlingguy.pip 3.1.0 => 3.1.2
+    * monolithprojects.github_actions_runner 1.25.1 => 1.28.1
+    * geerlingguy.docker 7.9.0 => 8.0.0


### PR DESCRIPTION
Includes support for `ansible_facts`