### PR TITLE
fix: update conditional for `None` mechanism drivers

### DIFF
--- a/etc/kayobe/environments/baremetal/kolla/config/ironic-inspector.conf
+++ b/etc/kayobe/environments/baremetal/kolla/config/ironic-inspector.conf
@@ -1,6 +1,6 @@
 [DEFAULT]
 timeout = 0
-{% if "genericswitch" in kolla_neutron_ml2_mechanism_drivers %}
+{% if kolla_enable_ironic | bool and "genericswitch" in kolla_neutron_ml2_mechanism_drivers %}
 # We are increasing the RPC response timeouts to 6 minutes due to the neutron
 # generic switch driver, which synchronously applies switch configuration for
 # each ironic port during node provisioning and tear down.

--- a/etc/kayobe/environments/baremetal/kolla/config/neutron.conf
+++ b/etc/kayobe/environments/baremetal/kolla/config/neutron.conf
@@ -1,5 +1,5 @@
 [DEFAULT]
-{% if kolla_enable_ironic | bool and "genericswitch" in kolla_neutron_ml2_mechanism_drivers %}
+{% if kolla_enable_ironic | bool and "genericswitch" in (kolla_neutron_ml2_mechanism_drivers | default([], true)) %}
 # We are increasing the RPC response timeouts to 6 minutes due to the neutron
 # generic switch driver, which synchronously applies switch configuration for
 # each ironic port during node provisioning and tear down.

--- a/etc/kayobe/environments/baremetal/kolla/config/nova.conf
+++ b/etc/kayobe/environments/baremetal/kolla/config/nova.conf
@@ -1,5 +1,5 @@
 [DEFAULT]
-{% if kolla_enable_ironic | bool and "genericswitch" in kolla_neutron_ml2_mechanism_drivers %}
+{% if kolla_enable_ironic | bool and "genericswitch" in (kolla_neutron_ml2_mechanism_drivers | default([], true)) %}
 # We are increasing the RPC response timeouts to 6 minutes due to the neutron
 # generic switch driver, which synchronously applies switch configuration for
 # each ironic port during node provisioning and tear down.

--- a/etc/kayobe/environments/baremetal/kolla/globals.yml
+++ b/etc/kayobe/environments/baremetal/kolla/globals.yml
@@ -3,7 +3,7 @@
 #############################################################################
 # HAProxy tunings
 
-{% if kolla_enable_ironic | bool and "genericswitch" in kolla_neutron_ml2_mechanism_drivers %}
+{% if kolla_enable_ironic | bool and "genericswitch" in (kolla_neutron_ml2_mechanism_drivers | default([], true)) %}
 # NOTE: We are increasing the HAProxy timeouts to 5 minutes and 30 seconds due
 # to the neutron
 # generic switch driver, which synchronously applies switch configuration for


### PR DESCRIPTION
By default `kolla_neutron_ml2_mechanism_drivers` is set to `None` we therefore need to ensure we default to empty list in the conditional check for `genericswitch`.