### PR TITLE
fix: use new property format for port group playbook

### DIFF
--- a/etc/kayobe/environments/baremetal/ansible/add-port-groups.yml
+++ b/etc/kayobe/environments/baremetal/ansible/add-port-groups.yml
@@ -63,7 +63,7 @@
             baremetal_ports: "{{ baremetal_ports | default([]) + [item] }}"
           loop: "{{ port_list.stdout | from_json | community.general.json_query(_query) }}"
           vars:
-            _query: "[?\"Physical Network\"=='{{ ironic_bond_physical_network_name }}'].{uuid: UUID, mac_address: Address, port_group: \"Portgroup UUID\"}"
+            _query: "[?\"physical_network\"=='{{ ironic_bond_physical_network_name }}'].{uuid: uuid, mac_address: address, port_group: \"portgroup_uuid\"}"
 
         - name: List existing port groups
           ansible.builtin.command:

--- a/releasenotes/notes/fix-port-group-query-62819a48038b06b4.yaml
+++ b/releasenotes/notes/fix-port-group-query-62819a48038b06b4.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixes problem whereby properties are now lowercase
+    and contain underscore rather than space in the
+    ``add-port-groups`` playbook.


### PR DESCRIPTION
It has been noticed in `2026.1` deployments that the playbook for adding new port groups will fail as the properties returned are no longer uppercase and use spaces instead they are now lowercase with underscores.