### PR TITLE
2026.1 - Host images

### DIFF
--- a/etc/kayobe/pulp-host-image-versions.yml
+++ b/etc/kayobe/pulp-host-image-versions.yml
@@ -1,6 +1,6 @@
 ---
 # Overcloud host image versioning tags
 # These images must be in SMS, since they are used by our AIO CI runners
-stackhpc_rocky_10_overcloud_host_image_version: 2025.1-20260715T072311
-stackhpc_rocky_10_overcloud_host_image_version_aarch64: 2025.1-20260715T072311
-stackhpc_ubuntu_noble_overcloud_host_image_version: 2025.1-20260706T191822
+stackhpc_rocky_10_overcloud_host_image_version: 2026.1-20260908T120846
+stackhpc_rocky_10_overcloud_host_image_version_aarch64: 2026.1-20260908T120846
+stackhpc_ubuntu_noble_overcloud_host_image_version: 2026.1-20260908T120846

--- a/etc/kayobe/stackhpc-overcloud-dib.yml
+++ b/etc/kayobe/stackhpc-overcloud-dib.yml
@@ -79,6 +79,7 @@ stackhpc_overcloud_dib_env_vars_ark:
 
 # StackHPC overcloud DIB image packages.
 stackhpc_overcloud_dib_packages:
+  - "acl"
   - "ethtool"
   - "git"
   - "less"
@@ -89,14 +90,14 @@ stackhpc_overcloud_dib_packages:
   - "python3"
   - "smartmontools"
   - "vim"
-  - "{% if os_distribution == 'ubuntu' %}netbase{% endif %}"
-  - "{% if os_distribution == 'ubuntu' %}iputils-ping{% endif %}"
-  - "{% if os_distribution == 'ubuntu' %}curl{% endif %}"
-  - "{% if os_distribution == 'ubuntu' %}apt-utils{% endif %}"
-  - "{% if os_distribution == 'rocky' %}NetworkManager-config-server{% endif %}"
-  - "{% if os_distribution == 'rocky' %}linux-firmware{% endif %}"
   - "{% if os_distribution == 'rocky' %}cloud-utils-growpart{% endif %}"
+  - "{% if os_distribution == 'rocky' %}linux-firmware{% endif %}"
+  - "{% if os_distribution == 'rocky' %}NetworkManager-config-server{% endif %}"
+  - "{% if os_distribution == 'ubuntu' %}apt-utils{% endif %}"
   - "{% if os_distribution == 'ubuntu' %}cloud-guest-utils{% endif %}"
+  - "{% if os_distribution == 'ubuntu' %}curl{% endif %}"
+  - "{% if os_distribution == 'ubuntu' %}iputils-ping{% endif %}"
+  - "{% if os_distribution == 'ubuntu' %}netbase{% endif %}"
 
 # StackHPC overcloud DIB image block device configuration.
 # This image layout conforms to the CIS partition benchmarks.

--- a/releasenotes/notes/gazpacho-host-image-1b2cfbdb2b3d2893.yaml
+++ b/releasenotes/notes/gazpacho-host-image-1b2cfbdb2b3d2893.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    New host images have been built for the 2026.1 (Gazpacho) release.

--- a/releasenotes/notes/host-image-acl-4aad7ee0a83c0375.yaml
+++ b/releasenotes/notes/host-image-acl-4aad7ee0a83c0375.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    The ``acl`` package is now included in host image builds.


### PR DESCRIPTION
* The `acl` package is now included in host image builds, this is required for bootstrapping on some systems
* New host images have been built for 2026.1